### PR TITLE
Add priotiyClassName to DaemonSet resource

### DIFF
--- a/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
+++ b/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
@@ -48,3 +48,6 @@ spec:
         kubernetes.io/os: linux
       terminationGracePeriodSeconds: 5
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -33,3 +33,5 @@ affinity:
           operator: In
           values:
             - amd64
+
+priorityClassName: ''


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed to allow priorityClassName to be added to DaemonSet.
By default, nothing is added, so there is no effect on existing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
