### PR TITLE
Amazon Cloudwatch Network Flow Monitor Agent K8s Application - v1.0.0…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,84 @@
-## My Project
+# Amazon CloudWatch Network Flow Monitor Agent
 
-TODO: Fill this README out!
+'Amazon CloudWatch Network Flow Monitor Agent' Kubernetes application to support collecting TCP connections statistics from all nodes within a Kubernetes cluster and publishing network flows reports to 'Amazon CloudWatch Network Flow Monitor' Ingestion APIs.
 
-Be sure to:
+## Before you begin
 
-* Change the title in this README
-* Edit your repository description on GitHub
+Before you start the installation process, follow the steps in this section to make sure that your environment is set up to successfully install agents on the right Kubernetes clusters.
+ 
+### Ensure that your version of Kubernetes is supported 
+'Amazon CloudWatch Network Flow Monitor Agent' installation requires Kubernetes Version 1.25, or a more recent version.
+ 
+### Ensure that you have installed required tools 
+The scripts that you use for this installation process require that you install the following tools. If you don’t have the tools installed already, see the provided links for more information. 
+
+* The AWS Command Line Interface. For more information, see [Installing or updating to the latest version of the AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) in the AWS Command Line Interface Reference Guide. 
+     
+* The Helm package manager. For more information, see [Installing Helm](https://helm.sh/docs/intro/install/) on the Helm website. 
+     
+* The `kubectl` command line tool. For more information, see [Install kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) on the Kubernetes website. 
+     
+* The `make` Linux command dependency. For more information, see the following blog post: [Intro to make Linux Command: Installation and Usage](https://ioflood.com/blog/install-make-command-linux/)
+    * For example, do one of the following:
+        * For Debian based distributions, such as Ubuntu, use the following command: `sudo apt-get install make`
+        * For RPM-based distributions, such as CentOS, use the following command: `sudo yum install make`
+
+Ensure that you have valid, correctly configured KubeConfig environment variables. 'Amazon CloudWatch Network Flow Monitor Agent' installation uses the Helm package manager tool, which uses the kubeconfig variable, `$HELM_KUBECONTEXT`, to determine the target Kubernetes clusters to work with. Also, be aware that when Helm runs installation scripts, by default, it references the standard `~/.kube/config` file. You can change the configuration environment variables, to use a different config file (by updating `$KUBECONFIG`) or to define the target cluster you want to work with (by updating `$HELM_KUBECONTEXT`). 
+
+### Create a 'Amazon CloudWatch Network Flow Monitor Agent' Kubernetes namespace
+
+'Amazon CloudWatch Network Flow Monitor Agent' Kubernetes application installs its resources into a specific namespace. The namespace must exist for the installation to succeed. To ensure that the required namespace is in place, you can do one of the following:
+
+* Create the default namespace, `amazon-network-flow-monitor`, before you begin.
+* Create a different namespace, and then define it in the `$NAMESPACE` environment variable when you run the installation make targets.
+
+## Setup
+'Amazon CloudWatch Network Flow Monitor Agent' Helm Charts and Makefile containing installation make targets are located in `./network-flow-monitor-agent/charts/amazon-network-flow-monitor-agent` directory.
+
+You install 'Amazon CloudWatch Network Flow Monitor Agent' by using the following Makefile target: `helm/install/customer`
+
+You can customize the installation if you like, for example, by doing the following:
+```
+# Overwrite the kubeconfig files to use
+make helm/install/customer KUBECONFIG=<MY_KUBECONFIG_ABS_PATH> 
+
+# Overwrite the Kubernetes namespace to use
+make helm/install/customer NAMESPACE=<MY_K8S_NAMESPACE>              
+```
+
+To verify that the 'Amazon CloudWatch Network Flow Monitor Agent' Pods have been created and deployed successfully, check to be sure that their state is `Running`. You can check state of the agents by running the following command: `kubectl get pods -o wide -A | grep amazon-network-flow-monitor`
+
+## IAM Policy
+'Amazon CloudWatch Network Flow Monitor Agent' must have permission to access the 'Amazon CloudWatch Network Flow Monitor Agent' ingestion APIs so they can deliver network flow reports that they've collected for each instance. You grant this access by appending `CloudWatchNetworkFlowMonitorAgentPublishPolicy` managed IAM Policy to the permissions chain associated to 'Amazon CloudWatch Network Flow Monitor Agent' Pods.
+
+### Implement IAM Roles for Service Accounts (IRSA)
+
+IAM roles for service accounts (IRSA) provide the ability to manage credentials for your applications, similar to the way that Amazon EC2 instance profiles provide credentials to Amazon EC2 instances. Implementing IRSA is the recommended way to provide all permissions required by 'Amazon CloudWatch Network Flow Monitor Agent' Pods to successfully communicate with 'Amazon CloudWatch Network Flow Monitor Agent' Ingestion APIs. For more information on how to implement IRSA: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+
+### Confirm that 'Amazon CloudWatch Network Flow Monitor Agent' is successfully communicating with 'Amazon CloudWatch Network Flow Monitor Agent' ingestion APIs
+
+You can check to make sure that your 'Amazon CloudWatch Network Flow Monitor Agent' Pods have permissions set correctly by looking up for HTTP 200 logs. For example, you can do the following: 
+
+1. Locate a 'Amazon CloudWatch Network Flow Monitor Agent' Pod name. For example, you can use the following command:
+
+```
+RANDOM_AGENT_POD_NAME=$(kubectl get pods -o wide -A | grep amazon-network-flow-monitor | grep Running | head -n 1 | tr -s ' ' | cut -d " " -f 2)
+```
+
+2. Grep all the HTTP logs for that Pod. If you've changed the NAMESPACE, make sure that you use the new one.
+```
+NAMESPACE=amazon-network-flow-monitor
+kubectl logs $RANDOM_AGENT_POD_NAME --namespace ${NAMESPACE} | grep HTTP
+```
+
+If access has been granted successfully, you should see log entries similar to the following:
+```
+...{"level":"INFO","message":"HTTP request complete","status":200,"target":"aws-network-flow-monitoring-agent::reports::publisher_endpoint","timestamp":1729519236073}{"level":"INFO","message":"HTTP request complete","status":200,"target":"aws-network-flow-monitoring-agent::reports::publisher_endpoint","timestamp":1729519263143}{"level":"INFO","message":"HTTP request complete","status":200,"target":"aws-network-flow-monitoring-agent::reports::publisher_endpoint","timestamp":1729519293406}
+```
+                        
+
+Note that 'Amazon CloudWatch Network Flow Monitor Agent' publishes network flow reports to 'Amazon CloudWatch Network Flow Monitor Agent' ingestion APIs every 30 seconds.
+
 
 ## Security
 

--- a/charts/amazon-network-flow-monitor-agent/.helmignore
+++ b/charts/amazon-network-flow-monitor-agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/amazon-network-flow-monitor-agent/Chart.yaml
+++ b/charts/amazon-network-flow-monitor-agent/Chart.yaml
@@ -1,0 +1,21 @@
+# Chart.yaml file schema: https://helm.sh/docs/topics/charts/#the-chartyaml-file
+apiVersion: v2
+name: aws-network-flow-monitoring-agent
+description: A Helm chart for Amazon CloudWatch Network Flow Monitor Agent
+type: application
+
+# This version needs to increase every time the chart and its templates
+# change. This should follow SemVer.
+version: 1.0.0
+
+# Keep this in sync with Amazon CloudWatch Network Flow Monitor Agent package version
+# used when building the its Docker image
+appVersion: "0.1"
+
+kubeVersion: ">=1.25.0-0"
+keywords:
+  - aws
+  - network
+  - flow
+  - monitor
+  - agent

--- a/charts/amazon-network-flow-monitor-agent/Makefile
+++ b/charts/amazon-network-flow-monitor-agent/Makefile
@@ -1,0 +1,9 @@
+# Helm installs 'Amazon CloudWatch Network Flow Monitor Agent' to an existing K8s Cluster
+.PHONY: helm/install/customer
+helm/install/customer:
+	./bin/agent-k8s-install.sh
+
+# Helm uninstalls 'Amazon CloudWatch Network Flow Monitor Agent' from an existing K8s Cluster
+.PHONY: helm/uninstall/customer
+helm/uninstall/customer:
+	UNINSTALL=true ./bin/agent-k8s-install.sh

--- a/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
+++ b/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This script is used for installing/uninstalling 'Amazon CloudWatch Network Flow Monitor Agent' Kubernetes Application
+#
+# For installing: ./charts/amazon-network-flow-monitor-agent/agent-k8s-install.sh
+# For uninstalling: UNINSTALL=true ./charts/amazon-network-flow-monitor-agent/agent-k8s-install.sh
+#
+# RECOMMENDED to call this script via available make targets
+
+NAMESPACE=${NAMESPACE:-"amazon-network-flow-monitor"}
+HELM_RELEASE_NAME="amazon-network-flow-monitor"
+HELM_CHARTS_DIR="$(dirname "$(realpath "$0")")/../"
+VALUES_FILENAME=values.yaml
+
+# Publicly Accessible Docker Image Repository for 'Amazon CloudWatch Network Flow Monitor'
+CONTAINER_REGISTRY="602401143452.dkr.ecr.us-west-2.amazonaws.com"
+
+export LATEST_KNOWN_IMAGE_TAG="v1.0.0-eksbuild.4"
+export IMAGE_TAG=${IMAGE_TAG:-$LATEST_KNOWN_IMAGE_TAG}
+
+# Will install 'Amazon CloudWatch Network Flow Monitor Agent' Manifest Files to an existing K8s Cluster
+# - If you want just to see the rendered template, add '--dry-run' to the command
+function install-add-on-manifests() {
+  helm install --debug -n ${NAMESPACE} ${HELM_RELEASE_NAME} ${HELM_CHARTS_DIR} -f ${HELM_CHARTS_DIR}/${VALUES_FILENAME} \
+  --set image.containerRegistry=${CONTAINER_REGISTRY} \
+  --set image.tag=${IMAGE_TAG}
+}
+
+# Will uninstall 'Amazon CloudWatch Network Flow Monitor Agent' Manifest Files from an existing K8s Cluster
+function uninstall-add-on-manifests() {
+  helm uninstall -n ${NAMESPACE} ${HELM_RELEASE_NAME}
+}
+
+if [ $UNINSTALL ]; then
+  uninstall-add-on-manifests
+else
+  install-add-on-manifests
+fi

--- a/charts/amazon-network-flow-monitor-agent/templates/_helpers.tpl
+++ b/charts/amazon-network-flow-monitor-agent/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Get the current recommended 'aws-network-flow-monitoring-agent' image for a given k8s version
+*/}}
+{{- define "aws-network-flow-monitoring-agent.image" -}}
+{{- if .Values.image.override -}}
+{{- .Values.image.override -}}
+{{- else -}}
+{{- $imageDomain := "" -}}
+{{- if .Values.image.containerRegistry -}}
+{{- $imageDomain = .Values.image.containerRegistry -}}
+{{- end -}}
+{{- if not $imageDomain -}}
+{{- fail "Undefined Image Container Registry" -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $imageDomain .Values.image.name .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "aws-network-flow-monitoring-agent.labels" -}}
+{{ include "aws-network-flow-monitoring-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: EKS
+{{- end }}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-network-flow-monitoring-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "aws-network-flow-monitoring-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aws-network-flow-monitoring-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
+++ b/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
@@ -1,0 +1,50 @@
+# Create Amazon CloudWatch Network Flow Monitor Agent DaemonSet
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Values.daemonSet.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-network-flow-monitoring-agent.labels" . | nindent 4}}
+spec:
+  selector:
+    matchLabels:
+      name: {{ .Values.daemonSet.name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.daemonSet.name }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      hostNetwork: true
+      containers:
+        - name: {{ .Values.daemonSet.name }}
+          image: {{ include "aws-network-flow-monitoring-agent.image" . }}
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+      nodeSelector:
+        kubernetes.io/os: linux
+      terminationGracePeriodSeconds: 5
+      serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/amazon-network-flow-monitor-agent/templates/serviceAccount.yaml
+++ b/charts/amazon-network-flow-monitor-agent/templates/serviceAccount.yaml
@@ -1,0 +1,40 @@
+# Create Amazon CloudWatch Network Flow Monitor Agent ServiceAccount
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-network-flow-monitoring-agent.labels" . | nindent 4}}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.clusterRole.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-network-flow-monitoring-agent.labels" . | nindent 4}}
+rules:
+    - apiGroups: ["", "discovery.k8s.io"]
+      resources: ["pods", "nodes", "endpoints", "services", "endpointslices"]
+      verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.clusterRoleBinding.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-network-flow-monitoring-agent.labels" . | nindent 4}}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.clusterRole.name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -1,0 +1,35 @@
+image:
+  override: '' # if defined, this value is used as the canonical image name ("{image_repo}{image_name}:{tag}")
+  tag: v1.0.0-eksbuild.4  # this is the default image tag. It might be overwritten at runtime
+  containerRegistry: '' # this gets overriden at runtime with the correct Docker Image Registry
+  name: aws-network-sonar-agent  # DO NOT try to override this
+
+clusterRole:
+  name: aws-network-flow-monitoring-agent-role
+
+clusterRoleBinding:
+  name: aws-network-flow-monitoring-agent-role-binding
+
+serviceAccount:
+  name: aws-network-flow-monitoring-agent-service-account
+
+daemonSet:
+  name: aws-network-flow-monitoring-agent
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+          # Don't schedule on special compute types
+        - key: eks.amazonaws.com/compute-type
+          operator: NotIn
+          values:
+            - fargate
+            - auto
+            - hybrid
+          # Only schedule on amd64 nodes
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+            - amd64


### PR DESCRIPTION
### Context
PR with all content required to enable self-managed Kubernetes customers to install 'Amazon Cloudwatch Network Flow Monitor Agent' v1.0.0-eksbuild.4 to their cluster.

### Tests
Executed functional test suite locally to confirm 1) Pods were successfully deployed and 2) were successfully communicating with 'Amazon Cloudwatch Network Flow Monitor Agent' ingestion APIs.


