### PR TITLE
Provide the initial release of the NFM agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode/
+target/
+**/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+resolver = "2"
+members = ["nfm-controller", "nfm-common"]
+
+[workspace.metadata]
+bpf_target = "bpfel-unknown-none"

--- a/LICENSE
+++ b/LICENSE
@@ -173,3 +173,30 @@
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,2 @@
+network-flow-monitor-agent
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,55 @@
-# Amazon CloudWatch Network Flow Monitor Agent
+# Network Flow Monitor Agent
 
-'Amazon CloudWatch Network Flow Monitor Agent' Kubernetes application to support collecting TCP connections statistics from all nodes within a Kubernetes cluster and publishing network flows reports to 'Amazon CloudWatch Network Flow Monitor' Ingestion APIs.
+This is an on-host agent that passively collects performance statistics related
+to various communication protocols of interest, beginning with TCP.  The
+statistics can be published in an OpenTelemetry format to an ingestion
+endpoint.
+
+This application runs on Linux kernel version 5.8 and newer.
 
 ## Installation
 
-Please follow the [documentation here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents-kubernetes-non-eks.html) to install the application to your clusters.
+> [!TIP] [Instructions are
+> available](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents.html)
+> to deploy across a fleet of EC2 instances or EKS clusters and integrate with
+> Amazon CloudWatch Network Flow Monitor.
 
-## Security
+### Building
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+> [!NOTE]
+> Before proceeding, make sure you have a C compiler and [Rust development
+> tools](https://www.rust-lang.org/tools/install) available on your system.
+
+Build the application using the command:
+
+```bash
+cargo build --release
+```
+
+### Running
+
+> [!NOTE]
+> Before starting the application, make sure you've created a cgroup.  This
+> usually requires root priveleges or the `CAP_SYS_ADMIN` capability.
+>
+> ```bash
+> mkdir /mnt/cgroup-nfm
+> mount -t cgroup2 none /mnt/cgroup-nfm
+> ```
+
+To run the application with statistics printed to stdout, use the following
+command.  Run this as root or with the `CAP_BPF` capability. 
+
+```bash
+target/release/network-flow-monitor-agent --cgroup /mnt/cgroup-nfm --publish-reports off --log-reports on
+```
+
+To see the available command-line options, run:
+
+```bash
+target/release/network-flow-monitor-agent --help
+```
 
 ## License
 
-This project is licensed under the Apache-2.0 License.
+This project is licensed under the Apache 2.0 License.

--- a/nfm-bpf/.cargo/config.toml
+++ b/nfm-bpf/.cargo/config.toml
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["core"]

--- a/nfm-bpf/Cargo.toml
+++ b/nfm-bpf/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "nfm-bpf"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+aya-ebpf = "0.1"
+aya-log-common = "0.1"
+nfm-common = { path = "../nfm-common", features = ["bpf"] }
+
+[[bin]]
+name = "nfm-bpf"
+path = "src/main.rs"
+
+[profile.dev]
+codegen-units = 1
+debug-assertions = false
+lto = true
+opt-level = 3
+panic = "abort"
+
+[profile.release]
+codegen-units = 1
+debug-assertions = false
+lto = true
+panic = "abort"
+
+[workspace]
+members = []

--- a/nfm-bpf/src/main.rs
+++ b/nfm-bpf/src/main.rs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{
+    bindings::bpf_ret_code::BPF_OK,
+    macros::sock_ops,
+    programs::SockOpsContext,
+};
+
+use nfm_common::{BpfControlConveyor, TcpSockOpsHandler, nfm_now_us};
+
+// The eBPF entry point.
+#[sock_ops]
+pub fn nfm_sock_ops(ctx: SockOpsContext) -> u32 {
+    // We check whether to handle the event as early as possible, to minimize CPU cycles when
+    // discarding events.
+    let conveyor = BpfControlConveyor{};
+    if conveyor.should_handle_event(ctx.op()) {
+        let _result_code = TcpSockOpsHandler::new(&ctx, nfm_now_us()).handle_socket_event();
+    }
+
+    // Always return ok so as not to mess with the customer connection.
+    BPF_OK
+}
+
+#[no_mangle]
+#[link_section = "license"]
+pub static LICENSE: [u8; 11] = *b"Apache-2.0\0";
+    
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { core::hint::unreachable_unchecked() }
+}

--- a/nfm-common/Cargo.toml
+++ b/nfm-common/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nfm-common"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+aya = { version = "0.13", optional = true }
+aya-ebpf = { version = "*", optional = true}
+bitflags = { version = "2", optional = true, features = ["serde"] }
+libc = { version = "0.2", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[lib]
+path = "src/mod.rs"
+
+[features]
+default = []
+bpf = ["aya-ebpf", "bitflags"]
+user = ["aya", "bitflags", "libc", "serde"]

--- a/nfm-common/src/constants.rs
+++ b/nfm-common/src/constants.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub const SK_STATS_TO_PROPS_RATIO: u64 = 3;
+
+pub const MAX_ENTRIES_SK_PROPS_LO: u64 = 250;
+pub const MAX_ENTRIES_SK_STATS_LO: u64 = SK_STATS_TO_PROPS_RATIO * MAX_ENTRIES_SK_PROPS_LO;
+
+pub const MAX_ENTRIES_SK_PROPS_HI: u64 = 20000;
+pub const MAX_ENTRIES_SK_STATS_HI: u64 = SK_STATS_TO_PROPS_RATIO * MAX_ENTRIES_SK_PROPS_HI;
+
+pub const AGG_FLOWS_MAX_ENTRIES: u32 = 10_000;
+
+pub const EBPF_PROGRAM_NAME: &str = "nfm_sock_ops";
+pub const NFM_CONTROL_MAP_NAME: &str = "NFM_CONTROL";
+pub const NFM_COUNTERS_MAP_NAME: &str = "NFM_COUNTERS";
+pub const NFM_SK_PROPS_MAP_NAME: &str = "NFM_SK_PROPS";
+pub const NFM_SK_STATS_MAP_NAME: &str = "NFM_SK_STATS";

--- a/nfm-common/src/ebpf_actuals.rs
+++ b/nfm-common/src/ebpf_actuals.rs
@@ -1,0 +1,136 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * This module contains scaffolding used to interact with the eBPF subsystem through Aya, and is
+ * excluded from compilation into user-space packages.  Everything here has counterparts within the
+ * `ebpf_mocks` module.
+ */
+
+use crate::constants::{MAX_ENTRIES_SK_PROPS_LO, MAX_ENTRIES_SK_STATS_LO};
+use crate::network::{
+    ControlData, CpuSockKey, EventCounters, SingletonKey, SockContext, SockOpsStats, SockStats,
+};
+
+use aya_ebpf::helpers::{bpf_get_smp_processor_id, bpf_get_socket_cookie, bpf_ktime_get_boot_ns};
+
+// These imports are flagged as public to allow them to be exported to the crate root.
+pub use aya_ebpf::{
+    // Constants we depend on from `aya-ebpf-bindings`.
+    bindings::{BPF_ANY, BPF_EXIST, BPF_F_NO_PREALLOC, BPF_NOEXIST},
+    bindings::{
+        BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB, BPF_SOCK_OPS_HDR_OPT_LEN_CB,
+        BPF_SOCK_OPS_PARSE_HDR_OPT_CB, BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB,
+        BPF_SOCK_OPS_RETRANS_CB, BPF_SOCK_OPS_RTO_CB, BPF_SOCK_OPS_RTT_CB, BPF_SOCK_OPS_STATE_CB,
+        BPF_SOCK_OPS_TCP_CONNECT_CB,
+    },
+    bindings::{
+        BPF_SOCK_OPS_ALL_CB_FLAGS, BPF_SOCK_OPS_PARSE_ALL_HDR_OPT_CB_FLAG,
+        BPF_SOCK_OPS_RETRANS_CB_FLAG, BPF_SOCK_OPS_RTO_CB_FLAG, BPF_SOCK_OPS_RTT_CB_FLAG,
+        BPF_SOCK_OPS_STATE_CB_FLAG, BPF_SOCK_OPS_WRITE_HDR_OPT_CB_FLAG,
+    },
+    bindings::{
+        BPF_TCP_CLOSE, BPF_TCP_CLOSE_WAIT, BPF_TCP_CLOSING, BPF_TCP_ESTABLISHED, BPF_TCP_FIN_WAIT1,
+        BPF_TCP_FIN_WAIT2, BPF_TCP_LAST_ACK, BPF_TCP_LISTEN, BPF_TCP_SYN_RECV, BPF_TCP_SYN_SENT,
+        BPF_TCP_TIME_WAIT,
+    },
+
+    helpers::bpf_get_prandom_u32,
+
+    // The BPF_MAP interface we depend on from `aya-ebpf`.
+    macros::map,
+    maps::PerCpuHashMap,
+
+    // The context passed into our eBPF SOCK_OPS program by the kernel.
+    programs::SockOpsContext,
+
+    // The trait for the as_ptr() fn.
+    EbpfContext,
+};
+
+pub type SharedHashMap<K, V> = aya_ebpf::maps::HashMap<K, V>;
+
+// *** Instances of eBPF maps used by our program, prefixed under the "NETWORK_FLOW_MONITOR" namespace. ***
+
+// NFM_CONTROL communicates control knobs from user-space to BPF – one writer, many readers,
+// never deleted from.
+#[map]
+pub static NFM_CONTROL: SharedHashMap<SingletonKey, ControlData> =
+    SharedHashMap::with_max_entries(1, BPF_F_NO_PREALLOC);
+
+// NFM_COUNTERS communicates events from BPF to user-space.  It is per-CPU and contents are never
+// deleted.
+#[map]
+pub static NFM_COUNTERS: PerCpuHashMap<SingletonKey, EventCounters> =
+    PerCpuHashMap::with_max_entries(1, 0);
+
+// SK_PROPS communicates the properties of a newly established socket to user-space.  It is used as
+// a signaling channel; entries are deleted by user-space once read.
+#[map]
+pub static NFM_SK_PROPS: SharedHashMap<CpuSockKey, SockContext> =
+    SharedHashMap::with_max_entries(MAX_ENTRIES_SK_PROPS_LO as u32, BPF_F_NO_PREALLOC);
+
+// SK_STATS is where the BPF program writes socket statistics in response to sock_ops events for
+// tracked sockets.  Entries are deleted by user-space upon socket closure.
+#[map]
+pub static NFM_SK_STATS: SharedHashMap<CpuSockKey, SockStats> =
+    SharedHashMap::with_max_entries(MAX_ENTRIES_SK_STATS_LO as u32, BPF_F_NO_PREALLOC);
+
+// Operations on BPF maps.
+#[macro_export]
+macro_rules! bpf_map_get {
+    ($self:ident, $map_name:expr, $key:expr) => {
+        unsafe { $map_name.get($key) }
+    };
+}
+
+#[macro_export]
+macro_rules! bpf_map_get_ptr_mut {
+    ($self:ident, $map_name:expr, $key:expr) => {
+        $map_name.get_ptr_mut($key)
+    };
+}
+
+#[macro_export]
+macro_rules! bpf_map_insert {
+    ($self:ident, $map_name:expr, $key:expr, $val:expr, $flags:expr) => {
+        $map_name.insert($key, $val, <u32 as Into<u64>>::into($flags))
+    };
+}
+
+#[macro_export]
+macro_rules! bpf_get_rand_u32 {
+    ($self:ident) => {
+        unsafe { bpf_get_prandom_u32() }
+    };
+}
+
+// *** BPF helper functions, prefixed under the "nfm" namespace. ***
+
+pub fn nfm_get_cpu_id() -> u64 {
+    unsafe { bpf_get_smp_processor_id().into() }
+}
+
+pub fn nfm_now_us() -> u64 {
+    unsafe { bpf_ktime_get_boot_ns() / 1000 }
+}
+
+pub fn nfm_get_sock_cookie(ctx: &SockOpsContext) -> u64 {
+    unsafe { bpf_get_socket_cookie(ctx.as_ptr()) }
+}
+
+pub fn nfm_get_sock_state(ctx: &SockOpsContext) -> u32 {
+    unsafe { (*ctx.ops).state }
+}
+
+pub fn nfm_get_sock_ops_stats(ctx: &SockOpsContext) -> SockOpsStats {
+    unsafe {
+        SockOpsStats {
+            bytes_received: (*ctx.ops).bytes_received,
+            bytes_acked: (*ctx.ops).bytes_acked,
+            segments_received: (*ctx.ops).data_segs_in,
+            segments_delivered: (*ctx.ops).data_segs_out,
+            srtt_us: (*ctx.ops).srtt_us >> 3,
+        }
+    }
+}

--- a/nfm-common/src/ebpf_mocks.rs
+++ b/nfm-common/src/ebpf_mocks.rs
@@ -1,0 +1,290 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * This module contains scaffolding used to mock out interactions with eBPF.  The purpose is to
+ * enable our sock-ops logic to be unit-testable in a user-space binary, given the lack of unit
+ * test support in Aya [a].  Everything here has counterparts within the `ebpf_actuals` module.
+ *
+ * [a] https://github.com/aya-rs/aya/issues/36 Support Unit Testing of BPF Programs
+ */
+
+use crate::constants::{MAX_ENTRIES_SK_PROPS_HI, MAX_ENTRIES_SK_STATS_HI};
+use crate::network::{
+    ControlData, CpuSockKey, EventCounters, SingletonKey, SockContext, SockOpsStats, SockStats,
+    SINGLETON_KEY,
+};
+
+use libc::{EINVAL, ENOMEM};
+use std::collections::HashMap;
+use std::hash::Hash;
+
+pub const MOCK_CPU_ID: u64 = 199;
+
+// Constants we depend on from `aya-ebpf-bindings`.  Note that the values here do not need to match
+// those within Aya.
+pub const BPF_ANY: u64 = 0;
+pub const BPF_NOEXIST: u64 = 1 << 1;
+pub const BPF_EXIST: u64 = 1 << 2;
+
+pub const BPF_F_NO_PREALLOC: u32 = 1;
+
+pub const BPF_SOCK_OPS_RETRANS_CB_FLAG: u32 = 1 << 1;
+pub const BPF_SOCK_OPS_RTO_CB_FLAG: u32 = 1 << 2;
+pub const BPF_SOCK_OPS_RTT_CB_FLAG: u32 = 1 << 3;
+pub const BPF_SOCK_OPS_STATE_CB_FLAG: u32 = 1 << 4;
+pub const BPF_SOCK_OPS_PARSE_ALL_HDR_OPT_CB_FLAG: u32 = 1 << 5;
+pub const BPF_SOCK_OPS_WRITE_HDR_OPT_CB_FLAG: u32 = 1 << 6;
+pub const BPF_SOCK_OPS_ALL_CB_FLAGS: u32 = 1 << 7;
+
+pub const BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB: u32 = 1;
+pub const BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB: u32 = 2;
+pub const BPF_SOCK_OPS_RETRANS_CB: u32 = 3;
+pub const BPF_SOCK_OPS_RTO_CB: u32 = 4;
+pub const BPF_SOCK_OPS_RTT_CB: u32 = 5;
+pub const BPF_SOCK_OPS_STATE_CB: u32 = 6;
+pub const BPF_SOCK_OPS_TCP_CONNECT_CB: u32 = 7;
+pub const BPF_SOCK_OPS_PARSE_HDR_OPT_CB: u32 = 8;
+pub const BPF_SOCK_OPS_HDR_OPT_LEN_CB: u32 = 9;
+
+pub const BPF_TCP_CLOSE: u32 = 1;
+pub const BPF_TCP_CLOSE_WAIT: u32 = 2;
+pub const BPF_TCP_CLOSING: u32 = 3;
+pub const BPF_TCP_ESTABLISHED: u32 = 4;
+pub const BPF_TCP_FIN_WAIT1: u32 = 5;
+pub const BPF_TCP_FIN_WAIT2: u32 = 6;
+pub const BPF_TCP_LAST_ACK: u32 = 7;
+pub const BPF_TCP_LISTEN: u32 = 8;
+pub const BPF_TCP_SYN_RECV: u32 = 9;
+pub const BPF_TCP_SYN_SENT: u32 = 10;
+pub const BPF_TCP_TIME_WAIT: u32 = 11;
+
+// The BPF_MAP interface we depend on from `aya-ebpf`.
+pub struct SharedHashMap<K, V>
+where
+    K: Copy + Eq + Hash,
+    V: Copy,
+{
+    pub(crate) data: HashMap<K, V>,
+    capacity: u32,
+}
+
+impl<K, V> SharedHashMap<K, V>
+where
+    K: Copy + Eq + Hash,
+    V: Copy,
+{
+    pub fn with_max_entries(capacity: u32) -> SharedHashMap<K, V> {
+        SharedHashMap {
+            data: HashMap::new(),
+            capacity,
+        }
+    }
+
+    pub fn insert(&mut self, key: &K, val: &V, flags: u64) -> Result<(), i64> {
+        let exists = self.data.contains_key(key);
+        let should_exist = (flags & BPF_EXIST) > 0;
+        let should_not_exist = (flags & BPF_NOEXIST) > 0;
+
+        if !exists && self.data.len() >= self.capacity.try_into().unwrap() {
+            Err((-ENOMEM).into())
+        } else if (should_exist && !exists) || (should_not_exist && exists) {
+            Err((-EINVAL).into())
+        } else {
+            self.data.insert(*key, *val);
+            Ok(())
+        }
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.data.get(key)
+    }
+
+    pub fn get_ptr_mut(&mut self, key: &K) -> Option<*mut V> {
+        self.data.get_mut(key).map(|v| v as *mut V)
+    }
+}
+
+pub type PerCpuHashMap<K, V> = SharedHashMap<K, V>;
+
+// Instances of eBPF maps used by our program.  These maps are housed within a struct, instead of
+// defined globally, so that the invocation of each unit test function has its own local state.
+// This allows for test invocations that are free of both concurrency management and any risk of
+// polluted state.
+#[allow(non_snake_case)]
+pub struct MockEbpfMaps {
+    pub NFM_CONTROL: SharedHashMap<SingletonKey, ControlData>,
+    pub NFM_COUNTERS: PerCpuHashMap<SingletonKey, EventCounters>,
+    pub NFM_SK_PROPS: SharedHashMap<CpuSockKey, SockContext>,
+    pub NFM_SK_STATS: SharedHashMap<CpuSockKey, SockStats>,
+    pub mock_rand: u32,
+}
+
+impl MockEbpfMaps {
+    pub fn new() -> Self {
+        Self {
+            NFM_CONTROL: SharedHashMap::<SingletonKey, ControlData>::with_max_entries(1),
+            NFM_COUNTERS: PerCpuHashMap::<SingletonKey, EventCounters>::with_max_entries(1),
+            NFM_SK_PROPS: SharedHashMap::<CpuSockKey, SockContext>::with_max_entries(
+                MAX_ENTRIES_SK_PROPS_HI.try_into().unwrap(),
+            ),
+            NFM_SK_STATS: SharedHashMap::<CpuSockKey, SockStats>::with_max_entries(
+                MAX_ENTRIES_SK_STATS_HI.try_into().unwrap(),
+            ),
+            mock_rand: 1,
+        }
+    }
+
+    pub fn control_data(&self) -> &ControlData {
+        self.NFM_CONTROL.data.get(&SINGLETON_KEY).unwrap()
+    }
+
+    pub fn counters(&self) -> &EventCounters {
+        self.NFM_COUNTERS.data.get(&SINGLETON_KEY).unwrap()
+    }
+
+    pub fn sock_props(&self, key: &CpuSockKey) -> &SockContext {
+        self.NFM_SK_PROPS.data.get(key).unwrap()
+    }
+
+    pub fn sock_stats(&self, key: &CpuSockKey) -> &SockStats {
+        self.NFM_SK_STATS.data.get(key).unwrap()
+    }
+}
+
+impl Default for MockEbpfMaps {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// The context passed into our eBPF SOCK_OPS program by the kernel.
+#[derive(Default)]
+pub struct SockOpsContext {
+    pub op: u32,
+    pub family: u32,
+    pub cb_flags: i32,
+    pub remote_ip4: u32,
+    pub local_ip4: u32,
+    pub remote_ip6: [u32; 4],
+    pub local_ip6: [u32; 4],
+    pub local_port: u32,
+    pub remote_port: u32,
+    pub args: [u32; 2],
+    pub stats: SockOpsStats,
+    pub cookie: u64,
+    pub sock_state: u32,
+}
+
+// Match the function interfaces of an Aya SockOpsContext.
+impl SockOpsContext {
+    pub fn op(&self) -> u32 {
+        self.op
+    }
+
+    pub fn family(&self) -> u32 {
+        self.family
+    }
+
+    pub fn cb_flags(&self) -> i32 {
+        self.cb_flags
+    }
+
+    pub fn set_cb_flags(&self, flags: i32) -> Result<(), i64> {
+        assert!(flags as u32 & BPF_SOCK_OPS_RTT_CB_FLAG > 0);
+        assert!(flags as u32 & BPF_SOCK_OPS_RTO_CB_FLAG > 0);
+        assert!(flags as u32 & BPF_SOCK_OPS_STATE_CB_FLAG > 0);
+        assert!(flags as u32 & BPF_SOCK_OPS_RETRANS_CB_FLAG > 0);
+
+        // Note that without this callback, we receive no BPF events for a socket that's only
+        // receiving data.  The socket would then be treated as inactive and evicted from our
+        // cache.
+        assert!(flags as u32 & BPF_SOCK_OPS_PARSE_ALL_HDR_OPT_CB_FLAG > 0);
+
+        Ok(())
+    }
+
+    pub fn remote_ip4(&self) -> u32 {
+        self.remote_ip4
+    }
+
+    pub fn local_ip4(&self) -> u32 {
+        self.local_ip4
+    }
+
+    pub fn remote_ip6(&self) -> [u32; 4] {
+        self.remote_ip6
+    }
+
+    pub fn local_ip6(&self) -> [u32; 4] {
+        self.local_ip6
+    }
+
+    pub fn local_port(&self) -> u32 {
+        self.local_port
+    }
+
+    pub fn remote_port(&self) -> u32 {
+        self.remote_port
+    }
+
+    pub fn arg(&self, n: usize) -> u32 {
+        self.args[n]
+    }
+}
+
+// Operations on BPF maps.
+#[macro_export]
+macro_rules! bpf_map_get {
+    ($self:ident, $map_name:ident, $key:expr) => {
+        $self.mock_ebpf_maps.$map_name.get($key)
+    };
+}
+
+#[macro_export]
+macro_rules! bpf_map_get_ptr_mut {
+    ($self:ident, $map_name:ident, $key:expr) => {
+        $self
+            .mock_ebpf_maps
+            .as_mut()
+            .unwrap()
+            .$map_name
+            .get_ptr_mut($key)
+    };
+}
+
+#[macro_export]
+macro_rules! bpf_map_insert {
+    ($self:ident, $map_name:ident, $key:expr, $val:expr, $flags:expr) => {
+        $self
+            .mock_ebpf_maps
+            .as_mut()
+            .unwrap()
+            .$map_name
+            .insert($key, $val, $flags)
+    };
+}
+
+#[macro_export]
+macro_rules! bpf_get_rand_u32 {
+    ($self:ident) => {
+        $self.mock_ebpf_maps.mock_rand
+    };
+}
+
+// BPF helper functions.
+pub fn nfm_get_cpu_id() -> u64 {
+    MOCK_CPU_ID
+}
+
+pub fn nfm_get_sock_cookie(ctx: &SockOpsContext) -> u64 {
+    ctx.cookie
+}
+
+pub fn nfm_get_sock_state(ctx: &SockOpsContext) -> u32 {
+    ctx.sock_state
+}
+
+pub fn nfm_get_sock_ops_stats(ctx: &SockOpsContext) -> SockOpsStats {
+    ctx.stats
+}

--- a/nfm-common/src/mod.rs
+++ b/nfm-common/src/mod.rs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(feature = "bpf", no_std)]
+
+#[cfg(feature = "bpf")]
+pub mod ebpf_actuals;
+#[cfg(feature = "bpf")]
+pub use ebpf_actuals::*;
+
+#[cfg(not(feature = "bpf"))]
+pub mod ebpf_mocks;
+#[cfg(not(feature = "bpf"))]
+pub use ebpf_mocks::*;
+
+pub mod constants;
+pub use constants::*;
+
+pub mod network;
+pub use network::*;
+
+#[cfg(not(feature = "bpf"))]
+pub mod network_user;
+
+pub mod utils;
+pub use crate::utils::MinNonZero;
+
+pub mod sock_ops_handler;
+pub use sock_ops_handler::{BpfControlConveyor, TcpSockOpsHandler};

--- a/nfm-common/src/network.rs
+++ b/nfm-common/src/network.rs
@@ -1,0 +1,736 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{utils::MinNonZero, SockOpsContext};
+use bitflags::bitflags;
+
+pub type SockKey = u64;
+pub type SingletonKey = u64;
+pub type Ipv6Bytes = [u8; 16];
+
+pub const SINGLETON_KEY: u64 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_INET6: u32 = 10;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[cfg_attr(not(feature = "bpf"), derive(serde::Serialize))]
+pub struct CpuSockKey {
+    pub cpu_id: u64,
+    pub sock_key: SockKey,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(not(feature = "bpf"), derive(serde::Serialize))]
+pub struct ControlData {
+    pub sampling_interval: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd)]
+#[cfg_attr(not(feature = "bpf"), derive(serde::Deserialize, serde::Serialize))]
+pub struct EventCounters {
+    // Event counters.
+    pub active_connect_events: u32,
+    pub active_established_events: u32,
+    pub passive_established_events: u32,
+    pub state_change_events: u32,
+    pub rtt_events: u32,
+    pub retrans_events: u32,
+    pub rto_events: u32,
+    pub other_events: u32,
+    pub socket_events: u32,
+
+    // Error counters.
+    pub sockets_invalid: u32,
+    pub map_insertion_errors: u32,
+    pub rtts_invalid: u32,
+    pub set_flags_errors: u32,
+    pub other_errors: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(not(feature = "bpf"), derive(serde::Serialize))]
+pub struct SockContext {
+    pub local_ipv4: u32,
+    pub remote_ipv4: u32,
+    pub local_ipv6: Ipv6Bytes,
+    pub remote_ipv6: Ipv6Bytes,
+    pub local_port: u16,
+    pub remote_port: u16,
+    pub address_family: u32,
+    pub is_client: bool,
+
+    // Pad the struct length to a multiple of 8 to appease the verifier.
+    pub _pad: [u8; 3],
+}
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[cfg_attr(not(feature = "bpf"), derive(serde::Serialize))]
+    pub struct SockStateFlags: u32 {
+        // Types of states the socket has been in.
+        const ENTERED_ESTABLISH = 1 << 1;
+        const STARTED_CLOSURE = 1 << 2;
+
+        // Transitions the socket has gone through.
+        const TERMINATED_FROM_SYN = 1 << 3;
+        const TERMINATED_FROM_EST = 1 << 4;
+
+        // Is the socket ready to be evicted (meaning in state CLOSED or LISTEN).
+        const CLOSED = 1 << 5;
+    }
+}
+
+// Stats directly copied from a `bpf_sock_ops` structure.
+#[derive(Clone, Copy)]
+#[cfg_attr(not(feature = "bpf"), derive(Default))]
+pub struct SockOpsStats {
+    pub bytes_received: u64,
+    pub bytes_acked: u64,
+    pub segments_received: u32,
+    pub segments_delivered: u32,
+    pub srtt_us: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(not(feature = "bpf"), derive(serde::Serialize))]
+pub struct SockStats {
+    pub last_touched_us: u64,
+    pub connect_start_us: u64,
+    pub connect_end_us: u64,
+
+    pub bytes_received: u64,
+    pub bytes_delivered: u64,
+    pub segments_received: u32,
+    pub segments_delivered: u32,
+
+    pub rtt_count: u32,
+    pub rtt_latest_us: u32,
+    pub rtt_smoothed_us: u32,
+
+    pub retrans_syn: u32,
+    pub retrans_est: u32,
+    pub retrans_close: u32,
+
+    pub rtos_syn: u32,
+    pub rtos_est: u32,
+    pub rtos_close: u32,
+
+    pub state_flags: SockStateFlags,
+
+    pub connect_attempts: u8,
+    pub connect_successes: u8,
+
+    // Keep the struct size a multiple of 8 bytes to allow the eBPF verifier to confirm all bytes
+    // are initialized.
+    pub _pad: [u8; 6],
+}
+
+impl SockStats {
+    pub fn new() -> SockStats {
+        SockStats::default()
+    }
+
+    // Adds stats from one CPU core to the current stats (from another core for the same socket).
+    pub fn add_from(&mut self, other: &SockStats, last_agg_timestamp: u64) {
+        // If a certain core only handled this socket in the distant past, we don't want its old
+        // RTT measurement to inaccurately skew results within the current aggregation window.
+        // Thus, we'll accept a core's RTTs only if it has seen newer events for this socket.
+        if other.last_touched_us >= last_agg_timestamp {
+            if self.last_touched_us >= last_agg_timestamp {
+                self.rtt_latest_us = self.rtt_latest_us.min_non_zero(other.rtt_latest_us);
+                self.rtt_smoothed_us = self.rtt_smoothed_us.max(other.rtt_smoothed_us);
+            } else {
+                self.rtt_latest_us = other.rtt_latest_us;
+                self.rtt_smoothed_us = other.rtt_smoothed_us;
+            }
+        }
+
+        // Timestamps and flags represent latest observations, so we take the max or the union.
+        self.last_touched_us = self.last_touched_us.max(other.last_touched_us);
+        self.connect_start_us = self.connect_start_us.max(other.connect_start_us);
+        self.connect_end_us = self.connect_end_us.max(other.connect_end_us);
+        self.state_flags |= other.state_flags;
+
+        // Certain counters are accumulated per socket by the kernel, so no summation needed.
+        self.bytes_received = self.bytes_received.max(other.bytes_received);
+        self.bytes_delivered = self.bytes_delivered.max(other.bytes_delivered);
+        self.segments_received = self.segments_received.max(other.segments_received);
+        self.segments_delivered = self.segments_delivered.max(other.segments_delivered);
+
+        // Other counters are accumulated by our BPF layer, and must be summed across CPU cores.
+        self.retrans_syn += other.retrans_syn;
+        self.retrans_est += other.retrans_est;
+        self.retrans_close += other.retrans_close;
+
+        self.rtos_syn += other.rtos_syn;
+        self.rtos_est += other.rtos_est;
+        self.rtos_close += other.rtos_close;
+
+        self.rtt_count += other.rtt_count;
+        self.connect_attempts += other.connect_attempts;
+        self.connect_successes += other.connect_successes;
+    }
+
+    pub fn subtract(&self, rhs: &SockStats) -> SockStats {
+        SockStats {
+            // Preserve values that are not counters.
+            last_touched_us: self.last_touched_us,
+            connect_start_us: self.connect_start_us,
+            connect_end_us: self.connect_end_us,
+            state_flags: self.state_flags,
+            rtt_latest_us: self.rtt_latest_us,
+            rtt_smoothed_us: self.rtt_smoothed_us,
+
+            // Take the delta of all values that are counters.
+            bytes_received: self.bytes_received.wrapping_sub(rhs.bytes_received),
+            bytes_delivered: self.bytes_delivered.wrapping_sub(rhs.bytes_delivered),
+            segments_received: self.segments_received.wrapping_sub(rhs.segments_received),
+            segments_delivered: self.segments_delivered.wrapping_sub(rhs.segments_delivered),
+            rtt_count: self.rtt_count.wrapping_sub(rhs.rtt_count),
+
+            retrans_syn: self.retrans_syn.wrapping_sub(rhs.retrans_syn),
+            retrans_est: self.retrans_est.wrapping_sub(rhs.retrans_est),
+            retrans_close: self.retrans_close.wrapping_sub(rhs.retrans_close),
+
+            rtos_syn: self.rtos_syn.wrapping_sub(rhs.rtos_syn),
+            rtos_est: self.rtos_est.wrapping_sub(rhs.rtos_est),
+            rtos_close: self.rtos_close.wrapping_sub(rhs.rtos_close),
+
+            connect_attempts: self.connect_attempts.wrapping_sub(rhs.connect_attempts),
+            connect_successes: self.connect_successes.wrapping_sub(rhs.connect_successes),
+
+            ..Default::default()
+        }
+    }
+
+    pub fn connect_us(&self) -> Option<u32> {
+        if self.connect_start_us > 0 && self.connect_end_us > self.connect_start_us {
+            Some((self.connect_end_us - self.connect_start_us) as u32)
+        } else {
+            None
+        }
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.state_flags.contains(SockStateFlags::CLOSED)
+    }
+}
+
+impl SockContext {
+    pub fn from_sock_ops(ctx: &SockOpsContext, is_client: bool) -> SockContext {
+        // Note that the local port is expected to be in host byte order.
+        let remote_port = u32::from_be(ctx.remote_port());
+        let local_port = ctx.local_port();
+
+        SockContext {
+            is_client,
+            address_family: ctx.family(),
+            local_ipv4: u32::from_be(ctx.local_ip4()),
+            remote_ipv4: u32::from_be(ctx.remote_ip4()),
+            local_ipv6: SockContext::ipv6_to_bytes(ctx.local_ip6()),
+            remote_ipv6: SockContext::ipv6_to_bytes(ctx.remote_ip6()),
+            local_port: local_port.try_into().unwrap(),
+            remote_port: remote_port.try_into().unwrap(),
+            ..Default::default()
+        }
+    }
+
+    pub fn service_port(&self) -> u16 {
+        if self.is_client {
+            self.remote_port
+        } else {
+            self.local_port
+        }
+    }
+
+    pub fn ipv6_to_bytes(parts: [u32; 4]) -> Ipv6Bytes {
+        let mut bytes: Ipv6Bytes = [0; 16];
+        for (i, part) in parts.iter().enumerate() {
+            // Copy each byte, least-significant first, into the byte array left to right.
+            for j in 0..4 {
+                bytes[i * 4 + j] = (part >> (8 * j)) as u8;
+            }
+        }
+
+        bytes
+    }
+
+    pub fn is_valid(&self) -> bool {
+        matches!(self.address_family, AF_INET | AF_INET6)
+    }
+}
+
+impl EventCounters {
+    // Adds to the current set of counters.
+    pub fn add_from(&mut self, other: &EventCounters) {
+        self.active_connect_events = self
+            .active_connect_events
+            .wrapping_add(other.active_connect_events);
+        self.active_established_events = self
+            .active_established_events
+            .wrapping_add(other.active_established_events);
+        self.passive_established_events = self
+            .passive_established_events
+            .wrapping_add(other.passive_established_events);
+        self.state_change_events = self
+            .state_change_events
+            .wrapping_add(other.state_change_events);
+        self.rtt_events = self.rtt_events.wrapping_add(other.rtt_events);
+        self.retrans_events = self.retrans_events.wrapping_add(other.retrans_events);
+        self.rto_events = self.rto_events.wrapping_add(other.rto_events);
+        self.other_events = self.other_events.wrapping_add(other.other_events);
+        self.socket_events = self.socket_events.wrapping_add(other.socket_events);
+
+        self.sockets_invalid = self.sockets_invalid.wrapping_add(other.sockets_invalid);
+        self.map_insertion_errors = self
+            .map_insertion_errors
+            .wrapping_add(other.map_insertion_errors);
+        self.rtts_invalid = self.rtts_invalid.wrapping_add(other.rtts_invalid);
+        self.set_flags_errors = self.set_flags_errors.wrapping_add(other.set_flags_errors);
+        self.other_errors = self.other_errors.wrapping_add(other.other_errors);
+    }
+
+    // Returns a new set of counters as the difference between the current set and those supplied.
+    pub fn subtract(&self, rhs: &EventCounters) -> EventCounters {
+        EventCounters {
+            active_connect_events: self
+                .active_connect_events
+                .wrapping_sub(rhs.active_connect_events),
+            active_established_events: self
+                .active_established_events
+                .wrapping_sub(rhs.active_established_events),
+            passive_established_events: self
+                .passive_established_events
+                .wrapping_sub(rhs.passive_established_events),
+            state_change_events: self
+                .state_change_events
+                .wrapping_sub(rhs.state_change_events),
+            rtt_events: self.rtt_events.wrapping_sub(rhs.rtt_events),
+            retrans_events: self.retrans_events.wrapping_sub(rhs.retrans_events),
+            rto_events: self.rto_events.wrapping_sub(rhs.rto_events),
+            other_events: self.other_events.wrapping_sub(rhs.other_events),
+            socket_events: self.socket_events.wrapping_sub(rhs.socket_events),
+
+            sockets_invalid: self.sockets_invalid.wrapping_sub(rhs.sockets_invalid),
+            map_insertion_errors: self
+                .map_insertion_errors
+                .wrapping_sub(rhs.map_insertion_errors),
+            rtts_invalid: self.rtts_invalid.wrapping_sub(rhs.rtts_invalid),
+            set_flags_errors: self.set_flags_errors.wrapping_sub(rhs.set_flags_errors),
+            other_errors: self.other_errors.wrapping_sub(rhs.other_errors),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::SockOpsContext;
+
+    use super::{
+        EventCounters, Ipv6Bytes, SockContext, SockStateFlags, SockStats, AF_INET, AF_INET6,
+    };
+
+    #[test]
+    fn test_sock_context_is_valid() {
+        let mut sock_ctx = SockContext::default();
+        assert!(!sock_ctx.is_valid());
+
+        sock_ctx.address_family = AF_INET;
+        assert!(sock_ctx.is_valid());
+
+        sock_ctx.address_family = AF_INET6;
+        assert!(sock_ctx.is_valid());
+    }
+
+    #[test]
+    fn test_sock_stats_add_with_last_agg_timestamp() {
+        let stats1 = SockStats {
+            last_touched_us: 100,
+            rtt_count: 5,
+            rtt_latest_us: 20,
+            rtt_smoothed_us: 30,
+            ..Default::default()
+        };
+        let stats2 = SockStats {
+            last_touched_us: 200,
+            rtt_count: 7,
+            rtt_latest_us: 25,
+            rtt_smoothed_us: 35,
+            ..Default::default()
+        };
+
+        // Adding with an old timestamp adds 'em all.
+        let last_agg_ts: u64 = 99;
+        let expected = SockStats {
+            last_touched_us: 200,
+            rtt_count: 12,
+            rtt_latest_us: 20,
+            rtt_smoothed_us: 35,
+            ..Default::default()
+        };
+        let mut actual = stats1.clone();
+        actual.add_from(&stats2, last_agg_ts);
+        assert_eq!(actual, expected);
+        let mut actual = stats2.clone();
+        actual.add_from(&stats1, last_agg_ts);
+        assert_eq!(actual, expected);
+
+        // Adding with a last-touched on the aggregation threshold also adds 'em all.
+        let last_agg_ts: u64 = stats1.last_touched_us;
+        let mut actual = stats1.clone();
+        actual.add_from(&stats2, last_agg_ts);
+        assert_eq!(actual, expected);
+        let mut actual = stats2.clone();
+        actual.add_from(&stats1, last_agg_ts);
+        assert_eq!(actual, expected);
+
+        // Adding with the newest timestamp adds all fields but for RTT, using only newer stats.
+        let last_agg_ts: u64 = stats2.last_touched_us;
+        let expected = SockStats {
+            last_touched_us: 200,
+            rtt_count: 12,
+            rtt_latest_us: 25,
+            rtt_smoothed_us: 35,
+            ..Default::default()
+        };
+        let mut actual = stats1.clone();
+        actual.add_from(&stats2, last_agg_ts);
+        assert_eq!(actual, expected);
+        let mut actual = stats2.clone();
+        actual.add_from(&stats1, last_agg_ts);
+        assert_eq!(actual, expected);
+
+        // Adding with all old stats leaves us with the first RTT unchanged.
+        let last_agg_ts: u64 = 300;
+        let expected = SockStats {
+            last_touched_us: 200,
+            rtt_count: 12,
+            rtt_latest_us: 20,
+            rtt_smoothed_us: 30,
+            ..Default::default()
+        };
+        let mut actual = stats1.clone();
+        actual.add_from(&stats2, last_agg_ts);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_sock_stats_add_from() {
+        let stats1 = SockStats {
+            last_touched_us: 105,
+            connect_start_us: 97,
+            connect_end_us: 0,
+
+            bytes_received: 59,
+            bytes_delivered: 61,
+            segments_received: 73,
+            segments_delivered: 79,
+
+            rtt_count: 7,
+            rtt_latest_us: 31,
+            rtt_smoothed_us: 23,
+
+            retrans_syn: 11,
+            retrans_est: 12,
+            retrans_close: 13,
+
+            rtos_syn: 14,
+            rtos_est: 15,
+            rtos_close: 16,
+
+            connect_attempts: 17,
+            connect_successes: 18,
+
+            ..Default::default()
+        };
+
+        let stats2 = SockStats {
+            last_touched_us: 415,
+            connect_start_us: 0,
+            connect_end_us: 101,
+
+            bytes_received: 67,
+            bytes_delivered: 71,
+            segments_received: 83,
+            segments_delivered: 89,
+
+            rtt_count: 19,
+            rtt_latest_us: 37,
+            rtt_smoothed_us: 29,
+
+            retrans_syn: 17,
+            retrans_est: 18,
+            retrans_close: 19,
+
+            rtos_syn: 20,
+            rtos_est: 21,
+            rtos_close: 22,
+
+            connect_attempts: 23,
+            connect_successes: 24,
+
+            ..Default::default()
+        };
+
+        let expected = SockStats {
+            last_touched_us: 415,
+            connect_start_us: 97,
+            connect_end_us: 101,
+
+            bytes_received: 67,
+            bytes_delivered: 71,
+            segments_received: 83,
+            segments_delivered: 89,
+
+            rtt_count: 26,
+            rtt_latest_us: 31,
+            rtt_smoothed_us: 29,
+
+            retrans_syn: 28,
+            retrans_est: 30,
+            retrans_close: 32,
+
+            rtos_syn: 34,
+            rtos_est: 36,
+            rtos_close: 38,
+
+            connect_attempts: 40,
+            connect_successes: 42,
+
+            ..Default::default()
+        };
+
+        let last_agg_ts: u64 = 0;
+        {
+            let mut stats_a = stats1.clone();
+            let stats_b = stats2.clone();
+
+            stats_a.add_from(&stats_b, last_agg_ts);
+            assert_eq!(stats_a, expected);
+            assert_eq!(stats_a.connect_us().unwrap(), 4);
+
+            stats_a.add_from(&stats_b, last_agg_ts);
+            assert_eq!(stats_a.rtt_count, stats2.rtt_count * 2 + stats1.rtt_count);
+        }
+
+        {
+            let mut stats_a = stats2.clone();
+            let stats_b = stats1.clone();
+
+            stats_a.add_from(&stats_b, last_agg_ts);
+            assert_eq!(stats_a, expected);
+            assert_eq!(stats_a.connect_us().unwrap(), 4);
+
+            stats_a.add_from(&stats_b, last_agg_ts);
+            assert_eq!(stats_a.rtt_count, stats1.rtt_count * 2 + stats2.rtt_count);
+        }
+    }
+
+    #[test]
+    fn test_event_counters_rollover() {
+        // Start with values close to the edge to test rollover.
+        let original = EventCounters {
+            active_connect_events: u32::MAX - 1,
+            active_established_events: u32::MAX - 2,
+            passive_established_events: u32::MAX - 3,
+            state_change_events: u32::MAX - 4,
+            rtt_events: u32::MAX - 5,
+            retrans_events: u32::MAX - 6,
+            rto_events: u32::MAX - 7,
+            other_events: u32::MAX - 8,
+            socket_events: u32::MAX - 9,
+
+            sockets_invalid: u32::MAX - 10,
+            map_insertion_errors: u32::MAX - 18,
+            rtts_invalid: u32::MAX - 13,
+            set_flags_errors: u32::MAX - 14,
+            other_errors: u32::MAX - 15,
+        };
+        let additions = EventCounters {
+            active_connect_events: 10,
+            active_established_events: 11,
+            passive_established_events: 12,
+            state_change_events: 13,
+            rtt_events: 14,
+            retrans_events: 15,
+            rto_events: 16,
+            other_events: 17,
+            socket_events: 18,
+
+            sockets_invalid: 19,
+            map_insertion_errors: 27,
+            rtts_invalid: 22,
+            set_flags_errors: 23,
+            other_errors: 24,
+        };
+
+        let mut new_counters = original;
+        assert_eq!(new_counters, original);
+
+        // Perform an add to cause rollover.
+        new_counters.add_from(&additions);
+        assert_ne!(new_counters, original);
+
+        // Confirm subtraction still yields the values we added.
+        let delta = new_counters.subtract(&original);
+        assert_eq!(delta, additions);
+    }
+
+    #[test]
+    fn test_sock_context_from_network_byte_order() {
+        let actual_sock_ops_context = SockOpsContext {
+            family: 2,
+            local_port: 20,
+            remote_port: 184549376,
+            local_ip4: 318767104,
+            remote_ip4: 1325400064,
+            local_ip6: [0x01010101; 4],
+            remote_ip6: [0x01010101; 4],
+            ..Default::default()
+        };
+        let actual = SockContext::from_sock_ops(&actual_sock_ops_context, true);
+
+        let expected = SockContext {
+            is_client: true,
+            address_family: 2,
+            local_port: 20,
+
+            remote_port: 11,
+            local_ipv4: 19,
+            remote_ipv4: 79,
+            local_ipv6: [1; 16],
+            remote_ipv6: [1; 16],
+            ..Default::default()
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_port_edge_cases() {
+        let port_to_test: Vec<u16> = vec![0, 1, 500, 35_000, 65_535];
+        for port in port_to_test {
+            let actual_sock_ops_context = SockOpsContext {
+                family: 2,
+                local_port: port as u32,
+                remote_port: u32::to_be(port as u32),
+                local_ip4: 318767104,
+                remote_ip4: 1325400064,
+                local_ip6: [0x01010101; 4],
+                remote_ip6: [0x01010101; 4],
+                ..Default::default()
+            };
+            let actual = SockContext::from_sock_ops(&actual_sock_ops_context, true);
+            assert_eq!(actual.local_port, port);
+            assert_eq!(actual.remote_port, port);
+        }
+    }
+
+    #[test]
+    fn test_ipv6_to_bytes() {
+        let v6_quads: [u32; 4] = [67305985, 134678021, 202050057, 269422093];
+
+        // Expect byte values 1 thru 16.
+        let mut expected: Ipv6Bytes = [0; 16];
+        for (i, item) in expected.iter_mut().enumerate() {
+            *item = (i + 1) as u8;
+        }
+
+        let actual = SockContext::ipv6_to_bytes(v6_quads);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_sock_stats_subtract() {
+        let stats_a = SockStats {
+            last_touched_us: 10,
+            connect_start_us: 20,
+            connect_end_us: 30,
+            bytes_received: 40,
+            bytes_delivered: 50,
+            segments_received: 150,
+            segments_delivered: 160,
+            rtt_count: 60,
+            rtt_latest_us: 70,
+            rtt_smoothed_us: 80,
+            retrans_syn: 90,
+            retrans_est: 100,
+            retrans_close: 110,
+            rtos_syn: 120,
+            rtos_est: 130,
+            rtos_close: 140,
+            connect_attempts: 150,
+            connect_successes: 160,
+            state_flags: SockStateFlags::STARTED_CLOSURE,
+            ..Default::default()
+        };
+        let stats_b = SockStats {
+            last_touched_us: 1,
+            connect_start_us: 2,
+            connect_end_us: 3,
+            bytes_received: 4,
+            bytes_delivered: 5,
+            segments_received: 15,
+            segments_delivered: 16,
+            rtt_count: 6,
+            rtt_latest_us: 7,
+            rtt_smoothed_us: 8,
+            retrans_syn: 9,
+            retrans_est: 10,
+            retrans_close: 11,
+            rtos_syn: 12,
+            rtos_est: 13,
+            rtos_close: 14,
+            connect_attempts: 15,
+            connect_successes: 16,
+            state_flags: SockStateFlags::ENTERED_ESTABLISH,
+            ..Default::default()
+        };
+
+        // Test a typical diff.
+        let expected_diff = SockStats {
+            bytes_received: 36,
+            bytes_delivered: 45,
+            segments_received: 135,
+            segments_delivered: 144,
+            rtt_count: 54,
+            retrans_syn: 81,
+            retrans_est: 90,
+            retrans_close: 99,
+            rtos_syn: 108,
+            rtos_est: 117,
+            rtos_close: 126,
+            connect_attempts: 135,
+            connect_successes: 144,
+            ..stats_a
+        };
+        let actual_diff = stats_a.subtract(&stats_b);
+        assert_eq!(actual_diff, expected_diff);
+
+        // Test values having wrapped around.
+        let expected_diff_wrapped = SockStats {
+            bytes_received: u64::MAX - expected_diff.bytes_received + 1,
+            bytes_delivered: u64::MAX - expected_diff.bytes_delivered + 1,
+            segments_received: u32::MAX - expected_diff.segments_received + 1,
+            segments_delivered: u32::MAX - expected_diff.segments_delivered + 1,
+            rtt_count: u32::MAX - expected_diff.rtt_count + 1,
+            retrans_syn: u32::MAX - expected_diff.retrans_syn + 1,
+            retrans_est: u32::MAX - expected_diff.retrans_est + 1,
+            retrans_close: u32::MAX - expected_diff.retrans_close + 1,
+            rtos_syn: u32::MAX - expected_diff.rtos_syn + 1,
+            rtos_est: u32::MAX - expected_diff.rtos_est + 1,
+            rtos_close: u32::MAX - expected_diff.rtos_close + 1,
+            connect_attempts: u8::MAX - expected_diff.connect_attempts + 1,
+            connect_successes: u8::MAX - expected_diff.connect_successes + 1,
+            ..stats_b
+        };
+        let actual_diff_wrapped = stats_b.subtract(&stats_a);
+        assert_eq!(actual_diff_wrapped, expected_diff_wrapped);
+    }
+}

--- a/nfm-common/src/network_user.rs
+++ b/nfm-common/src/network_user.rs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::network::{ControlData, CpuSockKey, EventCounters, SockContext, SockStats};
+
+use aya::Pod;
+
+unsafe impl Pod for ControlData {}
+unsafe impl Pod for CpuSockKey {}
+unsafe impl Pod for EventCounters {}
+unsafe impl Pod for SockStats {}
+unsafe impl Pod for SockContext {}

--- a/nfm-common/src/sock_ops_handler.rs
+++ b/nfm-common/src/sock_ops_handler.rs
@@ -1,0 +1,1171 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::*;
+
+pub type SockOpsResult = Result<(), SockOpsResultCode>;
+
+#[derive(Debug, PartialEq)]
+pub enum SockOpsResultCode {
+    OperationUnknown,
+    ContextInvalid,
+    MapInsertionError,
+    SetCbFlagsError,
+    RttInvalid,
+    SampleDiscard,
+}
+
+// Convey's the values of user-space control knobs to BPF.
+pub struct BpfControlConveyor {
+    #[cfg(not(feature = "bpf"))]
+    pub mock_ebpf_maps: MockEbpfMaps,
+}
+
+impl BpfControlConveyor {
+    pub fn should_handle_event(&self, event_cb_id: u32) -> bool {
+        if self.is_new_sock_event(event_cb_id) {
+            self.should_handle_new_sock()
+        } else {
+            // Note that we only sample on letting newly connected sockets into the front door.
+            // For sockets we're already tracking we don't want to miss any events.
+            true
+        }
+    }
+
+    fn is_new_sock_event(&self, event_cb_id: u32) -> bool {
+        matches!(
+            event_cb_id,
+            BPF_SOCK_OPS_TCP_CONNECT_CB | BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB
+        )
+    }
+
+    fn should_handle_new_sock(&self) -> bool {
+        let control_option = bpf_map_get!(self, NFM_CONTROL, &SINGLETON_KEY);
+        if let Some(control_data) = control_option {
+            let sampling_interval = control_data.sampling_interval;
+            sampling_interval <= 1 || bpf_get_rand_u32!(self) % sampling_interval == 0
+        } else {
+            true
+        }
+    }
+}
+
+pub struct TcpSockOpsHandler<'a> {
+    ctx: &'a SockOpsContext,
+    now_us: u64,
+    counters: EventCounters,
+    composite_key: CpuSockKey,
+
+    #[cfg(not(feature = "bpf"))]
+    pub mock_ebpf_maps: Option<&'a mut MockEbpfMaps>,
+}
+
+impl<'a> TcpSockOpsHandler<'a> {
+    pub fn new(ctx: &'a SockOpsContext, now_us: u64) -> Self {
+        TcpSockOpsHandler {
+            ctx,
+            now_us,
+            counters: Default::default(),
+            composite_key: Default::default(),
+
+            #[cfg(not(feature = "bpf"))]
+            mock_ebpf_maps: None,
+        }
+    }
+
+    pub fn handle_socket_event(&mut self) -> SockOpsResult {
+        self.counters.socket_events += 1;
+        self.composite_key.sock_key = nfm_get_sock_cookie(self.ctx);
+        self.composite_key.cpu_id = nfm_get_cpu_id();
+
+        let result = match self.ctx.op() {
+            BPF_SOCK_OPS_TCP_CONNECT_CB => self.handle_connect(),
+            BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB => self.handle_passive_established(),
+            BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB => Ok(()), // No-op.
+            BPF_SOCK_OPS_STATE_CB => self.handle_state_change(),
+            BPF_SOCK_OPS_RTT_CB => self.handle_rtt(),
+            BPF_SOCK_OPS_RETRANS_CB => self.handle_retransmit(),
+            BPF_SOCK_OPS_RTO_CB => self.handle_rto(),
+            BPF_SOCK_OPS_PARSE_HDR_OPT_CB => self.handle_bytes_transferred_event(),
+            BPF_SOCK_OPS_HDR_OPT_LEN_CB => self.handle_bytes_transferred_event(),
+            _ => {
+                self.counters.other_events += 1;
+                Err(SockOpsResultCode::OperationUnknown)
+            }
+        };
+
+        // Persist our new counter contributions.
+        unsafe {
+            match bpf_map_get_ptr_mut!(self, NFM_COUNTERS, &SINGLETON_KEY) {
+                Some(persisted_counters) => {
+                    (*persisted_counters).add_from(&self.counters);
+                }
+                None => {
+                    let _ = bpf_map_insert!(
+                        self,
+                        NFM_COUNTERS,
+                        &SINGLETON_KEY,
+                        &self.counters,
+                        BPF_ANY
+                    );
+                }
+            };
+        }
+
+        result
+    }
+
+    fn handle_connect(&mut self) -> SockOpsResult {
+        self.counters.active_connect_events += 1;
+        const IS_CLIENT: bool = true;
+        self.handle_new_sock(IS_CLIENT)
+    }
+
+    fn handle_passive_established(&mut self) -> SockOpsResult {
+        self.counters.passive_established_events += 1;
+        const IS_CLIENT: bool = false;
+        self.handle_new_sock(IS_CLIENT)
+    }
+
+    fn handle_new_sock(&mut self, is_client: bool) -> SockOpsResult {
+        let sock_context = SockContext::from_sock_ops(self.ctx, is_client);
+        if !sock_context.is_valid() {
+            self.counters.sockets_invalid += 1;
+            return Err(SockOpsResultCode::ContextInvalid);
+        }
+
+        let res = bpf_map_insert!(
+            self,
+            NFM_SK_PROPS,
+            &self.composite_key,
+            &sock_context,
+            BPF_NOEXIST
+        );
+        if res.is_err() {
+            self.counters.map_insertion_errors += 1;
+            return Err(SockOpsResultCode::MapInsertionError);
+        }
+
+        // Register to receive events only for successfully recorded sockets, meaning after success
+        // of the above map insertion.
+        self.configure_flags()?;
+
+        match self.get_or_add_sock_stats() {
+            Ok(stats_raw) => unsafe {
+                let sock_stats = &mut *stats_raw;
+                sock_stats.connect_start_us = self.now_us;
+                if is_client {
+                    sock_stats.connect_attempts += 1;
+                }
+
+                if nfm_get_sock_state(self.ctx) == BPF_TCP_ESTABLISHED {
+                    sock_stats
+                        .state_flags
+                        .insert(SockStateFlags::ENTERED_ESTABLISH);
+                }
+                Ok(())
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    fn handle_state_change(&mut self) -> SockOpsResult {
+        self.counters.state_change_events += 1;
+
+        // This callback is called before the state is actually changed, so the arguments need to
+        // be used instead of the ctx.state.
+        let old_state = self.ctx.arg(0);
+        let new_state = self.ctx.arg(1);
+        let mut new_flags = SockStateFlags::empty();
+
+        match self.get_or_add_sock_stats() {
+            Ok(stats_raw) => unsafe {
+                let sock_stats = &mut *stats_raw;
+
+                if new_state == BPF_TCP_ESTABLISHED {
+                    new_flags |= SockStateFlags::ENTERED_ESTABLISH;
+                    sock_stats.connect_end_us = self.now_us;
+
+                    if old_state == BPF_TCP_SYN_SENT {
+                        self.counters.active_established_events += 1;
+                        sock_stats.connect_successes += 1;
+                    }
+                } else if !matches!(new_state, BPF_TCP_SYN_SENT | BPF_TCP_SYN_RECV) {
+                    new_flags |= SockStateFlags::STARTED_CLOSURE;
+
+                    if matches!(old_state, BPF_TCP_SYN_SENT | BPF_TCP_SYN_RECV) {
+                        new_flags |= SockStateFlags::TERMINATED_FROM_SYN;
+                    }
+
+                    if new_state == BPF_TCP_CLOSE {
+                        new_flags |= SockStateFlags::CLOSED;
+
+                        // Store some final stats on connection close.
+                        let event_stats = nfm_get_sock_ops_stats(self.ctx);
+                        sock_stats.bytes_received = event_stats.bytes_received;
+                        sock_stats.bytes_delivered = event_stats.bytes_acked;
+                        sock_stats.segments_received = event_stats.segments_received;
+                        sock_stats.segments_delivered = event_stats.segments_delivered;
+
+                        if old_state == BPF_TCP_ESTABLISHED {
+                            new_flags |= SockStateFlags::TERMINATED_FROM_EST;
+                        }
+                    }
+                }
+
+                sock_stats.state_flags.insert(new_flags);
+                Ok(())
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    fn handle_rtt(&mut self) -> SockOpsResult {
+        self.counters.rtt_events += 1;
+
+        // A recent Linux enhancement [a,b] supplies the most recently measured and smoothed RTT
+        // values as arguments to this BPF callback.  If we do not see those, we fallback to a less
+        // timely value on the sock-ops struct and increment a counter.
+        //
+        // [a] https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=48e2cd3e3dcf
+        // [b] https://code.amazon.com/reviews/CR-144526532/
+        let event_stats = nfm_get_sock_ops_stats(self.ctx);
+        let rtt_measured_us = match self.ctx.arg(0) {
+            0 => {
+                self.counters.rtts_invalid += 1;
+                event_stats.srtt_us
+            }
+            x => x,
+        };
+        let rtt_smoothed_us = match self.ctx.arg(1) {
+            0 => event_stats.srtt_us,
+            x => x >> 3,
+        };
+
+        match self.get_or_add_sock_stats() {
+            Ok(stats_raw) => unsafe {
+                let sock_stats = &mut *stats_raw;
+                sock_stats.rtt_count += 1;
+                sock_stats.rtt_latest_us = rtt_measured_us;
+                sock_stats.rtt_smoothed_us = rtt_smoothed_us;
+
+                // Take this opporunity to update bytes transferred as well.
+                sock_stats.bytes_received = event_stats.bytes_received;
+                sock_stats.bytes_delivered = event_stats.bytes_acked;
+                sock_stats.segments_received = event_stats.segments_received;
+                sock_stats.segments_delivered = event_stats.segments_delivered;
+
+                Ok(())
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    fn handle_retransmit(&mut self) -> SockOpsResult {
+        self.counters.retrans_events += 1;
+
+        // Args are: [seq-num, num-segs, tx-errno].
+        let retrans_segments = self.ctx.arg(1);
+
+        match self.get_or_add_sock_stats() {
+            Ok(stats_raw) => unsafe {
+                let sock_stats = &mut *stats_raw;
+                match nfm_get_sock_state(self.ctx) {
+                    BPF_TCP_ESTABLISHED => sock_stats.retrans_est += retrans_segments,
+                    BPF_TCP_SYN_SENT => {
+                        sock_stats.retrans_syn += retrans_segments;
+                        sock_stats.connect_attempts += retrans_segments as u8;
+                    }
+                    BPF_TCP_SYN_RECV => sock_stats.retrans_syn += retrans_segments,
+                    _ => sock_stats.retrans_close += retrans_segments,
+                };
+
+                Ok(())
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    fn handle_rto(&mut self) -> SockOpsResult {
+        self.counters.rto_events += 1;
+
+        match self.get_or_add_sock_stats() {
+            Ok(stats_raw) => unsafe {
+                let sock_stats = &mut *stats_raw;
+                match nfm_get_sock_state(self.ctx) {
+                    BPF_TCP_ESTABLISHED => sock_stats.rtos_est += 1,
+                    BPF_TCP_SYN_SENT | BPF_TCP_SYN_RECV => sock_stats.rtos_syn += 1,
+                    _ => sock_stats.rtos_close += 1,
+                };
+                Ok(())
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    fn handle_bytes_transferred_event(&mut self) -> SockOpsResult {
+        match self.get_or_add_sock_stats() {
+            Ok(stats_raw) => unsafe {
+                // Update running stats.
+                let sock_stats = &mut *stats_raw;
+                let event_stats = nfm_get_sock_ops_stats(self.ctx);
+                sock_stats.bytes_received = event_stats.bytes_received;
+                sock_stats.bytes_delivered = event_stats.bytes_acked;
+                sock_stats.segments_received = event_stats.segments_received;
+                sock_stats.segments_delivered = event_stats.segments_delivered;
+                Ok(())
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    fn get_or_add_sock_stats(&mut self) -> Result<*mut SockStats, SockOpsResultCode> {
+        match bpf_map_get_ptr_mut!(self, NFM_SK_STATS, &self.composite_key) {
+            Some(stats_raw) => unsafe {
+                let sock_stats = &mut *stats_raw;
+                sock_stats.last_touched_us = self.now_us;
+                Ok(sock_stats)
+            },
+            None => {
+                let new_stats = SockStats {
+                    last_touched_us: self.now_us,
+                    ..Default::default()
+                };
+                match bpf_map_insert!(
+                    self,
+                    NFM_SK_STATS,
+                    &self.composite_key,
+                    &new_stats,
+                    BPF_NOEXIST
+                ) {
+                    Ok(_) => match bpf_map_get_ptr_mut!(self, NFM_SK_STATS, &self.composite_key) {
+                        Some(stats) => Ok(stats),
+                        None => {
+                            self.counters.map_insertion_errors += 1;
+                            Err(SockOpsResultCode::MapInsertionError)
+                        }
+                    },
+                    Err(_) => {
+                        self.counters.map_insertion_errors += 1;
+                        Err(SockOpsResultCode::MapInsertionError)
+                    }
+                }
+            }
+        }
+    }
+
+    fn configure_flags(&mut self) -> SockOpsResult {
+        // Tell the kernel which events we want to receive for the current socket.
+        match self.ctx.set_cb_flags(
+            (BPF_SOCK_OPS_RTT_CB_FLAG
+                | BPF_SOCK_OPS_RTO_CB_FLAG
+                | BPF_SOCK_OPS_STATE_CB_FLAG
+                | BPF_SOCK_OPS_RETRANS_CB_FLAG
+                | BPF_SOCK_OPS_PARSE_ALL_HDR_OPT_CB_FLAG
+
+                // The following provides us with events for non-data egress packets (such as RSTs
+                // and dup-ACKs).  Without this, a socket can be evicted before being marked as
+                // severed within the flow.
+                | BPF_SOCK_OPS_WRITE_HDR_OPT_CB_FLAG) as i32,
+        ) {
+            Ok(_) => Ok(()),
+            Err(_code) => {
+                self.counters.set_flags_errors += 1;
+                Err(SockOpsResultCode::SetCbFlagsError)
+            }
+        }
+    }
+}
+
+#[cfg(all(test, not(feature = "bpf")))]
+mod test {
+    use super::*;
+
+    const NO_COOKIE: u64 = 0;
+
+    fn run_sock_ops_test(
+        cookie: u64,
+        op_code: u32,
+        mock_ebpf_maps: &mut MockEbpfMaps,
+        ktime_us: u64,
+        expectation: SockOpsResult,
+    ) {
+        let no_args: [u32; 2] = [0, 0];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_SYN_SENT,
+            op_code,
+            no_args,
+            mock_ebpf_maps,
+            ktime_us,
+            expectation,
+        );
+    }
+
+    fn run_sock_ops_test_with_args(
+        cookie: u64,
+        sock_state: u32,
+        op_code: u32,
+        args: [u32; 2],
+        mock_ebpf_maps: &mut MockEbpfMaps,
+        ktime_us: u64,
+        expectation: SockOpsResult,
+    ) {
+        let ctx = SockOpsContext {
+            cookie,
+            sock_state,
+            op: op_code,
+            args,
+            family: AF_INET,
+            ..Default::default()
+        };
+
+        // Handle the event.
+        let mut handler = TcpSockOpsHandler::new(&ctx, ktime_us);
+        handler.mock_ebpf_maps = Some(mock_ebpf_maps);
+        let result = handler.handle_socket_event();
+
+        // Validate initial results.
+        assert_eq!(result, expectation);
+        if expectation.is_ok() {
+            let composite_key = CpuSockKey {
+                sock_key: cookie,
+                cpu_id: MOCK_CPU_ID,
+            };
+            assert_eq!(
+                mock_ebpf_maps.sock_stats(&composite_key).last_touched_us,
+                ktime_us
+            );
+        }
+    }
+
+    #[test]
+    fn test_ebpf_op_invalid() {
+        let mock_ktime_us: u64 = 0;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        const INVALID_OP: u32 = 0;
+        run_sock_ops_test(
+            NO_COOKIE,
+            INVALID_OP,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Err(SockOpsResultCode::OperationUnknown),
+        );
+    }
+
+    #[test]
+    fn test_ebpf_op_valid() {
+        let mock_ktime_us: u64 = 0;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        let cookie: u64 = 211;
+        run_sock_ops_test(
+            cookie,
+            BPF_SOCK_OPS_TCP_CONNECT_CB,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+    }
+
+    #[test]
+    fn test_ebpf_context_invalid() {
+        // Prep our test data.
+        let mock_ktime_us: u64 = 0;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        const AF_OTHER: u32 = 0;
+        let ctx = SockOpsContext {
+            op: BPF_SOCK_OPS_TCP_CONNECT_CB,
+            family: AF_OTHER,
+            ..Default::default()
+        };
+
+        // Try to handle the event.
+        let mut handler = TcpSockOpsHandler::new(&ctx, mock_ktime_us);
+        handler.mock_ebpf_maps = Some(&mut mock_ebpf_maps);
+        let result = handler.handle_socket_event();
+
+        // Confirm failure.
+        assert_eq!(result, Err(SockOpsResultCode::ContextInvalid));
+        assert_eq!(mock_ebpf_maps.counters().active_connect_events, 1);
+        assert_eq!(mock_ebpf_maps.counters().sockets_invalid, 1);
+        assert!(mock_ebpf_maps.NFM_SK_PROPS.data.is_empty());
+        assert!(mock_ebpf_maps.NFM_SK_STATS.data.is_empty());
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_connect() {
+        let mock_ktime_us: u64 = 0;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        let cookie: u64 = 197;
+        run_sock_ops_test(
+            cookie,
+            BPF_SOCK_OPS_TCP_CONNECT_CB,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        assert_eq!(mock_ebpf_maps.counters().active_connect_events, 1);
+        assert_eq!(mock_ebpf_maps.NFM_SK_PROPS.data.len(), 1);
+        assert_eq!(mock_ebpf_maps.NFM_SK_STATS.data.len(), 1);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_passive_established() {
+        let mock_ktime_us: u64 = 0;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        let cookie: u64 = 197;
+        run_sock_ops_test(
+            cookie,
+            BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        assert_eq!(mock_ebpf_maps.counters().passive_established_events, 1);
+        assert_eq!(mock_ebpf_maps.NFM_SK_PROPS.data.len(), 1);
+        assert_eq!(mock_ebpf_maps.NFM_SK_STATS.data.len(), 1);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_active_established_sans_connect() {
+        let mock_ktime_us: u64 = 0;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        let cookie: u64 = 197;
+        let ctx = SockOpsContext {
+            op: BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB,
+            family: AF_INET,
+            cookie,
+            ..Default::default()
+        };
+
+        // Handle the event.
+        let mut handler = TcpSockOpsHandler::new(&ctx, mock_ktime_us);
+        handler.mock_ebpf_maps = Some(&mut mock_ebpf_maps);
+        let result = handler.handle_socket_event();
+
+        // Validate results.
+        assert_eq!(result, Ok(()));
+        assert_eq!(mock_ebpf_maps.counters().active_established_events, 0);
+        assert!(mock_ebpf_maps.NFM_SK_PROPS.data.is_empty());
+        assert!(mock_ebpf_maps.NFM_SK_STATS.data.is_empty());
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_active_established() {
+        let mock_ktime_us: u64 = 99;
+        let cookie: u64 = 197;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+
+        // Handle two events.
+        run_sock_ops_test(
+            cookie,
+            BPF_SOCK_OPS_TCP_CONNECT_CB,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_SYN_SENT,
+            BPF_SOCK_OPS_STATE_CB,
+            [BPF_TCP_SYN_SENT, BPF_TCP_ESTABLISHED],
+            &mut mock_ebpf_maps,
+            mock_ktime_us + 10,
+            Ok(()),
+        );
+
+        // Validate results.
+        assert_eq!(mock_ebpf_maps.NFM_SK_PROPS.data.len(), 1);
+        assert_eq!(mock_ebpf_maps.counters().active_connect_events, 1);
+
+        let composite_key = CpuSockKey {
+            sock_key: cookie,
+            cpu_id: MOCK_CPU_ID,
+        };
+        let _ = mock_ebpf_maps.sock_props(&composite_key);
+        let sock_stats = mock_ebpf_maps.sock_stats(&composite_key);
+        assert_eq!(sock_stats.connect_start_us, mock_ktime_us);
+        assert_eq!(sock_stats.connect_end_us, mock_ktime_us + 10);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_rtt_with_arg() {
+        let mock_ktime_us: u64 = 0;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        let cookie: u64 = 197;
+
+        // Handle a first event.
+        run_sock_ops_test(
+            cookie,
+            BPF_SOCK_OPS_TCP_CONNECT_CB,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        // Handle a second event.
+        let ctx = SockOpsContext {
+            cookie,
+            op: BPF_SOCK_OPS_RTT_CB,
+            args: [52, 59 << 3],
+            ..Default::default()
+        };
+        let mut handler = TcpSockOpsHandler::new(&ctx, mock_ktime_us);
+        handler.mock_ebpf_maps = Some(&mut mock_ebpf_maps);
+        let result = handler.handle_socket_event();
+
+        // Validate results.
+        assert_eq!(result, Ok(()));
+        let composite_key = CpuSockKey {
+            sock_key: cookie,
+            cpu_id: MOCK_CPU_ID,
+        };
+        let sock_stats = mock_ebpf_maps.sock_stats(&composite_key);
+        assert_eq!(sock_stats.rtt_count, 1);
+        assert_eq!(sock_stats.rtt_latest_us, 52);
+        assert_eq!(sock_stats.rtt_smoothed_us, 59);
+        assert_eq!(mock_ebpf_maps.counters().rtt_events, 1);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_rtt_no_arg() {
+        let mock_ktime_us: u64 = 0;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        let cookie: u64 = 197;
+
+        // Handle a first event.
+        run_sock_ops_test(
+            cookie,
+            BPF_SOCK_OPS_TCP_CONNECT_CB,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        // Handle a second event.
+        let ctx = SockOpsContext {
+            cookie,
+            op: BPF_SOCK_OPS_RTT_CB,
+            args: [0, 0],
+            stats: SockOpsStats {
+                srtt_us: 59,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut handler = TcpSockOpsHandler::new(&ctx, mock_ktime_us);
+        handler.mock_ebpf_maps = Some(&mut mock_ebpf_maps);
+        let result = handler.handle_socket_event();
+
+        // Validate results.
+        assert_eq!(result, Ok(()));
+        let composite_key = CpuSockKey {
+            sock_key: cookie,
+            cpu_id: MOCK_CPU_ID,
+        };
+        let sock_stats = mock_ebpf_maps.sock_stats(&composite_key);
+        assert_eq!(sock_stats.rtt_count, 1);
+        assert_eq!(sock_stats.rtt_latest_us, 59);
+        assert_eq!(sock_stats.rtt_smoothed_us, 59);
+        assert_eq!(mock_ebpf_maps.counters().rtt_events, 1);
+        assert_eq!(mock_ebpf_maps.counters().rtts_invalid, 1);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_retrans() {
+        let mock_ktime_us: u64 = 0;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        let cookie: u64 = 197;
+
+        // A connection is initiated, followed by retransmits.
+        run_sock_ops_test(
+            cookie,
+            BPF_SOCK_OPS_TCP_CONNECT_CB,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        let mut num_retrans = 11;
+        let args: [u32; 2] = [0, num_retrans];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_SYN_SENT,
+            BPF_SOCK_OPS_RETRANS_CB,
+            args,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        // After entering established, more retransmits are seen.  Notice that the new state is
+        // reflected in the args, and not the sock context.
+        let args: [u32; 2] = [BPF_TCP_SYN_SENT, BPF_TCP_ESTABLISHED];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_SYN_SENT,
+            BPF_SOCK_OPS_STATE_CB,
+            args,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        num_retrans = 22;
+        let args: [u32; 2] = [0, num_retrans];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_ESTABLISHED,
+            BPF_SOCK_OPS_RETRANS_CB,
+            args,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        // Finally, during close, more retransmits are seen.
+        let args: [u32; 2] = [BPF_TCP_ESTABLISHED, BPF_TCP_FIN_WAIT1];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_ESTABLISHED,
+            BPF_SOCK_OPS_STATE_CB,
+            args,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        num_retrans = 33;
+        let args: [u32; 2] = [0, num_retrans];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_FIN_WAIT1,
+            BPF_SOCK_OPS_RETRANS_CB,
+            args,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        // Validate results.
+        let composite_key = CpuSockKey {
+            sock_key: cookie,
+            cpu_id: MOCK_CPU_ID,
+        };
+        let sock_stats = mock_ebpf_maps.sock_stats(&composite_key);
+        assert_eq!(sock_stats.retrans_syn, 11);
+        assert_eq!(sock_stats.retrans_est, 22);
+        assert_eq!(sock_stats.retrans_close, 33);
+        assert_eq!(mock_ebpf_maps.counters().retrans_events, 3);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_rto() {
+        let mock_ktime_us: u64 = 0;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        let cookie: u64 = 197;
+
+        // A connection is initiated, followed by an RTO.
+        run_sock_ops_test(
+            cookie,
+            BPF_SOCK_OPS_TCP_CONNECT_CB,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+        run_sock_ops_test(
+            cookie,
+            BPF_SOCK_OPS_RTO_CB,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        // After entering established, we see another RTO.
+        let args: [u32; 2] = [BPF_TCP_SYN_SENT, BPF_TCP_ESTABLISHED];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_SYN_SENT,
+            BPF_SOCK_OPS_STATE_CB,
+            args,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_ESTABLISHED,
+            BPF_SOCK_OPS_RTO_CB,
+            [0, 0],
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        // Finally, during close, another RTO.
+        let args: [u32; 2] = [BPF_TCP_ESTABLISHED, BPF_TCP_FIN_WAIT1];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_ESTABLISHED,
+            BPF_SOCK_OPS_STATE_CB,
+            args,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_FIN_WAIT1,
+            BPF_SOCK_OPS_RTO_CB,
+            [0, 0],
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        // Validate results.
+        let composite_key = CpuSockKey {
+            sock_key: cookie,
+            cpu_id: MOCK_CPU_ID,
+        };
+        let sock_stats = mock_ebpf_maps.sock_stats(&composite_key);
+        assert_eq!(sock_stats.rtos_syn, 1);
+        assert_eq!(sock_stats.rtos_est, 1);
+        assert_eq!(sock_stats.rtos_close, 1);
+        assert_eq!(mock_ebpf_maps.counters().rto_events, 3);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_rst_on_passive_connect() {
+        let mock_ktime_us: u64 = 99;
+        let cookie: u64 = 197;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+
+        // Receive a connection.
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_ESTABLISHED,
+            BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB,
+            [0, 0],
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        // Terminate the connect attempt.
+        let args: [u32; 2] = [BPF_TCP_ESTABLISHED, BPF_TCP_CLOSE];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_ESTABLISHED,
+            BPF_SOCK_OPS_STATE_CB,
+            args,
+            &mut mock_ebpf_maps,
+            mock_ktime_us + 10,
+            Ok(()),
+        );
+
+        // Validate results.
+        let composite_key = CpuSockKey {
+            sock_key: cookie,
+            cpu_id: MOCK_CPU_ID,
+        };
+        let sock_wrap = mock_ebpf_maps.sock_stats(&composite_key);
+        assert_eq!(
+            sock_wrap.state_flags,
+            SockStateFlags::ENTERED_ESTABLISH
+                | SockStateFlags::STARTED_CLOSURE
+                | SockStateFlags::TERMINATED_FROM_EST
+                | SockStateFlags::CLOSED
+        );
+        assert_eq!(mock_ebpf_maps.counters().state_change_events, 1);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_rst_on_active_connect() {
+        let mock_ktime_us: u64 = 99;
+        let cookie: u64 = 197;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+
+        // Initiate a connection.
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_SYN_SENT,
+            BPF_SOCK_OPS_TCP_CONNECT_CB,
+            [0, 0],
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+
+        // Terminate the connect attempt.
+        let args: [u32; 2] = [BPF_TCP_SYN_SENT, BPF_TCP_CLOSE];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_SYN_SENT,
+            BPF_SOCK_OPS_STATE_CB,
+            args,
+            &mut mock_ebpf_maps,
+            mock_ktime_us + 10,
+            Ok(()),
+        );
+
+        // Validate results.
+        let composite_key = CpuSockKey {
+            sock_key: cookie,
+            cpu_id: MOCK_CPU_ID,
+        };
+        let sock_wrap = mock_ebpf_maps.sock_stats(&composite_key);
+        assert_eq!(
+            sock_wrap.state_flags,
+            SockStateFlags::STARTED_CLOSURE
+                | SockStateFlags::TERMINATED_FROM_SYN
+                | SockStateFlags::CLOSED
+        );
+        assert_eq!(mock_ebpf_maps.counters().state_change_events, 1);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_rst_on_establish() {
+        let mock_ktime_us: u64 = 99;
+        let cookie: u64 = 197;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+
+        // Handle two events.
+        run_sock_ops_test(
+            cookie,
+            BPF_SOCK_OPS_TCP_CONNECT_CB,
+            &mut mock_ebpf_maps,
+            mock_ktime_us,
+            Ok(()),
+        );
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_SYN_SENT,
+            BPF_SOCK_OPS_STATE_CB,
+            [BPF_TCP_SYN_SENT, BPF_TCP_ESTABLISHED],
+            &mut mock_ebpf_maps,
+            mock_ktime_us + 10,
+            Ok(()),
+        );
+
+        // Handle a 3rd event that mimicks a TCP RST by transitioning from ESTABLISHED to CLOSED.
+        let args: [u32; 2] = [BPF_TCP_ESTABLISHED, BPF_TCP_CLOSE];
+        run_sock_ops_test_with_args(
+            cookie,
+            BPF_TCP_ESTABLISHED,
+            BPF_SOCK_OPS_STATE_CB,
+            args,
+            &mut mock_ebpf_maps,
+            mock_ktime_us + 10,
+            Ok(()),
+        );
+
+        // Validate results.
+        let composite_key = CpuSockKey {
+            sock_key: cookie,
+            cpu_id: MOCK_CPU_ID,
+        };
+        let sock_wrap = mock_ebpf_maps.sock_stats(&composite_key);
+        assert_eq!(
+            sock_wrap.state_flags,
+            SockStateFlags::ENTERED_ESTABLISH
+                | SockStateFlags::STARTED_CLOSURE
+                | SockStateFlags::TERMINATED_FROM_EST
+                | SockStateFlags::CLOSED
+        );
+        assert_eq!(mock_ebpf_maps.counters().state_change_events, 2);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_max_connections() {
+        let mut mock_ktime_us: u64 = 99;
+        let mut cookie: u64 = 197;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+
+        let effective_max = MAX_ENTRIES_SK_PROPS_HI.min(MAX_ENTRIES_SK_STATS_HI);
+        for _ in 0..effective_max {
+            run_sock_ops_test(
+                cookie,
+                BPF_SOCK_OPS_TCP_CONNECT_CB,
+                &mut mock_ebpf_maps,
+                mock_ktime_us,
+                Ok(()),
+            );
+            run_sock_ops_test_with_args(
+                cookie,
+                BPF_TCP_SYN_SENT,
+                BPF_SOCK_OPS_STATE_CB,
+                [BPF_TCP_SYN_SENT, BPF_TCP_ESTABLISHED],
+                &mut mock_ebpf_maps,
+                mock_ktime_us + 10,
+                Ok(()),
+            );
+
+            cookie += 3;
+            mock_ktime_us += 10;
+        }
+
+        // Validate results.
+        assert!(effective_max > 0);
+        assert_eq!(
+            mock_ebpf_maps.counters().active_connect_events,
+            effective_max.try_into().unwrap(),
+        );
+        assert_eq!(
+            mock_ebpf_maps.NFM_SK_PROPS.data.len(),
+            effective_max.try_into().unwrap()
+        );
+        assert_eq!(
+            mock_ebpf_maps.NFM_SK_STATS.data.len(),
+            effective_max.try_into().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_too_many_connections() {
+        let mut mock_ktime_us: u64 = 99;
+        let mut cookie: u64 = 197;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+
+        for _ in 0..MAX_ENTRIES_SK_PROPS_HI {
+            run_sock_ops_test(
+                cookie,
+                BPF_SOCK_OPS_TCP_CONNECT_CB,
+                &mut mock_ebpf_maps,
+                mock_ktime_us,
+                Ok(()),
+            );
+
+            cookie += 3;
+            mock_ktime_us += 10;
+        }
+
+        for _ in 0..10 {
+            run_sock_ops_test(
+                cookie,
+                BPF_SOCK_OPS_TCP_CONNECT_CB,
+                &mut mock_ebpf_maps,
+                mock_ktime_us,
+                Err(SockOpsResultCode::MapInsertionError),
+            );
+
+            cookie += 3;
+            mock_ktime_us += 10;
+        }
+
+        // Validate results.
+        assert!(MAX_ENTRIES_SK_PROPS_HI > 0);
+        assert_eq!(
+            mock_ebpf_maps.NFM_SK_PROPS.data.len(),
+            MAX_ENTRIES_SK_PROPS_HI.try_into().unwrap()
+        );
+        assert_eq!(
+            mock_ebpf_maps.counters().active_connect_events,
+            (MAX_ENTRIES_SK_PROPS_HI + 10).try_into().unwrap()
+        );
+        assert_eq!(mock_ebpf_maps.counters().map_insertion_errors, 10);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_too_many_events() {
+        let mut mock_ktime_us: u64 = 99;
+        let mut cookie: u64 = 197;
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+
+        for _ in 0..MAX_ENTRIES_SK_STATS_HI {
+            run_sock_ops_test_with_args(
+                cookie,
+                BPF_TCP_ESTABLISHED,
+                BPF_SOCK_OPS_STATE_CB,
+                [BPF_TCP_ESTABLISHED, BPF_TCP_CLOSE],
+                &mut mock_ebpf_maps,
+                mock_ktime_us,
+                Ok(()),
+            );
+
+            cookie += 3;
+            mock_ktime_us += 10;
+        }
+
+        for _ in 0..10 {
+            run_sock_ops_test_with_args(
+                cookie,
+                BPF_TCP_ESTABLISHED,
+                BPF_SOCK_OPS_STATE_CB,
+                [BPF_TCP_ESTABLISHED, BPF_TCP_CLOSE],
+                &mut mock_ebpf_maps,
+                mock_ktime_us,
+                Err(SockOpsResultCode::MapInsertionError),
+            );
+
+            cookie += 3;
+            mock_ktime_us += 10;
+        }
+
+        // Validate results.
+        assert!(MAX_ENTRIES_SK_STATS_HI > 0);
+        assert_eq!(
+            mock_ebpf_maps.NFM_SK_STATS.data.len(),
+            MAX_ENTRIES_SK_STATS_HI.try_into().unwrap()
+        );
+        assert_eq!(
+            mock_ebpf_maps.counters().state_change_events,
+            (MAX_ENTRIES_SK_STATS_HI + 10).try_into().unwrap()
+        );
+        assert_eq!(mock_ebpf_maps.counters().map_insertion_errors, 10);
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_sample_discard() {
+        // A random value not divisible by our sampling interval results in a discard.
+        let control_data = ControlData {
+            sampling_interval: 2,
+            ..Default::default()
+        };
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        mock_ebpf_maps.mock_rand = 121;
+        mock_ebpf_maps
+            .NFM_CONTROL
+            .insert(&SINGLETON_KEY, &control_data, BPF_ANY)
+            .unwrap();
+        let conveyor = BpfControlConveyor { mock_ebpf_maps };
+
+        // We discard new socket events.
+        assert!(!conveyor.should_handle_event(BPF_SOCK_OPS_TCP_CONNECT_CB));
+        assert!(!conveyor.should_handle_event(BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB));
+
+        // We capture other events.
+        assert!(conveyor.should_handle_event(BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB));
+        assert!(conveyor.should_handle_event(BPF_SOCK_OPS_RETRANS_CB));
+        assert!(conveyor.should_handle_event(BPF_SOCK_OPS_RTT_CB));
+        assert!(conveyor.should_handle_event(BPF_SOCK_OPS_RTO_CB));
+    }
+
+    #[test]
+    fn test_ebpf_sock_op_sample_capture() {
+        // A random value that is divisible by our sampling interval results in a capture.
+        let control_data = ControlData {
+            sampling_interval: 2,
+            ..Default::default()
+        };
+        let mut mock_ebpf_maps = MockEbpfMaps::new();
+        mock_ebpf_maps.mock_rand = 122;
+        mock_ebpf_maps
+            .NFM_CONTROL
+            .insert(&SINGLETON_KEY, &control_data, BPF_ANY)
+            .unwrap();
+        let conveyor = BpfControlConveyor { mock_ebpf_maps };
+
+        // We capture new socket events.
+        assert!(conveyor.should_handle_event(BPF_SOCK_OPS_TCP_CONNECT_CB));
+        assert!(conveyor.should_handle_event(BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB));
+
+        // We also capture other events.
+        assert!(conveyor.should_handle_event(BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB));
+        assert!(conveyor.should_handle_event(BPF_SOCK_OPS_RETRANS_CB));
+        assert!(conveyor.should_handle_event(BPF_SOCK_OPS_RTT_CB));
+        assert!(conveyor.should_handle_event(BPF_SOCK_OPS_RTO_CB));
+    }
+}

--- a/nfm-common/src/utils.rs
+++ b/nfm-common/src/utils.rs
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub trait MinNonZero {
+    fn min_non_zero(self, other: u32) -> u32;
+}
+
+impl MinNonZero for u32 {
+    fn min_non_zero(self, other: u32) -> u32 {
+        if self > 0 && other > 0 {
+            self.min(other)
+        } else {
+            self.max(other)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::MinNonZero;
+
+    #[test]
+    fn test_min_non_zero() {
+        let mut a: u32 = 0;
+        let mut b: u32 = 0;
+        assert_eq!(a.min_non_zero(b), 0);
+
+        (a, b) = (1, 0);
+        assert_eq!(a.min_non_zero(b), 1);
+
+        (a, b) = (0, 1);
+        assert_eq!(a.min_non_zero(b), 1);
+
+        (a, b) = (1, 2);
+        assert_eq!(a.min_non_zero(b), 1);
+
+        (a, b) = (2, 1);
+        assert_eq!(a.min_non_zero(b), 1);
+
+        (a, b) = (100, 200);
+        assert_eq!(a.min_non_zero(b), 100);
+
+        (a, b) = (u32::MAX, u32::MAX - 1);
+        assert_eq!(a.min_non_zero(b), u32::MAX - 1);
+    }
+}

--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -1,0 +1,82 @@
+[package]
+name = "nfm-controller"
+description = "network-flow-monitor-agent collects networking performance statistics from the local machine"
+version = "0.1.3"
+edition = "2021"
+publish = false
+build = "build.rs"
+
+[[bin]]
+# The controller and BPF packages join forces into a single 'network-flow-monitor-agent' executable.
+name = "network-flow-monitor-agent"
+path = "src/main.rs"
+
+[lib]
+name = "nfm_agent"
+path = "src/lib.rs"
+crate-type = ["lib"]
+
+[profile.dev]
+panic = "abort"
+overflow-checks = true
+
+[profile.release]
+panic = "abort"
+overflow-checks = true
+
+[dependencies]
+aws-config = { version = "1.5", features = [ "rustls" ] }
+aws-credential-types = "1.2"
+aws-sign-v4 = "0.3"
+nfm-common = { path = "../nfm-common", features = ["user"] }
+
+anyhow = "1"
+assert_approx_eq = "1"
+aya = "0.13"
+aya-obj = "0.2"
+caps = "0.5.5"
+chrono = "0.4"
+clap = { version = "4.1", features = ["derive"] }
+criterion = "0.5"
+env_logger = "0.10"
+flate2 = "1.0"
+futures = "0.3"
+hashbrown = "0.15"
+k8s-openapi = { version = "0.23", features = ["latest"] }
+kube = { version = "0.97", features = ["runtime", "derive", "rustls-tls"], default-features = false }
+libc = "0.2"
+log = "0.4"
+netlink-packet-core = { version = "0.7" }
+netlink-packet-netfilter = { package = "reyzell-netlink-packet-netfilter", version = "0.2" }
+netlink-packet-utils = { version = "0.5" }
+netlink-sys = { version = "0.8" }
+opentelemetry-proto = { version = "0.27", features = [
+    "metrics",
+    "gen-tonic-messages",
+    "gen-tonic",
+    "with-serde",
+] }
+procfs = "0.16"
+prost = "0.13"
+rand = "0.8"
+reqwest = { version = "0.12", features = ["blocking", "rustls-tls"], default-features = false }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+shadow-rs = "0.36"
+signal-hook = "0.3"
+structured-logger = "1.0"
+sys-info = "0.9"
+tokio = { version = "1.25", features = [
+    "fs",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "net",
+    "signal",
+] }
+url = "2.5"
+
+[build-dependencies]
+cargo_metadata = "0.19"
+shadow-rs = "0.36"
+which = { version = "6.0.0", default-features = false } 

--- a/nfm-controller/build.rs
+++ b/nfm-controller/build.rs
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cargo_metadata::MetadataCommand;
+use std::path::Path;
+use std::process::Command;
+use which::which;
+
+fn main() -> shadow_rs::SdResult<()> {
+    set_up_toolchain();
+
+    let release = std::env::var("PROFILE").unwrap() == "release";
+    build_ebpf(release);
+
+    shadow_rs::new()
+}
+
+fn set_up_toolchain() {
+    Command::new("rustup")
+        .args(&["component", "add", "rust-src"])
+        .status()
+        .expect("Failed to add rust-src");
+
+    if Command::new("bpf-linker")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        Command::new("cargo")
+            .args(&["install", "bpf-linker"])
+            .status()
+            .expect("Failed to install bpf-linker");
+    }
+
+    let bpf_linker = which("bpf-linker").unwrap();
+    println!("cargo:rerun-if-changed={}", bpf_linker.to_str().unwrap());
+}
+
+fn build_ebpf(release: bool) {
+    let metadata = MetadataCommand::new()
+        .manifest_path("../Cargo.toml")
+        .exec()
+        .expect("Failed to get cargo metadata");
+
+    let target_dir = Path::new("..").canonicalize().unwrap().join("target/ebpf");
+    let target_triple = metadata.workspace_metadata["bpf_target"]
+        .as_str()
+        .expect("Failed to get BPF target triple");
+
+    let bpf_obj_path = target_dir
+        .join(&target_triple)
+        .join(if release { "release" } else { "debug" })
+        .join("nfm-bpf");
+    println!(
+        "cargo:rustc-env=BPF_OBJECT_PATH={}",
+        bpf_obj_path.to_str().unwrap()
+    );
+
+    let target_trip_arg = format!("--target={}", &target_triple);
+    let target_dir_arg = format!("--target-dir={}", target_dir.to_str().unwrap());
+    let mut args = vec![
+        "build",
+        "--manifest-path=../nfm-bpf/Cargo.toml",
+        &target_trip_arg,
+        &target_dir_arg,
+        "-Z",
+        "build-std=core",
+    ];
+    if release {
+        args.push("--release");
+    }
+    let status = Command::new("cargo")
+        .env("RUSTC_BOOTSTRAP", "1")
+        .env("RUSTFLAGS", "")
+        .args(&args)
+        .status()
+        .expect("Failed to build eBPF program");
+    assert!(status.success());
+    println!("cargo:rerun-if-changed=../nfm-bpf/**");
+}

--- a/nfm-controller/rustfmt.toml
+++ b/nfm-controller/rustfmt.toml
@@ -1,0 +1,2 @@
+use_small_heuristics = "Default"
+max_width = 100

--- a/nfm-controller/src/events/event_filter.rs
+++ b/nfm-controller/src/events/event_filter.rs
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub trait EventFilter<T> {
+    fn filter_events(&mut self, events: Vec<T>) -> Vec<T>;
+}

--- a/nfm-controller/src/events/event_filter_top_loss.rs
+++ b/nfm-controller/src/events/event_filter_top_loss.rs
@@ -1,0 +1,215 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{event_filter::EventFilter, network_event::AggregateResults};
+use std::cmp::Ordering;
+
+pub(crate) struct EventFilterTopLoss {
+    max_items: u32,
+}
+
+impl EventFilterTopLoss {
+    pub fn new(max_items: u32) -> Self {
+        Self { max_items }
+    }
+}
+
+impl EventFilterTopLoss {
+    fn cmp(lhs: &AggregateResults, rhs: &AggregateResults) -> Ordering {
+        match lhs.stats.quantify_loss().cmp(&rhs.stats.quantify_loss()) {
+            val if val != Ordering::Equal => val,
+            _ => {
+                // When both sides have equal loss, compare by total bytes.
+                lhs.stats.total_bytes().cmp(&rhs.stats.total_bytes())
+            }
+        }
+    }
+}
+
+impl EventFilter<AggregateResults> for EventFilterTopLoss {
+    fn filter_events(&mut self, events: Vec<AggregateResults>) -> Vec<AggregateResults> {
+        // Note the comparison of `b` to `a` for a reverse sort.
+        let mut events = events;
+        events.sort_by(|a, b| EventFilterTopLoss::cmp(b, a));
+        events.truncate(self.max_items as usize);
+        events
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EventFilterTopLoss;
+    use crate::events::{
+        event_filter::EventFilter,
+        network_event::{AggregateResults, FlowProperties, InetProtocol, NetworkStats},
+    };
+    use std::cmp::Ordering;
+    use std::net::IpAddr;
+
+    fn empty_flow() -> FlowProperties {
+        FlowProperties {
+            protocol: InetProtocol::ANY,
+            local_address: "0.0.0.0".parse::<IpAddr>().unwrap(),
+            remote_address: "0.0.0.0".parse::<IpAddr>().unwrap(),
+            local_port: 0,
+            remote_port: 0,
+            kubernetes_metadata: None,
+        }
+    }
+
+    #[test]
+    fn test_top_loss_cmp() {
+        let result_all_good = AggregateResults {
+            flow: empty_flow(),
+            stats: Default::default(),
+        };
+        let result_retrans = AggregateResults {
+            flow: empty_flow(),
+            stats: NetworkStats {
+                retrans_syn: 20,
+                ..Default::default()
+            },
+        };
+        let result_rto = AggregateResults {
+            flow: empty_flow(),
+            stats: NetworkStats {
+                rtos_syn: 20,
+                ..Default::default()
+            },
+        };
+        let result_disconnect = AggregateResults {
+            flow: empty_flow(),
+            stats: NetworkStats {
+                severed_establish: 20,
+                ..Default::default()
+            },
+        };
+        let result_all_good_more_bytes = AggregateResults {
+            flow: empty_flow(),
+            stats: NetworkStats {
+                bytes_received: 1,
+                ..Default::default()
+            },
+        };
+
+        assert_eq!(
+            EventFilterTopLoss::cmp(&result_all_good, &result_retrans),
+            Ordering::Less
+        );
+        assert_eq!(
+            EventFilterTopLoss::cmp(&result_retrans, &result_all_good),
+            Ordering::Greater
+        );
+        assert_eq!(
+            EventFilterTopLoss::cmp(&result_retrans, &result_rto),
+            Ordering::Less
+        );
+        assert_eq!(
+            EventFilterTopLoss::cmp(&result_disconnect, &result_rto),
+            Ordering::Greater
+        );
+        assert_eq!(
+            EventFilterTopLoss::cmp(&result_disconnect, &result_disconnect),
+            Ordering::Equal
+        );
+        assert_eq!(
+            EventFilterTopLoss::cmp(&result_all_good, &result_all_good),
+            Ordering::Equal
+        );
+        assert_eq!(
+            EventFilterTopLoss::cmp(&result_all_good_more_bytes, &result_all_good),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn test_top_loss_filter() {
+        // Give each agg-result a flow with a unique local port so's to easily identify the flow in
+        // test results.
+        let empty_flow = empty_flow();
+        let result_all_good = AggregateResults {
+            flow: FlowProperties {
+                local_port: 1,
+                ..empty_flow.clone()
+            },
+            stats: Default::default(),
+        };
+        let result_retrans = AggregateResults {
+            flow: FlowProperties {
+                local_port: 2,
+                ..empty_flow.clone()
+            },
+            stats: NetworkStats {
+                retrans_syn: 20,
+                ..Default::default()
+            },
+        };
+        let result_rto = AggregateResults {
+            flow: FlowProperties {
+                local_port: 3,
+                ..empty_flow.clone()
+            },
+            stats: NetworkStats {
+                retrans_syn: 20,
+                ..Default::default()
+            },
+        };
+        let result_disconnect = AggregateResults {
+            flow: FlowProperties {
+                local_port: 4,
+                ..empty_flow.clone()
+            },
+            stats: NetworkStats {
+                severed_establish: 20,
+                ..Default::default()
+            },
+        };
+        let result_all_good_more_bytes = AggregateResults {
+            flow: FlowProperties {
+                local_port: 5,
+                ..empty_flow.clone()
+            },
+            stats: NetworkStats {
+                bytes_received: 1,
+                ..Default::default()
+            },
+        };
+
+        let mut event_list = vec![
+            result_rto.clone(),
+            result_all_good_more_bytes.clone(),
+            result_disconnect.clone(),
+            result_all_good.clone(),
+            result_retrans.clone(),
+        ];
+        let mut filter = EventFilterTopLoss::new(event_list.len() as u32);
+        let mut top_loss_result = filter.filter_events(event_list);
+
+        // Confirm results are in the expected order.
+        let expected_ids = vec![4, 3, 2, 5, 1];
+        let actual_ids = top_loss_result
+            .iter()
+            .map(|r| r.flow.local_port)
+            .collect::<Vec<u16>>();
+        assert_eq!(actual_ids, expected_ids);
+
+        // Test with a smaller max.
+        event_list = vec![
+            result_rto,
+            result_all_good_more_bytes,
+            result_disconnect,
+            result_all_good,
+            result_retrans,
+        ];
+        filter = EventFilterTopLoss { max_items: 3 };
+        top_loss_result = filter.filter_events(event_list);
+
+        // Confirm results are in the expected order.
+        let expected_ids = vec![4, 3, 2];
+        let actual_ids = top_loss_result
+            .iter()
+            .map(|r| r.flow.local_port)
+            .collect::<Vec<u16>>();
+        assert_eq!(actual_ids, expected_ids);
+    }
+}

--- a/nfm-controller/src/events/event_provider.rs
+++ b/nfm-controller/src/events/event_provider.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::events::nat_resolver::NatResolver;
+use crate::events::network_event::AggregateResults;
+use crate::reports::CountersOverall;
+
+use std::vec::Vec;
+
+pub trait EventProvider {
+    #[allow(clippy::borrowed_box)]
+    fn perform_aggregation_cycle(&mut self, nat_resolver: &Box<dyn NatResolver>);
+    fn network_stats(&mut self) -> Vec<AggregateResults>;
+    fn counters(&mut self) -> CountersOverall;
+    fn socket_count(&self) -> u64;
+}

--- a/nfm-controller/src/events/event_provider_ebpf.rs
+++ b/nfm-controller/src/events/event_provider_ebpf.rs
@@ -1,0 +1,854 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::events::event_provider::EventProvider;
+use crate::events::nat_resolver::NatResolver;
+use crate::events::network_event::{AggregateResults, FlowProperties, NetworkStats};
+use crate::events::{AggSockStats, SockCache, SockOperationResult, SockWrapper};
+use crate::reports::{CountersOverall, ProcessCounters};
+use crate::utils::Clock;
+use nfm_common::constants::{
+    AGG_FLOWS_MAX_ENTRIES, EBPF_PROGRAM_NAME, MAX_ENTRIES_SK_PROPS_HI, MAX_ENTRIES_SK_PROPS_LO,
+    MAX_ENTRIES_SK_STATS_HI, MAX_ENTRIES_SK_STATS_LO, NFM_CONTROL_MAP_NAME, NFM_COUNTERS_MAP_NAME,
+    NFM_SK_PROPS_MAP_NAME, NFM_SK_STATS_MAP_NAME, SK_STATS_TO_PROPS_RATIO,
+};
+use nfm_common::network::{
+    ControlData, CpuSockKey, EventCounters, SingletonKey, SockContext, SockKey, SockStats,
+    SINGLETON_KEY,
+};
+
+use anyhow::{Context, Result};
+use aya::{
+    include_bytes_aligned,
+    maps::{HashMap as SharedHashMap, MapData, MapError, PerCpuHashMap},
+    programs::{CgroupAttachMode, SockOps},
+    Btf, Ebpf, EbpfLoader, VerifierLogLevel,
+};
+use aya_obj::generated::BPF_ANY;
+use hashbrown::{hash_map::Entry, HashMap, HashSet};
+use log::info;
+use procfs::{Current, Meminfo};
+use std::fs::File;
+use std::mem;
+
+pub struct EventProviderEbpf<C: Clock> {
+    ebpf_handle: Ebpf,
+    ebpf_sock_props: SharedHashMap<MapData, CpuSockKey, SockContext>,
+    ebpf_sock_stats: SharedHashMap<MapData, CpuSockKey, SockStats>,
+    ebpf_control_data: ControlData,
+    ebpf_counters_latest: EventCounters,
+    ebpf_counters_published: EventCounters,
+
+    process_counters: ProcessCounters,
+    notrack_us: u64,
+    clock: C,
+    agg_socks_handled: u64,
+
+    sock_cache: SockCache,
+    sock_stream: HashMap<SockKey, AggSockStats>,
+    flow_cache: HashMap<FlowProperties, AggregateResults>,
+}
+
+fn instantiate_ebpf_object(
+    sock_props_max_entries: u64,
+    sock_stats_max_entries: u64,
+) -> Result<Ebpf> {
+    // Embed the eBPF raw bytes at compile time, and load them into the kernel at runtime.
+    let ebpf_bytes = include_bytes_aligned!(env!("BPF_OBJECT_PATH"));
+    info!(sock_props_max_entries, sock_stats_max_entries; "Loading eBPF program");
+    EbpfLoader::new()
+        .verifier_log_level(VerifierLogLevel::VERBOSE | VerifierLogLevel::STATS)
+        .btf(Btf::from_sys_fs().ok().as_ref())
+        .set_max_entries(
+            NFM_SK_PROPS_MAP_NAME,
+            sock_props_max_entries.try_into().unwrap(),
+        )
+        .set_max_entries(
+            NFM_SK_STATS_MAP_NAME,
+            sock_stats_max_entries.try_into().unwrap(),
+        )
+        .load(ebpf_bytes)
+        .context("Failed to parse eBPF program")
+}
+
+pub fn map_max_entries(mem_total_bytes: u64) -> (u64, u64) {
+    // We want our two BPF maps to consume less than a certain percentage of total memory, and the
+    // stats map to be a certain factor larger than the props map.
+
+    // This divisor was chosen arbitrarily based on experimentation.
+    let divisor: u64 = 5_000_000_000;
+    let sock_props_max_entries = (mem_total_bytes / divisor * MAX_ENTRIES_SK_PROPS_LO)
+        .clamp(MAX_ENTRIES_SK_PROPS_LO, MAX_ENTRIES_SK_PROPS_HI);
+    let sock_stats_max_entries = (sock_props_max_entries * SK_STATS_TO_PROPS_RATIO)
+        .clamp(MAX_ENTRIES_SK_STATS_LO, MAX_ENTRIES_SK_STATS_HI);
+
+    (sock_props_max_entries, sock_stats_max_entries)
+}
+
+impl<C: Clock> EventProvider for EventProviderEbpf<C> {
+    // Aggregates results from the eBPF layer, and evicts closed sockets.
+    fn perform_aggregation_cycle(&mut self, nat_resolver: &Box<dyn NatResolver>) {
+        info!("Aggregating across sockets");
+
+        // Apply adaptive sampling if we're receiving events faster than we can process.
+        if self.ebpf_counters().map_insertion_errors > 0 {
+            self.increase_sampling_interval();
+        } else {
+            self.decrease_sampling_interval();
+        }
+
+        // Retrieve properties of newly initiated sockets.
+        let mut new_cpu_sock_keys = HashSet::<CpuSockKey>::new();
+        let now_us = self.clock.now_us();
+        let context_timestamp = now_us - self.notrack_us / 2;
+        let mut sock_add_result = SockOperationResult::default();
+        for (cpu_sock_key, sock_context) in self.ebpf_sock_props.iter().flatten() {
+            let result =
+                self.sock_cache
+                    .add_context(cpu_sock_key.sock_key, sock_context, context_timestamp);
+            sock_add_result.add(&result);
+            if result.failed > 0 {
+                break;
+            }
+            new_cpu_sock_keys.insert(cpu_sock_key);
+        }
+
+        // Free the now no-longer needed contexts from BPF.  Thus, cycles are not spent re-reading
+        // these each iteration.
+        for cpu_sock_key in new_cpu_sock_keys.iter() {
+            if self.ebpf_sock_props.remove(cpu_sock_key).is_err() {
+                self.process_counters.socket_eviction_failed += 1;
+            }
+        }
+
+        // Aggregate stats across CPU cores, then take the delta from the previous aggregation cycle.
+        SocketQueries::aggregate_sock_stats(
+            self.ebpf_sock_stats.iter(),
+            &self.sock_cache,
+            &mut self.sock_stream,
+        );
+        let staleness_timestamp = now_us - self.notrack_us;
+        let sock_delta_result = self
+            .sock_cache
+            .update_stats_and_get_deltas(&mut self.sock_stream, staleness_timestamp);
+
+        // Apply beyond-NAT sock properties to any NAT'd sockets.
+        let sock_nat_result = nat_resolver.store_beyond_nat_entries(&mut self.sock_cache);
+
+        // Aggregate our delta stats into flows.
+        let num_flows_before = self.flow_cache.len();
+        let flow_aggregation_result = SocketQueries::aggregate_into_flows(
+            &self.sock_stream,
+            &self.sock_cache,
+            &mut self.flow_cache,
+        );
+        self.sock_stream.clear();
+
+        // Collect some stats before evicting entries.
+        self.agg_socks_handled = self.sock_cache.len().try_into().unwrap();
+        let (num_cpus_min, num_cpus_max, num_cpus_avg) = self.sock_cache.num_cpus();
+
+        // Evict sockets.
+        let (socks_to_evict, num_stale) = self.sock_cache.perform_eviction();
+        let sock_eviction_result = self.perform_bpf_eviction(socks_to_evict);
+
+        // Update counters.
+        self.process_counters.sockets_added += sock_add_result.completed;
+        self.process_counters.sockets_stale += num_stale;
+        self.process_counters.sockets_natd += sock_nat_result.completed;
+
+        self.process_counters.socket_deltas_completed += sock_delta_result.completed;
+        self.process_counters.socket_deltas_missing_props += sock_delta_result.partial;
+        self.process_counters.socket_deltas_above_limit += sock_delta_result.failed;
+
+        self.process_counters.socket_agg_completed += flow_aggregation_result.completed;
+        self.process_counters.socket_agg_missing_props += flow_aggregation_result.partial;
+        self.process_counters.socket_agg_above_limit += flow_aggregation_result.failed;
+
+        self.process_counters.socket_eviction_completed += sock_eviction_result.completed;
+        self.process_counters.socket_eviction_failed += sock_eviction_result.failed;
+
+        info!(
+            sock_add_result:serde,
+            sock_delta_result:serde,
+            sock_nat_result:serde,
+            flow_aggregation_result:serde,
+            sock_eviction_result:serde,
+            control_data:serde = self.ebpf_control_data,
+            sock_cache_len = self.sock_cache.len(),
+            flows_before = num_flows_before,
+            flows_after = self.flow_cache.len(),
+            cpus_per_sock_min = num_cpus_min,
+            cpus_per_sock_avg = num_cpus_avg,
+            cpus_per_sock_max = num_cpus_max;
+            "Aggregation complete"
+        );
+    }
+
+    // Returns and resets aggregated network stats.
+    fn network_stats(&mut self) -> Vec<AggregateResults> {
+        mem::take(&mut self.flow_cache).into_values().collect()
+    }
+
+    // Returns and resets tracked counters.
+    fn counters(&mut self) -> CountersOverall {
+        let ebpf_counters_delta = self
+            .ebpf_counters_latest
+            .subtract(&self.ebpf_counters_published);
+        self.ebpf_counters_published = self.ebpf_counters_latest;
+
+        CountersOverall {
+            event_related: ebpf_counters_delta,
+            process_related: self.process_counters(),
+        }
+    }
+
+    // Gets the number of sockets tracked.
+    fn socket_count(&self) -> u64 {
+        self.agg_socks_handled
+    }
+}
+
+impl<C: Clock> EventProviderEbpf<C> {
+    pub fn new(cgroup: &String, notrack_secs: u64, clock: C) -> Result<Self> {
+        let cgroup_file =
+            File::open(cgroup).context(format!("cgroup file not found: {}", cgroup))?;
+
+        let mem_total_bytes = match Meminfo::current() {
+            Ok(meminfo) => meminfo.mem_total,
+            Err(e) => {
+                panic!("Unable to determine total memory: {}", e);
+            }
+        };
+        let (sock_props_max_entries, sock_stats_max_entries) = map_max_entries(mem_total_bytes);
+        let mut ebpf_handle =
+            instantiate_ebpf_object(sock_props_max_entries, sock_stats_max_entries)?;
+
+        let program: &mut SockOps = ebpf_handle
+            .program_mut(EBPF_PROGRAM_NAME)
+            .unwrap()
+            .try_into()
+            .context("Failed to instantiate sockops program")?;
+        program
+            .load()
+            .context("Failed to load sockops program into the kernel")?;
+        program
+            .attach(cgroup_file, CgroupAttachMode::Single)
+            .context(format!("Failed to attach to cgroup: {}", cgroup))?;
+
+        let ebpf_sock_props =
+            SharedHashMap::try_from(ebpf_handle.take_map(NFM_SK_PROPS_MAP_NAME).unwrap())
+                .context(format!("Failed to load BPF map {}", NFM_SK_PROPS_MAP_NAME))?;
+        let ebpf_sock_stats =
+            SharedHashMap::try_from(ebpf_handle.take_map(NFM_SK_STATS_MAP_NAME).unwrap())
+                .context(format!("Failed to load BPF map {}", NFM_SK_STATS_MAP_NAME))?;
+
+        let max_concurrent_socks = sock_props_max_entries;
+        let mut provider = EventProviderEbpf {
+            ebpf_handle,
+            ebpf_sock_props,
+            ebpf_sock_stats,
+            ebpf_control_data: ControlData::default(),
+            ebpf_counters_latest: EventCounters::default(),
+            ebpf_counters_published: EventCounters::default(),
+            process_counters: ProcessCounters {
+                restarts: 1,
+                ..Default::default()
+            },
+            notrack_us: notrack_secs * 1_000_000,
+            clock,
+            sock_cache: SockCache::with_max_entries(max_concurrent_socks.try_into().unwrap()),
+            sock_stream: HashMap::new(),
+            flow_cache: HashMap::new(),
+            agg_socks_handled: 0,
+        };
+        provider.increase_sampling_interval();
+        Ok(provider)
+    }
+
+    fn increase_sampling_interval(&mut self) {
+        if self.ebpf_control_data.sampling_interval > 1 {
+            self.ebpf_control_data.sampling_interval =
+                self.ebpf_control_data.sampling_interval.saturating_mul(3) / 2;
+        } else {
+            self.ebpf_control_data.sampling_interval = 2;
+        }
+
+        self.send_control_data();
+    }
+
+    fn decrease_sampling_interval(&mut self) {
+        if self.ebpf_control_data.sampling_interval > 1 {
+            self.ebpf_control_data.sampling_interval -= 1;
+            self.send_control_data();
+        }
+    }
+
+    fn send_control_data(&mut self) {
+        SharedHashMap::try_from(self.ebpf_handle.map_mut(NFM_CONTROL_MAP_NAME).unwrap())
+            .unwrap_or_else(|_| panic!("Failed to load BPF map {}", NFM_CONTROL_MAP_NAME))
+            .insert(SINGLETON_KEY, self.ebpf_control_data, BPF_ANY.into())
+            .unwrap_or_else(|e| panic!("Failed to write control data: {:?}", e))
+    }
+
+    fn process_counters(&mut self) -> ProcessCounters {
+        let latest_counters = self.process_counters;
+        self.process_counters = ProcessCounters::default();
+
+        latest_counters
+    }
+
+    fn ebpf_counters(&mut self) -> EventCounters {
+        let data: PerCpuHashMap<&MapData, SingletonKey, EventCounters> =
+            PerCpuHashMap::try_from(self.ebpf_handle.map(NFM_COUNTERS_MAP_NAME).unwrap())
+                .unwrap_or_else(|_| panic!("Failed to load BPF map {}", NFM_COUNTERS_MAP_NAME));
+
+        let mut new_counters = EventCounters::default();
+        const EMPTY_FLAGS: u64 = 0;
+        if let Ok(counters_per_cpu) = data.get(&SINGLETON_KEY, EMPTY_FLAGS) {
+            for counters in (*counters_per_cpu).iter() {
+                new_counters.add_from(counters);
+            }
+        }
+
+        // eBPF counters continue accumulating.  The difference from our last set of counters
+        // represents new counts.
+        let delta_counts = new_counters.subtract(&self.ebpf_counters_latest);
+        self.ebpf_counters_latest = new_counters;
+
+        delta_counts
+    }
+
+    // Evicts from the sock_stats map.
+    fn perform_bpf_eviction(
+        &mut self,
+        to_evict: HashMap<SockKey, SockWrapper>,
+    ) -> SockOperationResult {
+        let mut result = SockOperationResult::default();
+        'sock_loop: for (sock_key, sock_wrap) in to_evict.iter() {
+            for cpu_id in &sock_wrap.agg_stats.cpus {
+                let composite_key = CpuSockKey {
+                    cpu_id: (*cpu_id).into(),
+                    sock_key: *sock_key,
+                };
+                if self.ebpf_sock_stats.remove(&composite_key).is_err() {
+                    result.failed += 1;
+                    continue 'sock_loop;
+                }
+            }
+
+            result.completed += 1;
+        }
+
+        result
+    }
+}
+
+// A private set of helper methods for running queries over collections of sockets.
+struct SocketQueries;
+impl SocketQueries {
+    fn aggregate_sock_stats<T>(
+        sock_stats_map: T,
+        sock_cache: &SockCache,
+        agg_stats_by_sock: &mut HashMap<SockKey, AggSockStats>,
+    ) where
+        T: Iterator<Item = Result<(CpuSockKey, SockStats), MapError>>,
+    {
+        // Retrieve sock stats from the eBPF map and sum results across CPU cores.
+        for (composite_key, new_stats) in sock_stats_map.flatten() {
+            let agg_stats = agg_stats_by_sock.entry(composite_key.sock_key).or_default();
+            let sock_last_read = sock_cache.get_last_touched(&composite_key.sock_key);
+            agg_stats.stats.add_from(&new_stats, sock_last_read);
+            agg_stats
+                .cpus
+                .push(composite_key.cpu_id.try_into().unwrap());
+        }
+    }
+
+    // Aggregates socket stats into stats by flow properties.
+    fn aggregate_into_flows(
+        sock_stats_deltas: &HashMap<SockKey, AggSockStats>,
+        sock_cache: &SockCache,
+        flow_cache: &mut HashMap<FlowProperties, AggregateResults>,
+    ) -> SockOperationResult {
+        // Reset the counts of sockets per state.
+        for flow in flow_cache.values_mut() {
+            flow.stats.clear_levels();
+        }
+
+        let mut result = SockOperationResult::default();
+        let flow_limit: usize = AGG_FLOWS_MAX_ENTRIES.try_into().unwrap();
+        for (sock_key, agg_stats) in sock_stats_deltas.iter() {
+            let sock_wrapper = match sock_cache.get(sock_key) {
+                Some(ctx) => ctx,
+                None => {
+                    result.failed += 1;
+                    continue;
+                }
+            };
+
+            let context_beyond_nat = sock_wrapper
+                .context_external
+                .unwrap_or(sock_wrapper.context);
+            if let Ok(flow_props) = FlowProperties::try_from(&context_beyond_nat) {
+                let flow_count = flow_cache.len();
+                let flow_entry = flow_cache.entry(flow_props.clone());
+                let flow_agg = match flow_entry {
+                    Entry::Occupied(o) => o.into_mut(),
+                    Entry::Vacant(v) => {
+                        if flow_count < flow_limit {
+                            // When below the flow limit, track new flows.
+                            v.insert(AggregateResults {
+                                flow: flow_props,
+                                stats: NetworkStats::default(),
+                            })
+                        } else {
+                            // When at the flow limit, move on to the next socket.
+                            result.failed += 1;
+                            continue;
+                        }
+                    }
+                };
+
+                flow_agg.stats.add_from(&agg_stats.stats);
+                if sock_wrapper.should_evict() {
+                    flow_agg.stats.sockets_completed += 1;
+                }
+                result.completed += 1;
+            } else {
+                result.partial += 1;
+            }
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::events::event_provider_ebpf::{map_max_entries, SocketQueries};
+    use crate::events::network_event::{AggregateResults, FlowProperties, InetProtocol};
+    use crate::events::{AggSockStats, SockCache, SockOperationResult};
+    use nfm_common::constants::{
+        AGG_FLOWS_MAX_ENTRIES, MAX_ENTRIES_SK_PROPS_HI, MAX_ENTRIES_SK_PROPS_LO,
+        MAX_ENTRIES_SK_STATS_HI, MAX_ENTRIES_SK_STATS_LO,
+    };
+    use nfm_common::{
+        network::{CpuSockKey, SockContext, SockKey, SockStats},
+        AF_INET,
+    };
+
+    use aya::maps::MapError;
+    use hashbrown::HashMap;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::str::FromStr;
+
+    const STALENESS_TS: u64 = 0;
+
+    #[test]
+    pub fn test_result_aggregation_into_flows() {
+        let mut ebpf_sk_stats: Vec<Result<(CpuSockKey, SockStats), MapError>> = Vec::new();
+
+        const NUM_CPUS: usize = 16;
+        let sock_keys: Vec<usize> = vec![99, 101, 4, 55, 19, 79];
+
+        let mut sock_cache = SockCache::new();
+        let now_us = 2025;
+        for (index, sock_key) in sock_keys.iter().enumerate() {
+            // Simulate sock properties having already been loaded.  All sockets alternate between
+            // two remote ports.
+            let fake_value = (index % 2 + 1) as u16 * 10;
+            let sk_context = SockContext {
+                is_client: true,
+                address_family: AF_INET,
+                local_ipv4: 1950,
+                remote_ipv4: 2265,
+                local_port: 1492,
+                remote_port: fake_value,
+                ..Default::default()
+            };
+            sock_cache.add_context((*sock_key).try_into().unwrap(), sk_context, now_us);
+
+            // Simulate later socket events being handled by two different CPUs.
+            let cpu_id = (sock_key + 3) % NUM_CPUS;
+            let composite_key = CpuSockKey {
+                cpu_id: cpu_id.try_into().unwrap(),
+                sock_key: (*sock_key).try_into().unwrap(),
+            };
+            let sk_stats = SockStats {
+                last_touched_us: now_us,
+                bytes_received: fake_value as u64 * 3,
+                rtt_count: fake_value as u32 * 5,
+                rtt_latest_us: 99,
+                ..Default::default()
+            };
+            ebpf_sk_stats.push(Ok((composite_key, sk_stats)));
+
+            let cpu_id = (sock_key + 4) % NUM_CPUS;
+            let composite_key = CpuSockKey {
+                cpu_id: cpu_id.try_into().unwrap(),
+                sock_key: (*sock_key).try_into().unwrap(),
+            };
+            let sk_stats = SockStats {
+                last_touched_us: now_us,
+                bytes_received: fake_value as u64 * 4,
+                rtt_count: fake_value as u32 * 6,
+                rtt_latest_us: 100,
+                ..Default::default()
+            };
+            ebpf_sk_stats.push(Ok((composite_key, sk_stats)));
+        }
+
+        // Aggregate results.
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        SocketQueries::aggregate_sock_stats(
+            ebpf_sk_stats.into_iter(),
+            &sock_cache,
+            &mut sock_stream,
+        );
+        let delta_result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, STALENESS_TS);
+
+        let mut flow_cache = HashMap::new();
+        let agg_result =
+            SocketQueries::aggregate_into_flows(&sock_stream, &sock_cache, &mut flow_cache);
+
+        // Now validate what we got.
+        assert_eq!(
+            delta_result,
+            SockOperationResult {
+                completed: sock_keys.len().try_into().unwrap(),
+                partial: 0,
+                failed: 0,
+            }
+        );
+        assert_eq!(
+            agg_result,
+            SockOperationResult {
+                completed: sock_keys.len().try_into().unwrap(),
+                partial: 0,
+                failed: 0,
+            }
+        );
+        let num_endpoints = sock_keys.len() as u32 / 2;
+        assert_eq!(flow_cache.len(), 2);
+        for result in flow_cache.into_values() {
+            assert_eq!(result.flow.local_address, Ipv4Addr::new(0, 0, 7, 158));
+            assert_eq!(result.flow.remote_address, Ipv4Addr::new(0, 0, 8, 217));
+            assert_eq!(result.flow.protocol, InetProtocol::TCP);
+            assert_eq!(result.flow.local_port, 0);
+
+            let fake_value = result.flow.remote_port;
+            assert!(fake_value == 10 || fake_value == 20);
+
+            // Validate the stats summed across CPUs.
+            assert_eq!(
+                result.stats.bytes_received,
+                fake_value as u64 * 4 * num_endpoints as u64,
+            );
+            assert_eq!(result.stats.rtt_us.count, num_endpoints);
+        }
+    }
+
+    #[test]
+    fn test_flow_aggregation_empty() {
+        let sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        let sock_cache = SockCache::new();
+        let mut flow_cache: HashMap<FlowProperties, AggregateResults> = HashMap::new();
+
+        let agg_result =
+            SocketQueries::aggregate_into_flows(&sock_stream, &sock_cache, &mut flow_cache);
+        assert!(flow_cache.is_empty());
+        assert_eq!(
+            agg_result,
+            SockOperationResult {
+                completed: 0,
+                partial: 0,
+                failed: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn test_flow_aggregation_one_flow() {
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        let mut sock_cache = SockCache::with_max_entries(AGG_FLOWS_MAX_ENTRIES as usize);
+        let mut flow_cache: HashMap<FlowProperties, AggregateResults> = HashMap::new();
+
+        // Test the aggregation of many sockets into one flow.
+        let now_us: u64 = 2025;
+        for i in 0..AGG_FLOWS_MAX_ENTRIES {
+            let sock_key = i as SockKey;
+            let sock_context = SockContext {
+                address_family: AF_INET,
+                remote_ipv4: Ipv4Addr::from_str("44.33.22.11").unwrap().to_bits(),
+                ..Default::default()
+            };
+            sock_cache.add_context(sock_key, sock_context, now_us);
+            sock_stream.insert(
+                sock_key,
+                AggSockStats {
+                    stats: SockStats {
+                        bytes_received: 1,
+                        ..Default::default()
+                    },
+                    cpus: vec![],
+                },
+            );
+        }
+        let agg_result =
+            SocketQueries::aggregate_into_flows(&sock_stream, &sock_cache, &mut flow_cache);
+
+        let expected_bytes: u64 = AGG_FLOWS_MAX_ENTRIES as u64;
+        let actual_bytes: u64 = flow_cache
+            .values()
+            .map(|agg_flow| agg_flow.stats.bytes_received)
+            .sum();
+        assert_eq!(flow_cache.len(), 1);
+        assert_eq!(actual_bytes, expected_bytes);
+        assert_eq!(
+            agg_result,
+            SockOperationResult {
+                completed: AGG_FLOWS_MAX_ENTRIES as u64,
+                partial: 0,
+                failed: 0,
+            }
+        );
+        for flow in flow_cache.keys() {
+            assert_eq!(
+                flow.remote_address,
+                IpAddr::from_str("44.33.22.11").unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn test_flow_aggregation_many_flows() {
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        let mut sock_cache = SockCache::with_max_entries(AGG_FLOWS_MAX_ENTRIES as usize);
+        let mut flow_cache: HashMap<FlowProperties, AggregateResults> = HashMap::new();
+
+        // Test the aggregation of many sockets into different flows.
+        let now_us = 1997;
+        for i in 0..AGG_FLOWS_MAX_ENTRIES {
+            let sock_key = i as SockKey;
+            let sock_context = SockContext {
+                address_family: AF_INET,
+                remote_ipv4: i,
+                ..Default::default()
+            };
+            sock_cache.add_context(sock_key, sock_context, now_us);
+            sock_stream.insert(
+                sock_key,
+                AggSockStats {
+                    stats: SockStats {
+                        bytes_received: i as u64,
+                        ..Default::default()
+                    },
+                    cpus: vec![],
+                },
+            );
+        }
+        let agg_result =
+            SocketQueries::aggregate_into_flows(&sock_stream, &sock_cache, &mut flow_cache);
+        assert_eq!(
+            agg_result,
+            SockOperationResult {
+                completed: AGG_FLOWS_MAX_ENTRIES as u64,
+                partial: 0,
+                failed: 0,
+            }
+        );
+
+        let expected_bytes: u64 =
+            ((AGG_FLOWS_MAX_ENTRIES - 1) * (AGG_FLOWS_MAX_ENTRIES / 2)).into();
+        let actual_bytes: u64 = flow_cache
+            .values()
+            .map(|agg_flow| agg_flow.stats.bytes_received)
+            .sum();
+        assert_eq!(flow_cache.len(), AGG_FLOWS_MAX_ENTRIES as usize);
+        assert_eq!(actual_bytes, expected_bytes);
+    }
+
+    #[test]
+    fn test_flow_aggregation_too_many_flows() {
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        let mut sock_cache = SockCache::with_max_entries(AGG_FLOWS_MAX_ENTRIES as usize);
+        let mut flow_cache: HashMap<FlowProperties, AggregateResults> = HashMap::new();
+
+        // Test the aggregation of many sockets into *too many* flows.
+        let now_us = 2342;
+        for i in 0..AGG_FLOWS_MAX_ENTRIES * 2 {
+            let sock_key = i as SockKey;
+            let sock_context = SockContext {
+                address_family: AF_INET,
+                remote_ipv4: i,
+                ..Default::default()
+            };
+            sock_cache.add_context(sock_key, sock_context, now_us);
+            sock_stream.insert(
+                sock_key,
+                AggSockStats {
+                    stats: SockStats {
+                        bytes_received: i as u64,
+                        ..Default::default()
+                    },
+                    cpus: vec![],
+                },
+            );
+        }
+        let agg_result =
+            SocketQueries::aggregate_into_flows(&sock_stream, &sock_cache, &mut flow_cache);
+
+        let expected_bytes_min: u64 =
+            ((AGG_FLOWS_MAX_ENTRIES - 1) * (AGG_FLOWS_MAX_ENTRIES / 2)).into();
+        let actual_bytes: u64 = flow_cache
+            .values()
+            .map(|agg_flow| agg_flow.stats.bytes_received)
+            .sum();
+        assert_eq!(flow_cache.len(), AGG_FLOWS_MAX_ENTRIES as usize);
+        assert!(actual_bytes >= expected_bytes_min);
+        assert_eq!(
+            agg_result,
+            SockOperationResult {
+                completed: AGG_FLOWS_MAX_ENTRIES as u64,
+                partial: 0,
+                failed: AGG_FLOWS_MAX_ENTRIES as u64,
+            }
+        );
+    }
+
+    #[test]
+    fn test_sock_wrappers_missing_on_flow_agg() {
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        sock_stream.insert(11, AggSockStats::default());
+        sock_stream.insert(22, AggSockStats::default());
+
+        // Create an empty sock cache.
+        let sock_cache = SockCache::new();
+
+        let mut flow_cache = HashMap::new();
+        let agg_result =
+            SocketQueries::aggregate_into_flows(&sock_stream, &sock_cache, &mut flow_cache);
+        assert_eq!(
+            agg_result,
+            SockOperationResult {
+                completed: 0,
+                partial: 0,
+                failed: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn test_map_max_entries_low_mem() {
+        let mem_total_bytes: u64 = 1;
+        let (max_sk_props, max_sk_stats) = map_max_entries(mem_total_bytes);
+        assert_eq!(max_sk_props, MAX_ENTRIES_SK_PROPS_LO);
+        assert_eq!(max_sk_stats, MAX_ENTRIES_SK_STATS_LO);
+    }
+
+    #[test]
+    fn test_map_max_entries_lowish_mem() {
+        let mem_total_bytes: u64 = 400_000_000;
+        let (max_sk_props, max_sk_stats) = map_max_entries(mem_total_bytes);
+        assert_eq!(max_sk_props, MAX_ENTRIES_SK_PROPS_LO);
+        assert_eq!(max_sk_stats, MAX_ENTRIES_SK_STATS_LO);
+    }
+
+    #[test]
+    fn test_map_max_entries_medium_mem() {
+        let mem_total_bytes: u64 = 1_000_000_000;
+        let (max_sk_props, max_sk_stats) = map_max_entries(mem_total_bytes);
+        assert_eq!(max_sk_props, MAX_ENTRIES_SK_PROPS_LO);
+        assert_eq!(max_sk_stats, MAX_ENTRIES_SK_STATS_LO);
+    }
+
+    #[test]
+    fn test_map_max_entries_highish_mem() {
+        let mem_total_bytes: u64 = 34_000_000_000;
+        let (max_sk_props, max_sk_stats) = map_max_entries(mem_total_bytes);
+        assert!(max_sk_props > MAX_ENTRIES_SK_PROPS_LO);
+        assert!(max_sk_props < MAX_ENTRIES_SK_PROPS_HI);
+
+        assert!(max_sk_stats > MAX_ENTRIES_SK_STATS_LO);
+        assert!(max_sk_stats < MAX_ENTRIES_SK_STATS_HI);
+    }
+
+    #[test]
+    fn test_map_max_entries_highest_mem() {
+        let mem_total_bytes: u64 = u64::MAX;
+        let (max_sk_props, max_sk_stats) = map_max_entries(mem_total_bytes);
+        assert_eq!(max_sk_props, MAX_ENTRIES_SK_PROPS_HI);
+        assert_eq!(max_sk_stats, MAX_ENTRIES_SK_STATS_HI);
+    }
+
+    #[test]
+    fn test_flow_aggregation_with_nat() {
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        let mut sock_cache = SockCache::with_max_entries(AGG_FLOWS_MAX_ENTRIES as usize);
+        let mut flow_cache: HashMap<FlowProperties, AggregateResults> = HashMap::new();
+
+        // Aggregate many sockets into one flow.
+        let now_us: u64 = 2025;
+        for i in 0..AGG_FLOWS_MAX_ENTRIES {
+            let sock_key = i as SockKey;
+            let sock_context = SockContext {
+                address_family: AF_INET,
+                remote_ipv4: Ipv4Addr::from_str("4.3.2.1").unwrap().to_bits(),
+                ..Default::default()
+            };
+            sock_cache.add_context(sock_key, sock_context, now_us);
+            sock_stream.insert(
+                sock_key,
+                AggSockStats {
+                    stats: SockStats {
+                        bytes_received: 1,
+                        ..Default::default()
+                    },
+                    cpus: vec![],
+                },
+            );
+        }
+
+        // Apply some NAT results.
+        for (_key, sock_wrap) in sock_cache.iter_mut() {
+            sock_wrap.context_external = Some(SockContext {
+                local_ipv4: Ipv4Addr::from_str("10.6.7.8").unwrap().to_bits(),
+                remote_ipv4: Ipv4Addr::from_str("44.33.22.11").unwrap().to_bits(),
+                local_port: 22,
+                remote_port: 2938,
+                address_family: AF_INET,
+                is_client: false,
+                ..Default::default()
+            });
+        }
+
+        // Do some aggregation.
+        let agg_result =
+            SocketQueries::aggregate_into_flows(&sock_stream, &sock_cache, &mut flow_cache);
+        assert_eq!(
+            agg_result,
+            SockOperationResult {
+                completed: AGG_FLOWS_MAX_ENTRIES.into(),
+                partial: 0,
+                failed: 0,
+            }
+        );
+
+        // Confirm the flow represents the view beyond local NAT.
+        assert_eq!(flow_cache.len(), 1);
+        for flow in flow_cache.keys() {
+            assert_eq!(
+                *flow,
+                FlowProperties {
+                    protocol: InetProtocol::TCP,
+                    local_address: IpAddr::from_str("10.6.7.8").unwrap(),
+                    remote_address: IpAddr::from_str("44.33.22.11").unwrap(),
+                    local_port: 22,
+                    remote_port: 0,
+                    kubernetes_metadata: None,
+                }
+            );
+        }
+    }
+}

--- a/nfm-controller/src/events/host_stats_provider.rs
+++ b/nfm-controller/src/events/host_stats_provider.rs
@@ -1,0 +1,421 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metadata::env_metadata_provider::NetworkDevice;
+use crate::reports::report::ReportValue;
+use crate::utils::report::to_value_pairs;
+use crate::utils::{CommandRunner, RealCommandRunner};
+
+use hashbrown::{HashMap, HashSet};
+use log::error;
+use serde::{Deserialize, Serialize};
+
+// Statistics within this structure are used by the Network Flow Monitor back-end to gauge the status of the host
+// on which the agent is running.  This allows for correlation with issues visible on the host.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct HostStats {
+    pub(crate) interface_stats: Vec<GroupedInterfaceStats>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct GroupedInterfaceStats {
+    pub interface_id: String,
+    pub stats: NetworkInterfaceStats,
+}
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct NetworkInterfaceStats {
+    // ENA driver stats from ethtool.
+    pub bw_in_allowance_exceeded: u64,
+    pub bw_out_allowance_exceeded: u64,
+    pub conntrack_allowance_exceeded: u64,
+    pub linklocal_allowance_exceeded: u64,
+    pub pps_allowance_exceeded: u64,
+    pub conntrack_allowance_available: u64,
+}
+
+impl NetworkInterfaceStats {
+    pub fn subtract(&self, rhs: &NetworkInterfaceStats) -> NetworkInterfaceStats {
+        NetworkInterfaceStats {
+            // Subtract cumulative counters.
+            bw_in_allowance_exceeded: self
+                .bw_in_allowance_exceeded
+                .wrapping_sub(rhs.bw_in_allowance_exceeded),
+            bw_out_allowance_exceeded: self
+                .bw_out_allowance_exceeded
+                .wrapping_sub(rhs.bw_out_allowance_exceeded),
+            conntrack_allowance_exceeded: self
+                .conntrack_allowance_exceeded
+                .wrapping_sub(rhs.conntrack_allowance_exceeded),
+            linklocal_allowance_exceeded: self
+                .linklocal_allowance_exceeded
+                .wrapping_sub(rhs.linklocal_allowance_exceeded),
+            pps_allowance_exceeded: self
+                .pps_allowance_exceeded
+                .wrapping_sub(rhs.pps_allowance_exceeded),
+
+            // Maintain level-based stats.
+            conntrack_allowance_available: self.conntrack_allowance_available,
+        }
+    }
+
+    pub fn enumerate(&self) -> Vec<(String, ReportValue)> {
+        to_value_pairs(&self)
+    }
+}
+
+pub trait HostStatsProvider {
+    fn set_network_devices(&mut self, net_devices: &[NetworkDevice]);
+    fn get_stats(&mut self) -> HostStats;
+}
+
+pub struct HostStatsProviderImpl {
+    pub(crate) network_interface_stats: HashMap<NetworkDevice, NetworkInterfaceStats>,
+
+    command_runner: Box<dyn CommandRunner>,
+}
+
+impl HostStatsProvider for HostStatsProviderImpl {
+    fn set_network_devices(&mut self, net_devices: &[NetworkDevice]) {
+        let devices: HashSet<&NetworkDevice> = HashSet::from_iter(net_devices);
+
+        // Purge old devices.
+        self.network_interface_stats
+            .retain(|key, _| devices.contains(key));
+
+        // Add new.
+        for net_dev in devices.into_iter() {
+            if !self.network_interface_stats.contains_key(net_dev) {
+                // Stats must be loaded now for newly added devices so that we don't treat
+                // historical values as large deltas.
+                let stats = self
+                    .load_single_iface_stats(&net_dev.device_name)
+                    .unwrap_or_default();
+                self.network_interface_stats.insert(net_dev.clone(), stats);
+            }
+        }
+    }
+
+    fn get_stats(&mut self) -> HostStats {
+        // Interface stats read from the host are cumulative.  Thus, we cache the latest values,
+        // then return the deltas.
+
+        let latest_iface_stats = self.load_all_iface_stats();
+        let mut delta_iface_stats = HashMap::<NetworkDevice, NetworkInterfaceStats>::new();
+
+        for (net_device, latest_stats) in latest_iface_stats.iter() {
+            delta_iface_stats.insert(
+                net_device.clone(),
+                latest_stats.subtract(self.network_interface_stats.get(net_device).unwrap()),
+            );
+        }
+        self.network_interface_stats = latest_iface_stats;
+
+        self.build_host_stats(delta_iface_stats)
+    }
+}
+
+impl Default for HostStatsProviderImpl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HostStatsProviderImpl {
+    pub fn new() -> Self {
+        Self {
+            network_interface_stats: HashMap::new(),
+            command_runner: Box::new(RealCommandRunner {}),
+        }
+    }
+
+    fn build_host_stats(
+        &self,
+        iface_stats: HashMap<NetworkDevice, NetworkInterfaceStats>,
+    ) -> HostStats {
+        let grouped_iface_stats = iface_stats
+            .into_iter()
+            .map(|(net_dev, stats)| GroupedInterfaceStats {
+                interface_id: net_dev.interface_id,
+                stats,
+            })
+            .collect();
+
+        HostStats {
+            interface_stats: grouped_iface_stats,
+        }
+    }
+
+    // Loads stats for all configured network interfaces.
+    fn load_all_iface_stats(&mut self) -> HashMap<NetworkDevice, NetworkInterfaceStats> {
+        let mut latest_iface_stats = HashMap::<NetworkDevice, NetworkInterfaceStats>::new();
+        let net_devices: Vec<NetworkDevice> =
+            self.network_interface_stats.keys().cloned().collect();
+        for net_device in net_devices {
+            match self.load_single_iface_stats(&net_device.device_name) {
+                Ok(stats) => {
+                    latest_iface_stats.insert(net_device.clone(), stats);
+                }
+                Err(err) => {
+                    error!(device:serde = net_device, error = err.to_string(); "Failed to get ethtool stats");
+
+                    // Preserve prior stats on error.
+                    let stats = self.network_interface_stats.get(&net_device).unwrap();
+                    latest_iface_stats.insert(net_device.clone(), *stats);
+                }
+            }
+        }
+
+        latest_iface_stats
+    }
+
+    // Loads stats for a single network interface.
+    fn load_single_iface_stats(
+        &mut self,
+        dev_name: &str,
+    ) -> Result<NetworkInterfaceStats, std::io::Error> {
+        let output = self.command_runner.run("ethtool", &["-S", dev_name])?;
+
+        let mut stats = NetworkInterfaceStats::default();
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let parts = line.split_ascii_whitespace().collect::<Vec<_>>();
+            if parts.len() != 2 {
+                continue;
+            }
+
+            let val: u64 = parts[1].parse().unwrap_or_default();
+            match parts[0] {
+                "bw_in_allowance_exceeded:" => stats.bw_in_allowance_exceeded = val,
+                "bw_out_allowance_exceeded:" => stats.bw_out_allowance_exceeded = val,
+                "conntrack_allowance_exceeded:" => stats.conntrack_allowance_exceeded = val,
+                "linklocal_allowance_exceeded:" => stats.linklocal_allowance_exceeded = val,
+                "pps_allowance_exceeded:" => stats.pps_allowance_exceeded = val,
+                "conntrack_allowance_available:" => stats.conntrack_allowance_available = val,
+                _ => {
+                    // No-op
+                }
+            };
+        }
+
+        Ok(stats)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::events::host_stats_provider::{
+        GroupedInterfaceStats, HostStats, HostStatsProvider, HostStatsProviderImpl,
+        NetworkInterfaceStats,
+    };
+    use crate::metadata::env_metadata_provider::NetworkDevice;
+    use crate::utils::FakeCommandRunner;
+
+    use hashbrown::HashMap;
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::{ExitStatus, Output};
+
+    // Used to create command output for test cases.
+    macro_rules! ethtool_template {
+        () => {
+            r#"
+	    NIC statistics:
+                 total_resets: 0
+                 reset_fail: 0
+                 tx_timeout: 0
+		 bw_in_allowance_exceeded: {}
+		 bw_out_allowance_exceeded: {}
+		 pps_allowance_exceeded: {}
+		 conntrack_allowance_exceeded: {}
+		 linklocal_allowance_exceeded: {}
+		 conntrack_allowance_available: {}
+		 ena_admin_q_out_of_space: 0
+		 ena_admin_q_no_completion: 0
+	    "#
+        };
+    }
+
+    #[test]
+    fn test_load_single_iface_stats() {
+        let mut fake_runner = FakeCommandRunner::new();
+        fake_runner.add_expectation(
+            "ethtool",
+            &["-S", "eth0"],
+            Ok(Output {
+                status: ExitStatus::from_raw(0),
+                stdout: format!(ethtool_template!(), 5, 6, 9, 7, 8, 10)
+                    .as_bytes()
+                    .to_vec(),
+                stderr: vec![],
+            }),
+        );
+
+        let expected_stats = NetworkInterfaceStats {
+            bw_in_allowance_exceeded: 5,
+            bw_out_allowance_exceeded: 6,
+            conntrack_allowance_exceeded: 7,
+            linklocal_allowance_exceeded: 8,
+            pps_allowance_exceeded: 9,
+            conntrack_allowance_available: 10,
+        };
+
+        let mut host_stats_provider = HostStatsProviderImpl {
+            network_interface_stats: HashMap::new(),
+            command_runner: Box::new(fake_runner.clone()),
+        };
+
+        let actual_stats = host_stats_provider.load_single_iface_stats("eth0").unwrap();
+        assert_eq!(actual_stats, expected_stats);
+        assert!(fake_runner.expectations.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_load_stats_from_incompatible_driver() {
+        let mut fake_runner = FakeCommandRunner::new();
+        fake_runner.add_expectation(
+            "ethtool",
+            &["-S", "eth0"],
+            Ok(Output {
+                status: ExitStatus::from_raw(0),
+                stdout: "NIC statistics from other driver".as_bytes().to_vec(),
+                stderr: vec![],
+            }),
+        );
+
+        let expected_stats = NetworkInterfaceStats {
+            bw_in_allowance_exceeded: 0,
+            bw_out_allowance_exceeded: 0,
+            conntrack_allowance_exceeded: 0,
+            linklocal_allowance_exceeded: 0,
+            pps_allowance_exceeded: 0,
+            conntrack_allowance_available: 0,
+        };
+
+        let mut host_stats_provider = HostStatsProviderImpl {
+            network_interface_stats: HashMap::new(),
+            command_runner: Box::new(fake_runner.clone()),
+        };
+
+        let actual_stats = host_stats_provider.load_single_iface_stats("eth0").unwrap();
+        assert_eq!(actual_stats, expected_stats);
+        assert!(fake_runner.expectations.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_get_host_stats() {
+        // Set our command expectations.
+        let mut fake_runner = FakeCommandRunner::new();
+        fake_runner.add_expectation(
+            "ethtool",
+            &["-S", "eth1"],
+            Ok(Output {
+                status: ExitStatus::from_raw(0),
+                stdout: format!(ethtool_template!(), 5, 6, 9, 7, 8, 10)
+                    .as_bytes()
+                    .to_vec(),
+                stderr: vec![],
+            }),
+        );
+        fake_runner.add_expectation(
+            "ethtool",
+            &["-S", "eth2"],
+            Ok(Output {
+                status: ExitStatus::from_raw(0),
+                stdout: format!(ethtool_template!(), 55, 66, 99, 77, 88, 1010)
+                    .as_bytes()
+                    .to_vec(),
+                stderr: vec![],
+            }),
+        );
+
+        // Build what we expect should be loaded.
+        let device1 = NetworkDevice {
+            interface_id: "id1".to_string(),
+            device_name: "eth1".to_string(),
+        };
+        let device2 = NetworkDevice {
+            interface_id: "id2".to_string(),
+            device_name: "eth2".to_string(),
+        };
+        let expected_stats1 = NetworkInterfaceStats {
+            bw_in_allowance_exceeded: 5,
+            bw_out_allowance_exceeded: 6,
+            conntrack_allowance_exceeded: 7,
+            linklocal_allowance_exceeded: 8,
+            pps_allowance_exceeded: 9,
+            conntrack_allowance_available: 10,
+        };
+        let expected_stats2 = NetworkInterfaceStats {
+            bw_in_allowance_exceeded: 55,
+            bw_out_allowance_exceeded: 66,
+            conntrack_allowance_exceeded: 77,
+            linklocal_allowance_exceeded: 88,
+            pps_allowance_exceeded: 99,
+            conntrack_allowance_available: 1010,
+        };
+
+        // Do work.
+        let mut host_stats_provider = HostStatsProviderImpl {
+            network_interface_stats: HashMap::new(),
+            command_runner: Box::new(fake_runner.clone()),
+        };
+        host_stats_provider.set_network_devices(&[device1.clone(), device2.clone()]);
+
+        // Validate stats initially loaded.
+        let mut expected_internal_stats = HashMap::<NetworkDevice, NetworkInterfaceStats>::new();
+        expected_internal_stats.insert(device1, expected_stats1);
+        expected_internal_stats.insert(device2, expected_stats2);
+        assert_eq!(
+            host_stats_provider.network_interface_stats,
+            expected_internal_stats
+        );
+
+        // Mimic an error for eth1 and the linklocal value changed for eth2.
+        fake_runner.add_expectation(
+            "ethtool",
+            &["-S", "eth1"],
+            Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "fake-error",
+            )),
+        );
+        fake_runner.add_expectation(
+            "ethtool",
+            &["-S", "eth2"],
+            Ok(Output {
+                status: ExitStatus::from_raw(0),
+                stdout: format!(ethtool_template!(), 55, 66, 99, 77, 89, 1010)
+                    .as_bytes()
+                    .to_vec(),
+                stderr: vec![],
+            }),
+        );
+        let mut expected_stats = HostStats {
+            interface_stats: vec![
+                // eth1 values show no change after command failure.
+                GroupedInterfaceStats {
+                    interface_id: "id1".to_string(),
+                    stats: NetworkInterfaceStats {
+                        conntrack_allowance_available: 10,
+                        ..Default::default()
+                    },
+                },
+                // eth2 values represent the diff on command success.
+                GroupedInterfaceStats {
+                    interface_id: "id2".to_string(),
+                    stats: NetworkInterfaceStats {
+                        linklocal_allowance_exceeded: 1,
+                        conntrack_allowance_available: 1010,
+                        ..Default::default()
+                    },
+                },
+            ],
+        };
+
+        // Do work again, and validate.
+        assert_eq!(
+            host_stats_provider.get_stats().interface_stats.sort(),
+            expected_stats.interface_stats.sort()
+        );
+        assert!(fake_runner.expectations.lock().unwrap().is_empty());
+    }
+}

--- a/nfm-controller/src/events/mod.rs
+++ b/nfm-controller/src/events/mod.rs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod event_filter;
+pub mod event_filter_top_loss;
+pub mod event_provider;
+pub mod event_provider_ebpf;
+pub mod host_stats_provider;
+pub mod nat_resolver;
+pub mod network_event;
+pub mod sock_cache;
+
+pub use sock_cache::{AggSockStats, SockCache, SockOperationResult, SockWrapper};

--- a/nfm-controller/src/events/nat_resolver.rs
+++ b/nfm-controller/src/events/nat_resolver.rs
@@ -1,0 +1,420 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::events::SockCache;
+use crate::events::SockOperationResult;
+use crate::utils::conntrack_listener::ConntrackProvider;
+use crate::utils::ConntrackListener;
+use nfm_common::SockContext;
+
+use hashbrown::HashMap;
+use log::error;
+use netlink_packet_netfilter::nfconntrack::nlas::ConnectionProperties;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+// We use a ring buffer of maps to maintain NAT mappings beyond a single aggregation cycle.  This
+// is because we're taking no reliance on which of our subsystems will be the first to see an event
+// for a new socket: eBPF sock_ops vs netlink conntrack.
+const RING_BUF_ENTRIES: usize = 3;
+
+pub trait NatResolver {
+    fn perform_aggregation_cycle(&mut self);
+    fn perform_eviction(&mut self);
+    fn get_beyond_nat_entry(&self, sock_context: &SockContext) -> Option<SockContext>;
+    fn store_beyond_nat_entries(&self, sock_cache: &mut SockCache) -> SockOperationResult;
+    fn num_entries(&self) -> usize;
+}
+
+#[derive(Clone, Default)]
+pub struct NatResolverNoOp;
+
+impl NatResolver for NatResolverNoOp {
+    fn perform_aggregation_cycle(&mut self) {}
+
+    fn perform_eviction(&mut self) {}
+
+    fn get_beyond_nat_entry(&self, _sock_context: &SockContext) -> Option<SockContext> {
+        None
+    }
+
+    fn store_beyond_nat_entries(&self, _sock_cache: &mut SockCache) -> SockOperationResult {
+        SockOperationResult::default()
+    }
+
+    fn num_entries(&self) -> usize {
+        0
+    }
+}
+
+pub struct NatResolverImpl {
+    conntrack_listener: Box<dyn ConntrackProvider>,
+    conntrack_ringbuf: [HashMap<ConnectionProperties, ConnectionProperties>; RING_BUF_ENTRIES],
+    ringbuf_index: usize,
+}
+
+impl NatResolver for NatResolverImpl {
+    fn num_entries(&self) -> usize {
+        self.conntrack_ringbuf.iter().map(|m| m.len()).sum()
+    }
+
+    fn perform_aggregation_cycle(&mut self) {
+        let new_entries = match self.conntrack_listener.get_new_entries() {
+            Ok(n) => n,
+            Err(error) => {
+                error!(error; "Failed to retrieve conntrack changes");
+                return;
+            }
+        };
+
+        let entry_cache = &mut self.conntrack_ringbuf[self.ringbuf_index];
+        for new_entry in new_entries.iter() {
+            // If the entry was not actually NAT'd, there's no need to store it.
+            if !new_entry.was_natd() {
+                continue;
+            }
+
+            // For locally-initiated connections, eBPF sock_ops sees the original flow, pre-NAT.
+            // For remote-initiated connections, eBPF sees the reply flow, post-NAT.  Hence, we key
+            // by both sides to allow for either lookup.
+            entry_cache.insert(new_entry.original, new_entry.reply);
+            entry_cache.insert(new_entry.reply, new_entry.original);
+        }
+    }
+
+    fn perform_eviction(&mut self) {
+        // Advance the head to where the tail currently is, then clear that slot.
+        self.ringbuf_index = (self.ringbuf_index + 1) % self.conntrack_ringbuf.len();
+        self.conntrack_ringbuf[self.ringbuf_index].clear();
+    }
+
+    // Gets a socket's properties as seen beyond NAT, meaning external to the local network
+    // namespace.
+    fn get_beyond_nat_entry(&self, sock_context: &SockContext) -> Option<SockContext> {
+        if sock_context.is_valid() {
+            let internal_info = Self::sock_context_to_egress_cxn_info(sock_context).unwrap();
+            for i in 0..self.conntrack_ringbuf.len() {
+                if let Some(external_info) = self.conntrack_ringbuf[i].get(&internal_info) {
+                    return Some(Self::ingress_cxn_info_to_sock_context(
+                        external_info,
+                        sock_context.is_client,
+                    ));
+                }
+            }
+        }
+
+        None
+    }
+
+    fn store_beyond_nat_entries(&self, sock_cache: &mut SockCache) -> SockOperationResult {
+        let mut result = SockOperationResult::default();
+
+        for (_key, sock_wrap) in sock_cache.iter_mut() {
+            if sock_wrap.context_external.is_none() {
+                match self.get_beyond_nat_entry(&sock_wrap.context) {
+                    Some(entry) => {
+                        sock_wrap.context_external = Some(entry);
+                        result.completed += 1;
+                    }
+                    _ => {
+                        result.partial += 1;
+                    }
+                }
+            }
+        }
+
+        result
+    }
+}
+
+impl NatResolverImpl {
+    pub fn initialize() -> Self {
+        Self {
+            conntrack_listener: Box::new(ConntrackListener::initialize()),
+            conntrack_ringbuf: std::array::from_fn(|_i| HashMap::new()),
+            ringbuf_index: 0,
+        }
+    }
+
+    fn sock_context_to_egress_cxn_info(
+        sock_context: &SockContext,
+    ) -> Result<ConnectionProperties, String> {
+        let (local_addr, remote_addr) = match sock_context.address_family as i32 {
+            libc::AF_INET => (
+                IpAddr::from(Ipv4Addr::from_bits(sock_context.local_ipv4)),
+                IpAddr::from(Ipv4Addr::from_bits(sock_context.remote_ipv4)),
+            ),
+            libc::AF_INET6 => (
+                IpAddr::from(Ipv6Addr::from(sock_context.local_ipv6)),
+                IpAddr::from(Ipv6Addr::from(sock_context.remote_ipv6)),
+            ),
+            _ => {
+                return Err(format!(
+                    "Unhandled address family: {} for sock_context={:?}",
+                    sock_context.address_family, sock_context,
+                ));
+            }
+        };
+        Ok(ConnectionProperties {
+            src_ip: local_addr,
+            dst_ip: remote_addr,
+            src_port: sock_context.local_port,
+            dst_port: sock_context.remote_port,
+            protocol: libc::IPPROTO_TCP.try_into().unwrap(),
+        })
+    }
+
+    fn ingress_cxn_info_to_sock_context(
+        cxn_info: &ConnectionProperties,
+        is_client: bool,
+    ) -> SockContext {
+        match (cxn_info.src_ip, cxn_info.dst_ip) {
+            (IpAddr::V4(src_addr), IpAddr::V4(dst_addr)) => SockContext {
+                local_ipv4: dst_addr.to_bits(),
+                remote_ipv4: src_addr.to_bits(),
+                local_port: cxn_info.dst_port,
+                remote_port: cxn_info.src_port,
+                address_family: libc::AF_INET.try_into().unwrap(),
+                is_client,
+                ..Default::default()
+            },
+            (IpAddr::V6(src_addr), IpAddr::V6(dst_addr)) => SockContext {
+                local_ipv6: dst_addr.octets(),
+                remote_ipv6: src_addr.octets(),
+                local_port: cxn_info.dst_port,
+                remote_port: cxn_info.src_port,
+                address_family: libc::AF_INET6.try_into().unwrap(),
+                is_client,
+                ..Default::default()
+            },
+            _ => panic!("Found NAT entry of differing IP families: {:?}", cxn_info),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::events::{nat_resolver::RING_BUF_ENTRIES, SockCache, SockOperationResult};
+    use crate::utils::conntrack_listener::{ConntrackEntry, ConntrackProvider};
+    use crate::{NatResolver, NatResolverImpl};
+    use nfm_common::{SockContext, SockKey};
+
+    use hashbrown::HashMap;
+    use netlink_packet_netfilter::nfconntrack::nlas::ConnectionProperties;
+    use std::collections::VecDeque;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::str::FromStr;
+
+    struct ConntrackListenerSeeded {
+        pub pending_replies: VecDeque<Vec<ConntrackEntry>>,
+    }
+
+    impl ConntrackProvider for ConntrackListenerSeeded {
+        fn get_new_entries(&mut self) -> Result<Vec<ConntrackEntry>, String> {
+            Ok(self.pending_replies.pop_front().unwrap())
+        }
+    }
+
+    fn seeded_nat_resolver(conntrack_listener: ConntrackListenerSeeded) -> NatResolverImpl {
+        NatResolverImpl {
+            conntrack_listener: Box::new(conntrack_listener),
+            conntrack_ringbuf: std::array::from_fn(|_i| HashMap::new()),
+            ringbuf_index: 0,
+        }
+    }
+
+    #[test]
+    fn test_nat_resolver_aggregation() {
+        // Mirror reflection means NAT was not applied.
+        let ct_entry1 = ConntrackEntry {
+            original: ConnectionProperties {
+                src_ip: IpAddr::from_str("1.2.3.4").unwrap(),
+                dst_ip: IpAddr::from_str("5.6.7.8").unwrap(),
+                src_port: 1234,
+                dst_port: 5678,
+                protocol: libc::IPPROTO_TCP as u8,
+            },
+            reply: ConnectionProperties {
+                src_ip: IpAddr::from_str("5.6.7.8").unwrap(),
+                dst_ip: IpAddr::from_str("1.2.3.4").unwrap(),
+                src_port: 5678,
+                dst_port: 1234,
+                protocol: libc::IPPROTO_TCP as u8,
+            },
+        };
+
+        // Change some reply values to represent NAT.
+        let mut ct_entry2 = ct_entry1.clone();
+        ct_entry2.reply.src_ip = IpAddr::from_str("9.10.11.12").unwrap();
+        ct_entry2.reply.src_port = 9876;
+
+        let conntrack_listener = ConntrackListenerSeeded {
+            pending_replies: VecDeque::from([vec![ct_entry1], vec![ct_entry2]]),
+        };
+        let mut nat_resolver = seeded_nat_resolver(conntrack_listener);
+
+        // After the first agg cycle, expect nothing cached.
+        nat_resolver.perform_aggregation_cycle();
+        assert_eq!(nat_resolver.num_entries(), 0);
+
+        // After the second agg cycle, expect a cache entry for each direction.
+        nat_resolver.perform_aggregation_cycle();
+        assert_eq!(nat_resolver.num_entries(), 2);
+
+        // Now try NAT resolution.
+        let sock_ctx = SockContext {
+            local_ipv4: Ipv4Addr::from_str("1.2.3.4").unwrap().to_bits(),
+            remote_ipv4: Ipv4Addr::from_str("5.6.7.8").unwrap().to_bits(),
+            local_ipv6: [0; 16],
+            remote_ipv6: [0; 16],
+            local_port: 1234,
+            remote_port: 5678,
+            address_family: libc::AF_INET.try_into().unwrap(),
+            is_client: true,
+            ..Default::default()
+        };
+        let actual_natd_ctx = nat_resolver.get_beyond_nat_entry(&sock_ctx).unwrap();
+        let expected_natd_ctx = SockContext {
+            local_ipv4: Ipv4Addr::from_str("1.2.3.4").unwrap().to_bits(),
+            remote_ipv4: Ipv4Addr::from_str("9.10.11.12").unwrap().to_bits(),
+            local_ipv6: [0; 16],
+            remote_ipv6: [0; 16],
+            local_port: 1234,
+            remote_port: 9876,
+            address_family: libc::AF_INET.try_into().unwrap(),
+            is_client: true,
+            ..Default::default()
+        };
+        assert_eq!(actual_natd_ctx, expected_natd_ctx);
+
+        // Test the resolver updating the sock cache.
+        let mut sock_cache = SockCache::new();
+        let sock_key: SockKey = 1979;
+        let now_us = 1997;
+        sock_cache.add_context(sock_key, sock_ctx, now_us);
+        let store_result = nat_resolver.store_beyond_nat_entries(&mut sock_cache);
+        assert_eq!(
+            store_result,
+            SockOperationResult {
+                completed: 1,
+                partial: 0,
+                failed: 0,
+            }
+        );
+        assert_eq!(
+            sock_cache.get(&sock_key).unwrap().context_external.unwrap(),
+            expected_natd_ctx
+        );
+
+        // After evicting everything, there's nothing more to resolve.
+        for _ in 0..RING_BUF_ENTRIES {
+            nat_resolver.perform_eviction();
+        }
+        assert!(nat_resolver.get_beyond_nat_entry(&sock_ctx).is_none());
+    }
+
+    #[test]
+    fn test_sock_context_to_egress_cxn_info_ipv4() {
+        let ctx = SockContext {
+            local_ipv4: Ipv4Addr::from_str("1.2.3.4").unwrap().to_bits(),
+            remote_ipv4: Ipv4Addr::from_str("5.6.7.8").unwrap().to_bits(),
+            local_ipv6: [0; 16],
+            remote_ipv6: [0; 16],
+            local_port: 99,
+            remote_port: 100,
+            address_family: libc::AF_INET.try_into().unwrap(),
+            is_client: true,
+            ..Default::default()
+        };
+        let expected_cxn_info = ConnectionProperties {
+            src_ip: IpAddr::from_str("1.2.3.4").unwrap(),
+            dst_ip: IpAddr::from_str("5.6.7.8").unwrap(),
+            src_port: 99,
+            dst_port: 100,
+            protocol: libc::IPPROTO_TCP.try_into().unwrap(),
+        };
+        let actual_cxn_info = NatResolverImpl::sock_context_to_egress_cxn_info(&ctx).unwrap();
+        assert_eq!(actual_cxn_info, expected_cxn_info);
+    }
+
+    #[test]
+    fn test_sock_context_to_egress_cxn_info_ipv6() {
+        let ctx = SockContext {
+            local_ipv4: 0,
+            remote_ipv4: 0,
+            local_ipv6: Ipv6Addr::from_str("fe80::1979:4bff:febb:da61")
+                .unwrap()
+                .octets(),
+            remote_ipv6: Ipv6Addr::from_str("fe80:2160::1997:4bff:febb:da61")
+                .unwrap()
+                .octets(),
+            local_port: 99,
+            remote_port: 100,
+            address_family: libc::AF_INET6.try_into().unwrap(),
+            is_client: true,
+            ..Default::default()
+        };
+        let expected_cxn_info = ConnectionProperties {
+            src_ip: IpAddr::from_str("fe80::1979:4bff:febb:da61").unwrap(),
+            dst_ip: IpAddr::from_str("fe80:2160::1997:4bff:febb:da61").unwrap(),
+            src_port: 99,
+            dst_port: 100,
+            protocol: libc::IPPROTO_TCP.try_into().unwrap(),
+        };
+        let actual_cxn_info = NatResolverImpl::sock_context_to_egress_cxn_info(&ctx).unwrap();
+        assert_eq!(actual_cxn_info, expected_cxn_info);
+    }
+
+    #[test]
+    fn test_ingress_cxn_info_tp_sock_context_ipv4() {
+        let cxn_info = ConnectionProperties {
+            src_ip: IpAddr::from_str("1.2.3.4").unwrap(),
+            dst_ip: IpAddr::from_str("5.6.7.8").unwrap(),
+            src_port: 99,
+            dst_port: 100,
+            protocol: libc::IPPROTO_TCP.try_into().unwrap(),
+        };
+        let is_client = true;
+        let expected_ctx = SockContext {
+            local_ipv4: Ipv4Addr::from_str("5.6.7.8").unwrap().to_bits(),
+            remote_ipv4: Ipv4Addr::from_str("1.2.3.4").unwrap().to_bits(),
+            local_ipv6: [0; 16],
+            remote_ipv6: [0; 16],
+            local_port: 100,
+            remote_port: 99,
+            address_family: libc::AF_INET.try_into().unwrap(),
+            is_client,
+            ..Default::default()
+        };
+        let actual_ctx = NatResolverImpl::ingress_cxn_info_to_sock_context(&cxn_info, is_client);
+        assert_eq!(actual_ctx, expected_ctx);
+    }
+
+    #[test]
+    fn test_ingress_cxn_info_tp_sock_context_ipv6() {
+        let cxn_info = ConnectionProperties {
+            src_ip: IpAddr::from_str("fe80::1979:4bff:febb:da61").unwrap(),
+            dst_ip: IpAddr::from_str("fe80:2160::1997:4bff:febb:da61").unwrap(),
+            src_port: 99,
+            dst_port: 100,
+            protocol: libc::IPPROTO_TCP.try_into().unwrap(),
+        };
+        let is_client = true;
+        let expected_ctx = SockContext {
+            local_ipv4: 0,
+            remote_ipv4: 0,
+            local_ipv6: Ipv6Addr::from_str("fe80:2160::1997:4bff:febb:da61")
+                .unwrap()
+                .octets(),
+            remote_ipv6: Ipv6Addr::from_str("fe80::1979:4bff:febb:da61")
+                .unwrap()
+                .octets(),
+            local_port: 100,
+            remote_port: 99,
+            address_family: libc::AF_INET6.try_into().unwrap(),
+            is_client,
+            ..Default::default()
+        };
+        let actual_ctx = NatResolverImpl::ingress_cxn_info_to_sock_context(&cxn_info, is_client);
+        assert_eq!(actual_ctx, expected_ctx);
+    }
+}

--- a/nfm-controller/src/events/network_event.rs
+++ b/nfm-controller/src/events/network_event.rs
@@ -1,0 +1,725 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{add_histogram_to_report, utils::report::to_value_pairs};
+use crate::{
+    kubernetes::flow_metadata::FlowMetadata,
+    reports::report::{MetricHistogram, ReportValue},
+};
+use nfm_common::{
+    network::{SockContext, SockStats, AF_INET, AF_INET6},
+    MinNonZero, SockStateFlags,
+};
+
+use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
+use std::{
+    convert::TryFrom,
+    fmt,
+    hash::Hash,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+};
+
+pub const ELIDED_PORT: u16 = 0;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize)]
+pub enum InetProtocol {
+    ANY,
+    TCP,
+    UDP,
+}
+
+// Represents the properties by which flows are grouped. Properties aggregated across carry their
+// empty value.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd)]
+pub struct FlowProperties {
+    pub protocol: InetProtocol,
+    pub local_address: IpAddr,
+    pub remote_address: IpAddr,
+    pub local_port: u16,
+    pub remote_port: u16,
+    pub kubernetes_metadata: Option<FlowMetadata>,
+}
+
+impl FlowProperties {
+    pub fn enumerate(&self) -> Vec<(String, ReportValue)> {
+        let mut values = to_value_pairs(self);
+        if let Some(metadata) = self.kubernetes_metadata.as_ref() {
+            values.extend(metadata.enumerate());
+        }
+        values
+    }
+
+    // Returns true if this flow is an aggregation of many local socket connections towards a single remote socket
+    // Or, if the local party (this host) is the initiator of this flow. Check BPF_SOCK_OPS_TCP_CONNECT_CB event for details.
+    pub fn is_client_flow(&self) -> bool {
+        self.local_port == ELIDED_PORT
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, PartialOrd, Serialize)]
+pub struct NetworkStats {
+    // These are levels that represent states at a single point in time.
+    pub sockets_connecting: u32,
+    pub sockets_established: u32,
+    pub sockets_closing: u32,
+    pub sockets_closed: u32,
+
+    // These are counters that accumulate throughout a publishing window.
+    pub sockets_completed: u32,
+    pub severed_connect: u32,
+    pub severed_establish: u32,
+
+    pub connect_attempts: u32,
+    pub bytes_received: u64,
+    pub bytes_delivered: u64,
+    pub segments_received: u64,
+    pub segments_delivered: u64,
+
+    pub retrans_syn: u32,
+    pub retrans_est: u32,
+    pub retrans_close: u32,
+
+    pub rtos_syn: u32,
+    pub rtos_est: u32,
+    pub rtos_close: u32,
+
+    // These are timing statistics based on events across sockets within the publishing window.
+    pub connect_us: MetricHistogram,
+    pub rtt_us: MetricHistogram,
+    pub rtt_smoothed_us: MetricHistogram,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
+pub struct AggregateResults {
+    // The properties by which flows have been grouped to perform aggregation.
+    pub flow: FlowProperties,
+
+    // Statistic values from aggregating over all flows matching the above flow properties.
+    pub stats: NetworkStats,
+}
+
+impl NetworkStats {
+    pub fn total_bytes(&self) -> u64 {
+        self.bytes_received.saturating_add(self.bytes_delivered)
+    }
+
+    pub fn retrans_total(&self) -> u32 {
+        self.retrans_syn
+            .saturating_add(self.retrans_est)
+            .saturating_add(self.retrans_close)
+    }
+
+    pub fn rtos_total(&self) -> u32 {
+        self.rtos_syn
+            .saturating_add(self.rtos_est)
+            .saturating_add(self.rtos_close)
+    }
+
+    pub fn quantify_loss(&self) -> u32 {
+        const SCALE_FACTOR: u32 = 2;
+        self.retrans_total()
+            .saturating_add(self.rtos_total().saturating_mul(SCALE_FACTOR))
+            .saturating_add(
+                (self.severed_connect.saturating_add(self.severed_establish))
+                    .saturating_mul(SCALE_FACTOR * SCALE_FACTOR),
+            )
+    }
+
+    pub fn enumerate(&self) -> Vec<(String, ReportValue)> {
+        let mut report = to_value_pairs(self);
+        add_histogram_to_report!(self, connect_us, report);
+        add_histogram_to_report!(self, rtt_us, report);
+        add_histogram_to_report!(self, rtt_smoothed_us, report);
+
+        report
+    }
+
+    // Adds a socket's stats to a flow's stats.
+    pub fn add_from(&mut self, sock_stats: &SockStats) {
+        self.update_sock_counters(sock_stats);
+
+        // We're aggregating across sockets into flows, so we must be sure to sum even across
+        // fields that are cumulative on the socket.
+        self.connect_attempts = self
+            .connect_attempts
+            .saturating_add(sock_stats.connect_attempts.into());
+        self.bytes_received = self
+            .bytes_received
+            .saturating_add(sock_stats.bytes_received);
+        self.bytes_delivered = self
+            .bytes_delivered
+            .saturating_add(sock_stats.bytes_delivered);
+        self.segments_received = self
+            .segments_received
+            .saturating_add(sock_stats.segments_received.into());
+        self.segments_delivered = self
+            .segments_delivered
+            .saturating_add(sock_stats.segments_delivered.into());
+
+        self.retrans_syn = self.retrans_syn.saturating_add(sock_stats.retrans_syn);
+        self.retrans_est = self.retrans_est.saturating_add(sock_stats.retrans_est);
+        self.retrans_close = self.retrans_close.saturating_add(sock_stats.retrans_close);
+
+        self.rtos_syn = self.rtos_syn.saturating_add(sock_stats.rtos_syn);
+        self.rtos_est = self.rtos_est.saturating_add(sock_stats.rtos_est);
+        self.rtos_close = self.rtos_close.saturating_add(sock_stats.rtos_close);
+
+        // Carry forward timing measurements only if the socket actually saw their corresponding
+        // events during this period.
+        if sock_stats.connect_successes > 0 {
+            if let Some(connect_us) = sock_stats.connect_us() {
+                self.connect_us.count = self
+                    .connect_us
+                    .count
+                    .saturating_add(sock_stats.connect_successes.into());
+                self.connect_us.min = self.connect_us.min.min_non_zero(connect_us);
+                self.connect_us.max = self.connect_us.max.max(connect_us);
+                self.connect_us.sum = self.connect_us.sum.saturating_add(connect_us.into());
+            }
+        }
+        if sock_stats.rtt_count > 0 {
+            // We're about to add one new RTT meaurement to our sum, hence the count of RTTs
+            // sampled into this flow will rise by one.
+            let rtt_count = 1;
+
+            if sock_stats.rtt_latest_us > 0 {
+                self.rtt_us.count = self.rtt_us.count.saturating_add(rtt_count);
+                self.rtt_us.min = self.rtt_us.min.min_non_zero(sock_stats.rtt_latest_us);
+                self.rtt_us.max = self.rtt_us.max.max(sock_stats.rtt_latest_us);
+                self.rtt_us.sum = self
+                    .rtt_us
+                    .sum
+                    .saturating_add(sock_stats.rtt_latest_us.into());
+            }
+            if sock_stats.rtt_smoothed_us > 0 {
+                self.rtt_smoothed_us.count = self.rtt_smoothed_us.count.saturating_add(rtt_count);
+                self.rtt_smoothed_us.min = self
+                    .rtt_smoothed_us
+                    .min
+                    .min_non_zero(sock_stats.rtt_smoothed_us);
+                self.rtt_smoothed_us.max = self.rtt_smoothed_us.max.max(sock_stats.rtt_smoothed_us);
+                self.rtt_smoothed_us.sum = self
+                    .rtt_smoothed_us
+                    .sum
+                    .saturating_add(sock_stats.rtt_smoothed_us.into());
+            }
+        }
+    }
+
+    pub fn clear_levels(&mut self) {
+        self.sockets_connecting = 0;
+        self.sockets_established = 0;
+        self.sockets_closing = 0;
+        self.sockets_closed = 0;
+    }
+
+    pub fn update_sock_counters(&mut self, sock_stats: &SockStats) {
+        if !sock_stats
+            .state_flags
+            .contains(SockStateFlags::STARTED_CLOSURE)
+        {
+            if sock_stats
+                .state_flags
+                .contains(SockStateFlags::ENTERED_ESTABLISH)
+            {
+                self.sockets_established += 1;
+            } else {
+                self.sockets_connecting += 1;
+            }
+        } else {
+            if sock_stats.state_flags.contains(SockStateFlags::CLOSED) {
+                self.sockets_closed += 1;
+            } else {
+                self.sockets_closing += 1;
+            }
+            if sock_stats
+                .state_flags
+                .contains(SockStateFlags::TERMINATED_FROM_SYN)
+            {
+                self.severed_connect += 1;
+            } else if sock_stats
+                .state_flags
+                .contains(SockStateFlags::TERMINATED_FROM_EST)
+            {
+                self.severed_establish += 1;
+            }
+        }
+    }
+}
+
+impl TryFrom<&SockContext> for FlowProperties {
+    type Error = String;
+
+    fn try_from(context: &SockContext) -> Result<FlowProperties, Self::Error> {
+        let (local_address, remote_address) = match context.address_family {
+            AF_INET => (
+                IpAddr::V4(Ipv4Addr::from(context.local_ipv4)),
+                IpAddr::V4(Ipv4Addr::from(context.remote_ipv4)),
+            ),
+            AF_INET6 => (
+                IpAddr::V6(Ipv6Addr::from(context.local_ipv6)),
+                IpAddr::V6(Ipv6Addr::from(context.remote_ipv6)),
+            ),
+            _ => {
+                return Err(format!(
+                    "Unsupported address family: {}",
+                    context.address_family,
+                ));
+            }
+        };
+
+        // We aggregate sockets into 4-tuples (across client ports), hence the client port is elided.
+        let (local_port, remote_port) = if context.is_client {
+            (ELIDED_PORT, context.remote_port)
+        } else {
+            (context.local_port, ELIDED_PORT)
+        };
+
+        Ok(FlowProperties {
+            protocol: InetProtocol::TCP,
+            local_address,
+            remote_address,
+            local_port,
+            remote_port,
+            kubernetes_metadata: None,
+        })
+    }
+}
+
+impl Serialize for FlowProperties {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("FlowProperties", 5)?;
+        state.serialize_field("protocol", &self.protocol.to_string())?;
+        state.serialize_field("local_address", &self.local_address.to_string())?;
+        state.serialize_field("remote_address", &self.remote_address.to_string())?;
+        state.serialize_field("local_port", &self.local_port)?;
+        state.serialize_field("remote_port", &self.remote_port)?;
+        state.end()
+    }
+}
+
+impl fmt::Display for InetProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            InetProtocol::ANY => write!(f, "ANY"),
+            InetProtocol::TCP => write!(f, "TCP"),
+            InetProtocol::UDP => write!(f, "UDP"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::reports::report::MetricHistogram;
+    use nfm_common::network::{SockStateFlags, SockStats};
+
+    #[test]
+    fn test_from_sock_context_v4() {
+        let context = SockContext {
+            address_family: AF_INET,
+            local_ipv4: 16909060,
+            remote_ipv4: 16909060,
+            local_port: 9,
+            remote_port: 10,
+            is_client: true,
+            local_ipv6: [0; 16],
+            remote_ipv6: [0; 16],
+            ..Default::default()
+        };
+        let properties = FlowProperties::try_from(&context).unwrap();
+        assert_eq!(
+            properties,
+            FlowProperties {
+                protocol: InetProtocol::TCP,
+                local_address: IpAddr::V4(Ipv4Addr::from([1, 2, 3, 4])),
+                remote_address: IpAddr::V4(Ipv4Addr::from([1, 2, 3, 4])),
+                local_port: ELIDED_PORT,
+                remote_port: 10,
+                kubernetes_metadata: None,
+            }
+        );
+
+        assert!(properties.is_client_flow() == true);
+    }
+
+    #[test]
+    fn test_from_sock_context_v6() {
+        let context = SockContext {
+            address_family: AF_INET6,
+            local_ipv6: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            remote_ipv6: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            local_port: 9,
+            remote_port: 10,
+            is_client: true,
+            local_ipv4: 0,
+            remote_ipv4: 0,
+            ..Default::default()
+        };
+        let properties = FlowProperties::try_from(&context).unwrap();
+        assert_eq!(
+            properties,
+            FlowProperties {
+                protocol: InetProtocol::TCP,
+                local_address: IpAddr::V6(Ipv6Addr::from([
+                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+                ])),
+                remote_address: IpAddr::V6(Ipv6Addr::from([
+                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+                ])),
+                local_port: ELIDED_PORT,
+                remote_port: 10,
+                kubernetes_metadata: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_from_sock_context_invalid_address_family() {
+        let context = SockContext {
+            address_family: 99, // Any
+            local_ipv6: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            remote_ipv6: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            local_port: 9,
+            remote_port: 10,
+            is_client: true,
+            local_ipv4: 0,
+            remote_ipv4: 0,
+            ..Default::default()
+        };
+        assert!(FlowProperties::try_from(&context).is_err());
+    }
+
+    #[test]
+    fn test_sock_to_flow_rtt_add() {
+        // No RTT measurements taken.
+        let mut net_stats = NetworkStats {
+            rtt_us: MetricHistogram {
+                count: 0,
+                min: 0,
+                max: 0,
+                sum: 0,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: 0,
+                min: 0,
+                max: 0,
+                sum: 0,
+            },
+            ..Default::default()
+        };
+        let sock_stats = SockStats {
+            rtt_count: 0,
+            rtt_latest_us: 0,
+            rtt_smoothed_us: 0,
+            ..Default::default()
+        };
+
+        let expected_net_stats = NetworkStats {
+            sockets_connecting: 1,
+            rtt_us: MetricHistogram {
+                count: 0,
+                min: 0,
+                max: 0,
+                sum: 0,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: 0,
+                min: 0,
+                max: 0,
+                sum: 0,
+            },
+            ..Default::default()
+        };
+        net_stats.add_from(&sock_stats);
+        assert_eq!(net_stats, expected_net_stats);
+
+        // RTTs with no count.
+        let sock_stats = SockStats {
+            rtt_count: 0,
+            rtt_latest_us: 1,
+            rtt_smoothed_us: 2,
+            ..Default::default()
+        };
+        let expected_net_stats = NetworkStats {
+            sockets_connecting: 2,
+            rtt_us: MetricHistogram {
+                count: 0,
+                min: 0,
+                max: 0,
+                sum: 0,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: 0,
+                min: 0,
+                max: 0,
+                sum: 0,
+            },
+            ..Default::default()
+        };
+        net_stats.add_from(&sock_stats);
+        assert_eq!(net_stats, expected_net_stats);
+
+        // A new min and max.
+        let sock_stats = SockStats {
+            rtt_count: 1,
+            rtt_latest_us: 10,
+            rtt_smoothed_us: 3,
+            ..Default::default()
+        };
+        let expected_net_stats = NetworkStats {
+            sockets_connecting: 3,
+            rtt_us: MetricHistogram {
+                count: 1,
+                min: 10,
+                max: 10,
+                sum: 10,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: 1,
+                min: 3,
+                max: 3,
+                sum: 3,
+            },
+            ..Default::default()
+        };
+        net_stats.add_from(&sock_stats);
+        assert_eq!(net_stats, expected_net_stats);
+
+        // A new min, but no smoothed measurement.  Notice that multiple RTT occurrences increase
+        // our sampled count by just 1.
+        let sock_stats = SockStats {
+            rtt_count: 12,
+            rtt_latest_us: 5,
+            ..Default::default()
+        };
+        let expected_net_stats = NetworkStats {
+            sockets_connecting: 4,
+            rtt_us: MetricHistogram {
+                count: 2,
+                min: 5,
+                max: 10,
+                sum: 15,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: 1,
+                min: 3,
+                max: 3,
+                sum: 3,
+            },
+            ..Default::default()
+        };
+        net_stats.add_from(&sock_stats);
+        assert_eq!(net_stats, expected_net_stats);
+
+        // A new max with multiple observations, leading to one sampled.
+        let sock_stats = SockStats {
+            rtt_count: 29,
+            rtt_latest_us: 20,
+            rtt_smoothed_us: 25,
+            ..Default::default()
+        };
+        let expected_net_stats = NetworkStats {
+            sockets_connecting: 5,
+            rtt_us: MetricHistogram {
+                count: 3,
+                min: 5,
+                max: 20,
+                sum: 35,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: 2,
+                min: 3,
+                max: 25,
+                sum: 28,
+            },
+            ..Default::default()
+        };
+        net_stats.add_from(&sock_stats);
+        assert_eq!(net_stats, expected_net_stats);
+    }
+
+    #[test]
+    fn test_network_stats_add_from() {
+        let mut net_stats = NetworkStats {
+            sockets_connecting: 20,
+            sockets_established: 60,
+            sockets_closing: 5,
+            sockets_closed: 15,
+
+            sockets_completed: 9,
+            severed_connect: 4,
+            severed_establish: 2,
+
+            connect_attempts: 56,
+            bytes_received: 59,
+            bytes_delivered: 61,
+            segments_received: 73,
+            segments_delivered: 79,
+
+            connect_us: MetricHistogram {
+                count: 57,
+                min: 20,
+                max: 25,
+                sum: 1250,
+            },
+            rtt_us: MetricHistogram {
+                count: 11,
+                min: 29,
+                max: 31,
+                sum: 350,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: 11,
+                min: 50,
+                max: 100,
+                sum: 1000,
+            },
+
+            retrans_syn: 50,
+            retrans_est: 51,
+            retrans_close: 52,
+            rtos_syn: 53,
+            rtos_est: 54,
+            rtos_close: 55,
+        };
+        let sock_stats = SockStats {
+            last_touched_us: 451,
+            connect_start_us: 101,
+            connect_end_us: 127,
+            bytes_received: 67,
+            bytes_delivered: 71,
+            segments_received: 83,
+            segments_delivered: 89,
+            state_flags: SockStateFlags::ENTERED_ESTABLISH
+                | SockStateFlags::STARTED_CLOSURE
+                | SockStateFlags::CLOSED,
+
+            rtt_count: 3,
+            rtt_latest_us: 25,
+            rtt_smoothed_us: 40,
+
+            retrans_syn: 10,
+            retrans_est: 1,
+            retrans_close: 2,
+            rtos_syn: 3,
+            rtos_est: 4,
+            rtos_close: 5,
+
+            connect_attempts: 6,
+            connect_successes: 7,
+
+            ..Default::default()
+        };
+
+        let expected = NetworkStats {
+            sockets_connecting: 20,
+            sockets_established: 60,
+            sockets_closing: 5,
+            sockets_closed: 16,
+
+            sockets_completed: 9,
+            severed_connect: 4,
+            severed_establish: 2,
+
+            connect_attempts: 62,
+            bytes_received: 126,
+            bytes_delivered: 132,
+            segments_received: 156,
+            segments_delivered: 168,
+
+            connect_us: MetricHistogram {
+                count: 64,
+                min: 20,
+                max: 26,
+                sum: 1276,
+            },
+            rtt_us: MetricHistogram {
+                count: 12,
+                min: 25,
+                max: 31,
+                sum: 375,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: 12,
+                min: 40,
+                max: 100,
+                sum: 1040,
+            },
+
+            retrans_syn: 60,
+            retrans_est: 52,
+            retrans_close: 54,
+            rtos_syn: 56,
+            rtos_est: 58,
+            rtos_close: 60,
+        };
+
+        net_stats.add_from(&sock_stats);
+        assert_eq!(net_stats, expected);
+
+        net_stats.add_from(&sock_stats);
+        assert_eq!(
+            net_stats.bytes_delivered,
+            sock_stats.bytes_delivered * 2 + 61
+        );
+        assert_eq!(net_stats.connect_us.max, 26);
+    }
+
+    #[test]
+    fn test_quantify_loss() {
+        let mut stats = NetworkStats::default();
+        assert_eq!(stats.quantify_loss(), 0);
+
+        stats.bytes_received = 100;
+        assert_eq!(stats.quantify_loss(), 0);
+
+        stats.rtt_us.count = 50;
+        assert_eq!(stats.quantify_loss(), 0);
+
+        stats.retrans_syn = 1;
+        let loss_a1 = stats.quantify_loss();
+
+        stats.retrans_syn = 0;
+        stats.retrans_est = 1;
+        let loss_a2 = stats.quantify_loss();
+
+        stats.retrans_est = 0;
+        stats.retrans_close = 1;
+        let loss_a3 = stats.quantify_loss();
+
+        stats.retrans_close = 0;
+        stats.rtos_syn = 1;
+        let loss_b1 = stats.quantify_loss();
+
+        stats.rtos_syn = 0;
+        stats.rtos_est = 1;
+        let loss_b2 = stats.quantify_loss();
+
+        stats.rtos_est = 0;
+        stats.rtos_close = 1;
+        let loss_b3 = stats.quantify_loss();
+
+        stats.rtos_close = 0;
+        stats.severed_connect = 1;
+        let loss_c = stats.quantify_loss();
+
+        stats.retrans_syn = 1;
+        stats.rtos_syn = 1;
+        stats.severed_connect = 1;
+        let loss_d = stats.quantify_loss();
+
+        assert!(loss_d > loss_c);
+        assert!(loss_c > loss_b1);
+        assert!(loss_b1 > loss_a1);
+
+        assert_eq!(loss_a2, loss_a1);
+        assert_eq!(loss_a3, loss_a1);
+        assert_eq!(loss_b2, loss_b1);
+        assert_eq!(loss_b3, loss_b1);
+    }
+}

--- a/nfm-controller/src/events/sock_cache.rs
+++ b/nfm-controller/src/events/sock_cache.rs
@@ -1,0 +1,941 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use nfm_common::{
+    constants::MAX_ENTRIES_SK_PROPS_HI,
+    network::{SockContext, SockKey, SockStats},
+};
+
+use hashbrown::{hash_map::Entry, HashMap};
+use serde::Serialize;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct AggSockStats {
+    pub stats: SockStats,
+    pub cpus: Vec<u32>,
+}
+
+#[derive(Debug, Default, Eq, PartialEq, Serialize)]
+pub struct SockWrapper {
+    pub context: SockContext,
+    pub context_external: Option<SockContext>,
+    pub agg_stats: AggSockStats,
+    pub is_stale: bool,
+    pub is_complete: bool,
+}
+
+impl SockWrapper {
+    pub fn new(context: SockContext, agg_stats: AggSockStats) -> Self {
+        Self {
+            context,
+            context_external: None,
+            agg_stats,
+            is_stale: false,
+            is_complete: false,
+        }
+    }
+
+    pub fn update_context(&mut self, context: SockContext, now_us: u64) {
+        self.context = context;
+        self.context_external = None;
+        self.agg_stats.stats.last_touched_us = now_us;
+        self.is_stale = false;
+        self.is_complete = false;
+    }
+
+    pub fn update_status(&mut self, staleness_timestamp: u64) {
+        self.is_complete = self.agg_stats.stats.is_closed() && self.context.is_valid();
+        self.is_stale = self.agg_stats.stats.last_touched_us <= staleness_timestamp;
+    }
+
+    pub fn should_evict(&self) -> bool {
+        self.is_complete || self.is_stale
+    }
+}
+
+#[derive(Debug, Default, Eq, PartialEq, Serialize)]
+pub struct SockOperationResult {
+    pub completed: u64,
+    pub partial: u64,
+    pub failed: u64,
+}
+
+impl SockOperationResult {
+    pub fn add(&mut self, other: &Self) {
+        self.completed += other.completed;
+        self.partial += other.partial;
+        self.failed += other.failed;
+    }
+}
+
+#[derive(Default)]
+pub struct SockCache {
+    cache: HashMap<SockKey, SockWrapper>,
+    max_sock_entries: usize,
+}
+
+impl SockCache {
+    pub fn new() -> Self {
+        Self::with_max_entries(MAX_ENTRIES_SK_PROPS_HI.try_into().unwrap())
+    }
+
+    pub fn with_max_entries(max_sock_entries: usize) -> Self {
+        Self {
+            cache: HashMap::new(),
+            max_sock_entries,
+        }
+    }
+
+    pub fn max_entries(&self) -> usize {
+        self.max_sock_entries
+    }
+
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.cache.is_empty()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&SockKey, &mut SockWrapper)> {
+        self.cache.iter_mut()
+    }
+
+    pub fn get(&self, sock_key: &SockKey) -> Option<&SockWrapper> {
+        self.cache.get(sock_key)
+    }
+
+    pub fn get_last_touched(&self, sock_key: &SockKey) -> u64 {
+        if let Some(sock) = self.cache.get(sock_key) {
+            sock.agg_stats.stats.last_touched_us
+        } else {
+            0
+        }
+    }
+
+    // Gets the min, max, and avg number of CPUs handling each socket.
+    pub fn num_cpus(&self) -> (u64, u64, f64) {
+        let mut min: u64 = 0;
+        let mut max: u64 = 0;
+        let mut sum: u64 = 0;
+
+        for wrapper in self.cache.values() {
+            let num: u64 = 1u64.max(wrapper.agg_stats.cpus.len().try_into().unwrap());
+            sum += num;
+            if num > max {
+                max = num;
+            }
+            if num < min || min == 0 {
+                min = num;
+            }
+        }
+        let len = self.len();
+        let avg: f64 = if len > 0 {
+            (sum as f64) / (len as f64)
+        } else {
+            0.0
+        };
+
+        (min, max, avg)
+    }
+
+    // Adds a socket context to this cache.
+    pub fn add_context(
+        &mut self,
+        sock_key: SockKey,
+        sock_context: SockContext,
+        now_us: u64,
+    ) -> SockOperationResult {
+        let mut result = SockOperationResult::default();
+        let num_socks = self.len();
+        let cache_entry = self.cache.entry(sock_key);
+        match cache_entry {
+            Entry::Occupied(o) => {
+                let wrapper = o.into_mut();
+                wrapper.update_context(sock_context, now_us);
+                result.partial += 1;
+            }
+            Entry::Vacant(v) => {
+                if num_socks < self.max_sock_entries {
+                    let agg_stat = SockStats {
+                        last_touched_us: now_us,
+                        ..Default::default()
+                    };
+                    v.insert(SockWrapper::new(
+                        sock_context,
+                        AggSockStats {
+                            stats: agg_stat,
+                            cpus: Vec::new(),
+                        },
+                    ));
+                    result.completed += 1;
+                } else {
+                    result.failed += 1;
+                }
+            }
+        };
+
+        result
+    }
+
+    // Stores the latest stats into this cache, and places the deltas compared to prior entries
+    // back into the supplied map.
+    pub fn update_stats_and_get_deltas(
+        &mut self,
+        incoming_stats: &mut HashMap<SockKey, AggSockStats>,
+        staleness_timestamp: u64,
+    ) -> SockOperationResult {
+        let mut result = SockOperationResult::default();
+
+        // This iterative update approach frees us from the memory hit of copying the entire map to
+        // produce deltas.
+        for (sock_key, incoming) in incoming_stats.iter_mut() {
+            let num_socks = self.len();
+            let cache_entry = self.cache.entry(*sock_key);
+
+            match cache_entry {
+                Entry::Occupied(o) => {
+                    let wrapper = o.into_mut();
+                    let delta = incoming.stats.subtract(&wrapper.agg_stats.stats);
+
+                    // Store the latest values in cache.
+                    wrapper.agg_stats.stats = incoming.stats;
+                    wrapper.agg_stats.cpus.clear();
+                    incoming
+                        .cpus
+                        .iter()
+                        .for_each(|cpu| wrapper.agg_stats.cpus.push(*cpu));
+                    wrapper.update_status(staleness_timestamp);
+
+                    // Store the delta onto the incoming structure.
+                    incoming.stats = delta;
+                    result.completed += 1;
+                }
+                Entry::Vacant(v) => {
+                    if num_socks < self.max_sock_entries {
+                        // Leave values on the incoming structure unchanged, as the whole amount is a delta.
+                        let mut wrapper = SockWrapper::new(
+                            SockContext::default(),
+                            AggSockStats {
+                                stats: incoming.stats,
+                                cpus: incoming.cpus.clone(),
+                            },
+                        );
+                        wrapper.update_status(staleness_timestamp);
+                        v.insert(wrapper);
+
+                        result.partial += 1;
+                    } else {
+                        result.failed += 1;
+                    }
+                }
+            };
+        }
+
+        result
+    }
+
+    // Evicts all closed and stale sockets from this cache.  Returns a map of all evicted entries,
+    // and the count of those that were stale.
+    pub fn perform_eviction(&mut self) -> (HashMap<SockKey, SockWrapper>, u64) {
+        let mut num_stale: u64 = 0;
+
+        let socks_evicted = self
+            .cache
+            .extract_if(|_key, sock_wrap| {
+                if sock_wrap.is_stale {
+                    num_stale += 1;
+                }
+
+                sock_wrap.should_evict()
+            })
+            .collect();
+
+        (socks_evicted, num_stale)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::events::{AggSockStats, SockCache, SockOperationResult};
+    use nfm_common::network::{SockContext, SockKey, SockStateFlags, SockStats, AF_INET, AF_INET6};
+
+    use hashbrown::HashMap;
+
+    const STALENESS_TS: u64 = 0;
+
+    #[test]
+    fn test_sock_cache_add_context_new() {
+        let sock_key: SockKey = 55;
+        let context = SockContext {
+            address_family: AF_INET,
+            local_ipv4: 99,
+            ..Default::default()
+        };
+        let now_us = 100;
+
+        let mut sock_cache = SockCache::new();
+        let result = sock_cache.add_context(sock_key, context, now_us);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: 1,
+                partial: 0,
+                failed: 0,
+            }
+        );
+
+        let wrapper = sock_cache.get(&sock_key).unwrap();
+        assert_eq!(wrapper.context, context);
+        assert_eq!(
+            wrapper.agg_stats,
+            AggSockStats {
+                stats: SockStats {
+                    last_touched_us: now_us,
+                    ..Default::default()
+                },
+                cpus: vec![],
+            }
+        );
+        assert_eq!(sock_cache.len(), 1);
+
+        let (min, max, avg) = sock_cache.num_cpus();
+        assert_eq!(min, 1);
+        assert_eq!(max, 1);
+        assert!((1.0 - avg).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_sock_cache_add_context_pre_existing() {
+        // Add an initial context.
+        let sock_key: SockKey = 55;
+        let context = SockContext {
+            address_family: AF_INET,
+            local_ipv4: 99,
+            ..Default::default()
+        };
+        let mut now_us = 100;
+        let mut sock_cache = SockCache::new();
+        sock_cache.add_context(sock_key, context, now_us);
+
+        // Add a second context and verify it takes precedence.
+        let context2 = SockContext {
+            address_family: AF_INET,
+            local_ipv4: context.local_ipv4 * 2,
+            ..Default::default()
+        };
+        now_us *= 2;
+
+        let result = sock_cache.add_context(sock_key, context2, now_us);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: 0,
+                partial: 1,
+                failed: 0,
+            }
+        );
+        let wrapper = sock_cache.get(&sock_key).unwrap();
+        assert_eq!(wrapper.context, context2);
+        assert_eq!(
+            wrapper.agg_stats,
+            AggSockStats {
+                stats: SockStats {
+                    last_touched_us: now_us,
+                    ..Default::default()
+                },
+                cpus: vec![],
+            }
+        );
+        assert_eq!(sock_cache.len(), 1);
+    }
+
+    #[test]
+    fn test_sock_cache_add_context_too_many() {
+        let context = SockContext {
+            address_family: AF_INET6,
+            local_port: 217,
+            ..Default::default()
+        };
+        let now_us = 100;
+
+        // Fill up the sock cache.
+        let mut sock_cache = SockCache::new();
+        for sock_key in 0..sock_cache.max_entries() {
+            let result = sock_cache.add_context(sock_key as SockKey, context, now_us);
+            assert_eq!(
+                result,
+                SockOperationResult {
+                    completed: 1,
+                    partial: 0,
+                    failed: 0,
+                }
+            );
+        }
+        assert_eq!(sock_cache.len(), sock_cache.max_entries());
+
+        // Now try to add beyond the limit.
+        for sock_key in sock_cache.max_entries()..sock_cache.max_entries() + 10 {
+            let result = sock_cache.add_context(sock_key as SockKey, context, now_us);
+            assert_eq!(
+                result,
+                SockOperationResult {
+                    completed: 0,
+                    partial: 0,
+                    failed: 1,
+                }
+            );
+        }
+        assert_eq!(sock_cache.len(), sock_cache.max_entries());
+    }
+
+    #[test]
+    fn test_get_sock_deltas_empty() {
+        let mut sock_cache = SockCache::new();
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+
+        // On empty should yield nothing.
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, STALENESS_TS);
+        assert_eq!(result, SockOperationResult::default());
+        assert!(sock_stream.is_empty());
+        assert!(sock_cache.is_empty());
+    }
+
+    #[test]
+    fn test_get_sock_deltas_all_new_stats() {
+        let mut sock_cache = SockCache::new();
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+
+        // Create a slew of sockets in the incoming stream.
+        let sock_keys: Vec<u64> = vec![99, 101, 4, 55, 19, 79];
+        let now_us = 2049;
+        for sock_key in sock_keys.iter() {
+            sock_stream.insert(
+                *sock_key,
+                AggSockStats {
+                    cpus: vec![*sock_key as u32 % 2, 100],
+                    stats: SockStats {
+                        last_touched_us: sock_key * 3,
+                        bytes_delivered: sock_key * 4,
+                        ..Default::default()
+                    },
+                },
+            );
+
+            // Also add a context in cache.
+            let context = SockContext {
+                address_family: AF_INET,
+                ..Default::default()
+            };
+            let result = sock_cache.add_context(*sock_key, context, now_us);
+            assert_eq!(
+                result,
+                SockOperationResult {
+                    completed: 1,
+                    partial: 0,
+                    failed: 0,
+                }
+            );
+        }
+
+        // On nothing before should yield all of the after.
+        let expected_deltas = sock_stream.clone();
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, STALENESS_TS);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: sock_keys.len().try_into().unwrap(),
+                partial: 0,
+                failed: 0,
+            }
+        );
+        assert_eq!(sock_cache.len(), sock_keys.len());
+        assert_eq!(sock_stream, expected_deltas);
+
+        let (min, max, avg) = sock_cache.num_cpus();
+        assert_eq!(min, 2);
+        assert_eq!(max, 2);
+        assert!((2.0 - avg).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_get_sock_deltas_all_new_contexts() {
+        let mut sock_cache = SockCache::new();
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+
+        // Create a slew of sockets in the incoming stream.
+        let sock_keys: Vec<u64> = vec![99, 101, 4, 55, 19, 79];
+        for sock_key in sock_keys.iter() {
+            sock_stream.insert(
+                *sock_key,
+                AggSockStats {
+                    cpus: vec![*sock_key as u32 % 2, 100],
+                    stats: SockStats {
+                        last_touched_us: sock_key * 3,
+                        bytes_delivered: sock_key * 4,
+                        ..Default::default()
+                    },
+                },
+            );
+        }
+
+        // On nothing before should yield all of the after.
+        let expected_deltas = sock_stream.clone();
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, STALENESS_TS);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: 0,
+                partial: sock_keys.len().try_into().unwrap(),
+                failed: 0,
+            }
+        );
+        assert_eq!(sock_cache.len(), sock_keys.len());
+        assert_eq!(sock_stream, expected_deltas);
+    }
+
+    #[test]
+    fn test_get_sock_deltas_all_changed() {
+        let mut sock_cache = SockCache::new();
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+
+        // Create a slew of sockets in the incoming stream.
+        let sock_keys: Vec<u64> = vec![99, 101, 4, 55, 19, 79];
+        for sock_key in sock_keys.iter() {
+            sock_stream.insert(
+                *sock_key,
+                AggSockStats {
+                    cpus: vec![*sock_key as u32 % 2, 100],
+                    stats: SockStats {
+                        bytes_delivered: sock_key * 4,
+                        ..Default::default()
+                    },
+                },
+            );
+        }
+
+        // Create sock stats already in cache, but with smaller values.
+        let mut old_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        for (sock_key, _val_after) in sock_stream.iter() {
+            let val_before = AggSockStats {
+                cpus: vec![],
+                stats: SockStats {
+                    bytes_delivered: *sock_key,
+                    ..Default::default()
+                },
+            };
+            old_stream.insert(*sock_key, val_before);
+        }
+        let result = sock_cache.update_stats_and_get_deltas(&mut old_stream, STALENESS_TS);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: 0,
+                partial: sock_keys.len().try_into().unwrap(),
+                failed: 0,
+            }
+        );
+
+        // Validate the resultant deltas placed into the sock stream.
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, STALENESS_TS);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: sock_keys.len().try_into().unwrap(),
+                partial: 0,
+                failed: 0,
+            }
+        );
+        assert_eq!(sock_stream.len(), sock_keys.len());
+        for (sock_key, actual_delta) in sock_stream.iter() {
+            let expected_delta = AggSockStats {
+                stats: SockStats {
+                    bytes_delivered: sock_key * 3,
+                    ..Default::default()
+                },
+                cpus: vec![*sock_key as u32 % 2, 100],
+            };
+            assert_eq!(*actual_delta, expected_delta);
+        }
+    }
+
+    #[test]
+    fn test_get_sock_deltas_new_and_changed() {
+        let mut sock_cache = SockCache::new();
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+
+        // Create a slew of sockets in the incoming stream.
+        let sock_keys: Vec<u64> = vec![99, 101, 4, 55, 19, 79];
+        for sock_key in sock_keys.iter() {
+            sock_stream.insert(
+                *sock_key,
+                AggSockStats {
+                    cpus: vec![*sock_key as u32 % 2, 100],
+                    stats: SockStats {
+                        bytes_delivered: sock_key * 4,
+                        ..Default::default()
+                    },
+                },
+            );
+        }
+
+        // Create sock stats already in cache, but with smaller values.
+        let mut old_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        for (sock_key, _val_after) in sock_stream.iter() {
+            let val_before = AggSockStats {
+                cpus: vec![],
+                stats: SockStats {
+                    bytes_delivered: *sock_key,
+                    ..Default::default()
+                },
+            };
+            old_stream.insert(*sock_key, val_before);
+        }
+
+        // Let's say two sockets were not in the old stream, and will thus appear anew.
+        old_stream.remove(&101);
+        old_stream.remove(&19);
+        let result = sock_cache.update_stats_and_get_deltas(&mut old_stream, STALENESS_TS);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: 0,
+                partial: sock_keys.len() as u64 - 2,
+                failed: 0,
+            }
+        );
+
+        // Validate the resultant deltas placed into the sock stream.
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, STALENESS_TS);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: sock_keys.len() as u64 - 2,
+                partial: 2,
+                failed: 0,
+            }
+        );
+        assert_eq!(sock_stream.len(), sock_keys.len());
+        for (sock_key, actual_delta) in sock_stream.iter() {
+            let delta_factor: u64 = if *sock_key == 101 || *sock_key == 19 {
+                4
+            } else {
+                3
+            };
+            let expected_delta = AggSockStats {
+                stats: SockStats {
+                    bytes_delivered: sock_key * delta_factor,
+                    ..Default::default()
+                },
+                cpus: vec![*sock_key as u32 % 2, 100],
+            };
+            assert_eq!(*actual_delta, expected_delta);
+        }
+    }
+
+    #[test]
+    fn test_get_sock_deltas_all_partial() {
+        let mut sock_cache = SockCache::new();
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+
+        // Place a slew of sockets into the cache.
+        let sock_keys: Vec<u64> = vec![99, 101, 4, 55, 19, 79];
+        for sock_key in sock_keys.iter() {
+            sock_stream.insert(
+                *sock_key,
+                AggSockStats {
+                    cpus: vec![*sock_key as u32 % 2, 100],
+                    stats: SockStats {
+                        bytes_delivered: sock_key * 4,
+                        ..Default::default()
+                    },
+                },
+            );
+        }
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, STALENESS_TS);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: 0,
+                partial: sock_keys.len().try_into().unwrap(),
+                failed: 0,
+            }
+        );
+
+        // On something before but nothing after is non-sensical, so should yield nothing.
+        sock_stream.clear();
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, STALENESS_TS);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: 0,
+                partial: 0,
+                failed: 0,
+            }
+        );
+        assert!(sock_stream.is_empty());
+    }
+
+    #[test]
+    fn test_get_sockets_to_evict_empty() {
+        let mut sock_cache = SockCache::new();
+        let (socks_evicted, num_stale) = sock_cache.perform_eviction();
+
+        assert!(socks_evicted.is_empty());
+        assert_eq!(num_stale, 0);
+        assert_eq!(sock_cache.len(), 0);
+    }
+
+    #[test]
+    fn test_get_sockets_to_evict_all_active() {
+        let now_us = 100;
+        let notrack_us = 10;
+        let mut sock_cache = SockCache::new();
+
+        // Many active sockets yields nothing.
+        let sock_keys: Vec<u64> = vec![99, 101, 4, 55, 19, 79];
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        for sock_key in sock_keys.iter() {
+            let cpu_id = *sock_key % 2;
+            sock_stream.insert(
+                *sock_key,
+                AggSockStats {
+                    cpus: vec![cpu_id as u32],
+                    stats: SockStats {
+                        last_touched_us: now_us - (notrack_us / 2),
+                        ..Default::default()
+                    },
+                },
+            );
+        }
+
+        let staleness_timestamp: u64 = now_us - notrack_us;
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, staleness_timestamp);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: 0,
+                partial: sock_keys.len().try_into().unwrap(),
+                failed: 0,
+            }
+        );
+
+        let (socks_evicted, num_stale) = sock_cache.perform_eviction();
+        assert_eq!(socks_evicted.len(), 0);
+        assert_eq!(num_stale, 0);
+        assert_eq!(sock_cache.len(), sock_keys.len());
+    }
+
+    #[test]
+    fn test_get_sockets_to_evict_some_closed() {
+        let now_us = 100;
+        let notrack_us = 10;
+        let mut sock_cache = SockCache::new();
+
+        // Create many active sockets.
+        let sock_keys: Vec<u64> = vec![99, 101, 4, 55, 19, 79];
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        for sock_key in sock_keys.iter() {
+            let cpu_id = *sock_key % 2;
+            sock_stream.insert(
+                *sock_key,
+                AggSockStats {
+                    cpus: vec![cpu_id as u32],
+                    stats: SockStats {
+                        last_touched_us: now_us - (notrack_us / 2),
+                        ..Default::default()
+                    },
+                },
+            );
+
+            // Also add a context in cache.
+            let context = SockContext {
+                address_family: AF_INET,
+                ..Default::default()
+            };
+            sock_cache.add_context(*sock_key, context, now_us);
+        }
+
+        // Close two of them.
+        sock_stream
+            .get_mut(&sock_keys[0])
+            .unwrap()
+            .stats
+            .state_flags
+            .insert(SockStateFlags::CLOSED);
+        sock_stream
+            .get_mut(&sock_keys[1])
+            .unwrap()
+            .stats
+            .state_flags
+            .insert(SockStateFlags::CLOSED);
+
+        // Store the full set in cache.
+        let staleness_timestamp: u64 = now_us - notrack_us;
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, staleness_timestamp);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: sock_keys.len().try_into().unwrap(),
+                partial: 0,
+                failed: 0,
+            }
+        );
+
+        // Perform eviction and validate.
+        let (socks_evicted, num_stale) = sock_cache.perform_eviction();
+        assert_eq!(socks_evicted.len(), 2);
+        assert_eq!(num_stale, 0);
+        assert_eq!(sock_cache.len(), sock_keys.len() - 2);
+        assert_eq!(
+            &socks_evicted.get(&sock_keys[0]).unwrap().agg_stats,
+            sock_stream.get(&sock_keys[0]).unwrap()
+        );
+        assert_eq!(
+            &socks_evicted.get(&sock_keys[1]).unwrap().agg_stats,
+            sock_stream.get(&sock_keys[1]).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_get_sockets_to_evict_some_inactive() {
+        let now_us = 100;
+        let notrack_us = 10;
+        let mut sock_cache = SockCache::new();
+
+        // Create many active sockets.
+        let sock_keys: Vec<u64> = vec![99, 101, 4, 55, 19, 79];
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        for sock_key in sock_keys.iter() {
+            let cpu_id = *sock_key % 2;
+            sock_stream.insert(
+                *sock_key,
+                AggSockStats {
+                    cpus: vec![cpu_id as u32],
+                    stats: SockStats {
+                        last_touched_us: now_us - (notrack_us / 2),
+                        ..Default::default()
+                    },
+                },
+            );
+        }
+
+        // Make two of them inactive.
+        sock_stream
+            .get_mut(&sock_keys[2])
+            .unwrap()
+            .stats
+            .last_touched_us = now_us - notrack_us;
+        sock_stream
+            .get_mut(&sock_keys[5])
+            .unwrap()
+            .stats
+            .last_touched_us = now_us - (notrack_us * 2);
+
+        // Store the full set in cache.
+        let staleness_timestamp: u64 = now_us - notrack_us;
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, staleness_timestamp);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: 0,
+                partial: sock_keys.len().try_into().unwrap(),
+                failed: 0,
+            }
+        );
+
+        // Perform eviction and validate.
+        let (socks_evicted, num_stale) = sock_cache.perform_eviction();
+        assert_eq!(socks_evicted.len(), 2);
+        assert_eq!(num_stale, 2);
+        assert_eq!(sock_cache.len(), sock_keys.len() - 2);
+        assert_eq!(
+            &socks_evicted.get(&sock_keys[2]).unwrap().agg_stats,
+            sock_stream.get(&sock_keys[2]).unwrap()
+        );
+        assert_eq!(
+            &socks_evicted.get(&sock_keys[5]).unwrap().agg_stats,
+            sock_stream.get(&sock_keys[5]).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_get_sockets_to_evict_all_closed() {
+        let now_us = 100;
+        let notrack_us = 10;
+        let mut sock_cache = SockCache::new();
+
+        // Create many sockets, all closed.
+        let sock_keys: Vec<u64> = vec![99, 101, 4, 55, 19, 79];
+        let mut sock_stream: HashMap<SockKey, AggSockStats> = HashMap::new();
+        for sock_key in sock_keys.iter() {
+            let cpu_id = *sock_key % 2;
+            sock_stream.insert(
+                *sock_key,
+                AggSockStats {
+                    cpus: vec![cpu_id as u32],
+                    stats: SockStats {
+                        last_touched_us: now_us - (notrack_us / 2),
+                        state_flags: SockStateFlags::CLOSED,
+                        ..Default::default()
+                    },
+                },
+            );
+
+            // Also add a context in cache.
+            let context = SockContext {
+                address_family: AF_INET,
+                ..Default::default()
+            };
+            let result = sock_cache.add_context(*sock_key, context, now_us);
+            assert_eq!(
+                result,
+                SockOperationResult {
+                    completed: 1,
+                    partial: 0,
+                    failed: 0,
+                }
+            );
+        }
+
+        // Store the full set in cache.
+        let staleness_timestamp: u64 = now_us - notrack_us;
+        let result = sock_cache.update_stats_and_get_deltas(&mut sock_stream, staleness_timestamp);
+        assert_eq!(
+            result,
+            SockOperationResult {
+                completed: sock_keys.len().try_into().unwrap(),
+                partial: 0,
+                failed: 0,
+            }
+        );
+
+        // Perform eviction and validate.
+        let (socks_evicted, num_stale) = sock_cache.perform_eviction();
+        assert_eq!(num_stale, 0);
+        assert_eq!(sock_cache.len(), 0);
+
+        assert_eq!(socks_evicted.len(), sock_keys.len());
+        for key in sock_keys.iter() {
+            assert!(socks_evicted.get(key).is_some());
+        }
+    }
+
+    #[test]
+    fn test_sock_cache_get_last_touched() {
+        let mut sock_cache = SockCache::new();
+
+        let sock_key1: SockKey = 1979;
+        let sock_key2: SockKey = 2005;
+        let sock_key_invalid: SockKey = 2553;
+
+        let now_us = 1997;
+        sock_cache.add_context(sock_key1, SockContext::default(), now_us);
+        sock_cache.add_context(sock_key2, SockContext::default(), now_us + 26);
+
+        assert_eq!(sock_cache.get_last_touched(&sock_key_invalid), 0);
+        assert_eq!(sock_cache.get_last_touched(&sock_key1), now_us);
+        assert_eq!(sock_cache.get_last_touched(&sock_key2), now_us + 26);
+    }
+}

--- a/nfm-controller/src/kubernetes/flow_metadata.rs
+++ b/nfm-controller/src/kubernetes/flow_metadata.rs
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Deserialize;
+
+use crate::reports::report::ReportValue;
+
+use super::kubernetes_metadata_collector::PodInfo;
+
+// carries kubernetes metadata related to local and remote parties, when applicable
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd)]
+pub struct FlowMetadata {
+    pub local: Option<PodInfo>,
+    pub remote: Option<PodInfo>,
+}
+
+impl FlowMetadata {
+    pub fn enumerate(&self) -> Vec<(String, ReportValue)> {
+        let mut values: Vec<(String, ReportValue)> = Vec::new();
+        // add local and remote pod info
+        if let Some(pod_info) = &self.local {
+            values.push((
+                "local_pod_name".to_string(),
+                ReportValue::String(pod_info.name.to_string()),
+            ));
+            values.push((
+                "local_pod_namespace".to_string(),
+                ReportValue::String(pod_info.namespace.to_string()),
+            ));
+            values.push((
+                "local_pod_service".to_string(),
+                ReportValue::String(pod_info.service_name.to_string()),
+            ));
+        }
+        if let Some(pod_info) = &self.remote {
+            values.push((
+                "remote_pod_name".to_string(),
+                ReportValue::String(pod_info.name.to_string()),
+            ));
+            values.push((
+                "remote_pod_namespace".to_string(),
+                ReportValue::String(pod_info.namespace.to_string()),
+            ));
+            values.push((
+                "remote_pod_service".to_string(),
+                ReportValue::String(pod_info.service_name.to_string()),
+            ));
+        }
+        values
+    }
+}

--- a/nfm-controller/src/kubernetes/kubernetes_metadata_collector.rs
+++ b/nfm-controller/src/kubernetes/kubernetes_metadata_collector.rs
@@ -1,0 +1,1050 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Instant;
+
+use futures::{Stream, StreamExt};
+use k8s_openapi::api::core::v1::{Container, Pod};
+use k8s_openapi::api::discovery::v1::{Endpoint, EndpointSlice};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_openapi::Metadata;
+use k8s_openapi::Resource;
+use kube::runtime::utils::StreamBackoff;
+use kube::runtime::watcher::{DefaultBackoff, Error, Event};
+use kube::runtime::{watcher, WatchStreamExt};
+use kube::ResourceExt;
+use kube::{Api, Client};
+use log::info;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use std::fmt::Debug;
+use tokio::runtime::Runtime;
+
+use crate::events::network_event::AggregateResults;
+use crate::kubernetes::flow_metadata::FlowMetadata;
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Default)]
+pub struct PodInfo {
+    pub name: String,
+    pub namespace: String,
+    pub service_name: String,
+}
+
+pub struct KubernetesMetadataCollector {
+    enriched_flows: u64,
+    refresher_runtime: Option<Runtime>,
+    pod_info_arc: Arc<Mutex<HashMap<IpAddr, HashMap<i32, PodInfo>>>>,
+}
+
+impl Default for KubernetesMetadataCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KubernetesMetadataCollector {
+    pub fn new() -> Self {
+        Self {
+            enriched_flows: 0,
+            refresher_runtime: None,
+            pod_info_arc: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /**
+     * Extract ip address from Pod object
+     */
+    fn get_ip_from_pod(pod: &Pod) -> Option<IpAddr> {
+        match pod.status {
+            Some(ref status) => status
+                .pod_ip
+                .as_ref()
+                .and_then(|ip_str| IpAddr::from_str(ip_str.as_str()).ok()),
+            None => None,
+        }
+    }
+
+    /**
+     * Extract pod name from Endpoint object
+     */
+    fn get_pod_name_from_endpoint(endpoint: &Endpoint) -> String {
+        endpoint
+            .target_ref
+            .as_ref()
+            .and_then(|object_ref| object_ref.name.clone())
+            .unwrap_or_default()
+    }
+
+    /**
+     * Extract what ports the service serves from, using endpoint slice.
+     * We only care for TCP ports right now, in future we can add others.
+     */
+    fn get_tcp_ports_from_endpoint_slice(endpoint_slice: &EndpointSlice) -> Vec<i32> {
+        endpoint_slice
+            .ports
+            .as_ref()
+            .map_or_else(Vec::new, |endpoint_ports| {
+                endpoint_ports
+                    .iter()
+                    .filter_map(|port| {
+                        match port.protocol.as_deref() {
+                            Some("TCP") => port.port, // can be None, but it will be filtered out in that case
+                            _ => None,
+                        }
+                    })
+                    .collect()
+            })
+    }
+
+    /**
+     * Get all the TCP ports this specific container serves from
+     */
+    fn extract_ports_from_pod_container(container: &Container) -> Vec<i32> {
+        container
+            .ports
+            .as_ref()
+            .map_or_else(Vec::new, |container_ports| {
+                container_ports
+                    .iter()
+                    .filter_map(|container_port| {
+                        match container_port.protocol.as_deref().unwrap_or_default() {
+                            "TCP" => Some(container_port.container_port), // can be None, but it will be filtered out in that case
+                            _ => None,
+                        }
+                    })
+                    .collect::<Vec<i32>>()
+            })
+    }
+
+    /**
+     * Extract what ports the pod serves from, using Pod data
+     * We only care for TCP ports right now, in future we can add others.
+     */
+    fn get_tcp_ports_from_pod(pod: &Pod) -> Vec<i32> {
+        pod.spec
+            .as_ref()
+            .map(|spec| {
+                spec.containers // Generally each pod contains 1 container, but can be more. They will share the same Network Namespace
+                    .iter()
+                    .flat_map(Self::extract_ports_from_pod_container)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /**
+     * Purge the given pod ip and ports from pod info map.
+     */
+    fn purge_pod_ip_ports_from_pod_info(
+        pod_info: &mut MutexGuard<'_, HashMap<IpAddr, HashMap<i32, PodInfo>>>,
+        pod_ip: &IpAddr,
+        ports: &Vec<i32>,
+    ) {
+        // Remove specific port entries, and remove whole ip port map if necessary
+        if let Some(port_map) = pod_info.get_mut(pod_ip) {
+            for port in ports {
+                port_map.remove(port);
+            }
+            if port_map.is_empty() {
+                pod_info.remove(pod_ip);
+            }
+        }
+    }
+
+    /**
+     * Handle a Pod event. Pod events are sent by kubernetes api server when a new pod is added, removed or modified.
+     * On add or update events we add to or replace an entry in our internal map.
+     * On delete events we remove associated entry from our internal map.
+     */
+    fn handle_pod_event(
+        pod_event_result: Result<Event<Pod>, watcher::Error>,
+        pod_info_root_map: Arc<Mutex<HashMap<IpAddr, HashMap<i32, PodInfo>>>>,
+    ) {
+        let pod_event = match pod_event_result {
+            Ok(event) => event,
+            Err(err) => {
+                info!(message = err.to_string(); "watcher encountered an error, will autorecover in next poll");
+                return;
+            }
+        };
+
+        match pod_event {
+            Event::Apply(pod) | Event::InitApply(pod) => {
+                let ports = Self::get_tcp_ports_from_pod(&pod);
+                if let Some(pod_ip) = Self::get_ip_from_pod(&pod) {
+                    let mut pod_info = pod_info_root_map.lock().unwrap();
+                    for port in &ports {
+                        pod_info
+                            .entry(pod_ip)
+                            .or_default()
+                            .entry(*port)
+                            .or_insert_with(||
+                                // Only insert if pod info for this port doesn't exist.
+                                // If its already filled by endpoint slice info, do not override it because it will contain more info.
+                                // In case this pod event comes before endpoint slice event, that is alright as endpoint slice event will override it.
+                                PodInfo {
+                                    name: pod.name_any(),
+                                    ..Default::default()
+                                });
+                    }
+                }
+            }
+            Event::Delete(pod) => {
+                if let Some(pod_ip) = Self::get_ip_from_pod(&pod) {
+                    let ports = Self::get_tcp_ports_from_pod(&pod);
+                    let mut pod_info = pod_info_root_map.lock().unwrap();
+                    Self::purge_pod_ip_ports_from_pod_info(&mut pod_info, &pod_ip, &ports);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /**
+     * An endpoint slice represents a group of endpoints(pod), sometimes a pod might have more than one IP
+     * We associate all those IPs with the same PodInfo
+     * Since we are overriding the entry, this handles both additions and updates
+     */
+    fn handle_endpoint_update(
+        slice: EndpointSlice,
+        mut pod_info_root_map: MutexGuard<'_, HashMap<IpAddr, HashMap<i32, PodInfo>>>,
+    ) {
+        let ports: Vec<i32> = Self::get_tcp_ports_from_endpoint_slice(&slice);
+        for endpoint in &slice.endpoints {
+            for address in &endpoint.addresses {
+                let pod_ip = match IpAddr::from_str(address) {
+                    Ok(ip) => ip,
+                    Err(_) => continue, // should never happen, but if happens, we dont care
+                };
+                let pod_name = Self::get_pod_name_from_endpoint(endpoint);
+
+                for port in &ports {
+                    pod_info_root_map.entry(pod_ip).or_default().insert(
+                        *port,
+                        PodInfo {
+                            name: pod_name.clone(),
+                            namespace: slice.metadata.namespace.as_ref().unwrap().clone(),
+                            service_name: Self::get_service_name_from_endpoint_slice(&slice),
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * An endpoint slice represents a group of endpoints(pod), sometimes a pod might have more than one IP
+     * We associate all those IPs with the same PodInfo
+     * We remove all those IPs from pod info map here
+     */
+    fn handle_endpoint_removal(
+        slice: EndpointSlice,
+        mut pod_info: MutexGuard<'_, HashMap<IpAddr, HashMap<i32, PodInfo>>>,
+    ) {
+        let ports: Vec<i32> = Self::get_tcp_ports_from_endpoint_slice(&slice);
+        for endpoint in &slice.endpoints {
+            for address in &endpoint.addresses {
+                let pod_ip = match IpAddr::from_str(address) {
+                    Ok(ip) => ip,
+                    Err(_) => continue,
+                };
+                Self::purge_pod_ip_ports_from_pod_info(&mut pod_info, &pod_ip, &ports);
+            }
+        }
+    }
+
+    /**
+     * Handle a EndpointSlice event. EndpointSlice events are sent by kubernetes api server when a new EndpointSlice is added, removed or modified.
+     * An EndpointSlice is a group of endpoints (thus Pods) that share the same service and port.
+     * On add or update events we add to or replace an entries of relevant pods in our internal map.
+     * On delete events we remove associated entries of relevant pods from our internal map.
+     */
+    fn handle_endpoint_slice_event(
+        slice_event_result: Result<Event<EndpointSlice>, watcher::Error>,
+        pod_info_arc: Arc<Mutex<HashMap<IpAddr, HashMap<i32, PodInfo>>>>,
+    ) {
+        let slice_event = match slice_event_result {
+            Ok(event) => event,
+            Err(_) => return, // a communication error might occur, stream will autorecover
+        };
+
+        match slice_event {
+            Event::Apply(slice) | Event::InitApply(slice) => {
+                let pod_info = pod_info_arc.lock().unwrap();
+                Self::handle_endpoint_update(slice, pod_info);
+            }
+            Event::Delete(slice) => {
+                let pod_info = pod_info_arc.lock().unwrap();
+                Self::handle_endpoint_removal(slice, pod_info);
+            }
+            _ => {}
+        }
+    }
+
+    /**
+     * Convenience function, to get a watcher stream for a given resource type, like Pod or EndpointSlice
+     */
+    async fn create_watcher_stream<K>(
+    ) -> StreamBackoff<impl Stream<Item = Result<Event<K>, Error>> + Send, DefaultBackoff>
+    where
+        K: Resource + Clone + DeserializeOwned + Debug + Send + 'static + Metadata<Ty = ObjectMeta>,
+    {
+        let client = Client::try_default()
+            .await
+            .expect("Failed to create Kubernetes client, perhaps you are running with '-k on' in a non kubernetes environment?");
+        let api = Api::all(client);
+        watcher(api, watcher::Config::default().page_size(150)).default_backoff()
+    }
+
+    /**
+     * Start a watcher for pod changes. This will run forever
+     */
+    async fn start_pod_watcher(pod_info: Arc<Mutex<HashMap<IpAddr, HashMap<i32, PodInfo>>>>) {
+        let pod_stream = Self::create_watcher_stream::<Pod>().await;
+        pod_stream
+            .for_each(|pod_event| async {
+                Self::handle_pod_event(pod_event, Arc::clone(&pod_info))
+            })
+            .await;
+    }
+
+    /**
+     * Start a watcher for endpoint slice changes. This will run forever
+     */
+    async fn start_endpoint_slice_watcher(
+        pod_info: Arc<Mutex<HashMap<IpAddr, HashMap<i32, PodInfo>>>>,
+    ) {
+        let endpoints_stream = Self::create_watcher_stream::<EndpointSlice>().await;
+        endpoints_stream
+            .for_each(|slice_result| async {
+                Self::handle_endpoint_slice_event(slice_result, Arc::clone(&pod_info))
+            })
+            .await;
+    }
+
+    /**
+     * Create two tasks running forever, with main goals of listening pod and endpoint slice updates
+     */
+    pub fn setup_watchers(&mut self) {
+        if self.refresher_runtime.is_none() {
+            self.refresher_runtime = Some(tokio::runtime::Runtime::new().unwrap());
+        } else {
+            // the watchers are already running, no need to do anything
+            return;
+        }
+
+        let runtime = self.refresher_runtime.as_ref().unwrap();
+        runtime.spawn(Self::start_pod_watcher(Arc::clone(&self.pod_info_arc)));
+        runtime.spawn(Self::start_endpoint_slice_watcher(Arc::clone(
+            &self.pod_info_arc,
+        )));
+    }
+
+    /**
+     * Get pod info associated with given IP address
+     */
+    fn get_pod_info<'a>(
+        pod_info: &'a HashMap<IpAddr, HashMap<i32, PodInfo>>,
+        address: &'a IpAddr,
+    ) -> Option<&'a HashMap<i32, PodInfo>> {
+        let mut pod_data = pod_info.get(address);
+        if pod_data.is_none() {
+            // there can be cases where reported IPs are IPv4 adresses wrapped with IPv6
+            // for example "::ffff:100.64.38.124". Try to extract the underlying IPv4 for that case
+            if let IpAddr::V6(ipv6) = address {
+                if let Some(ipv4) = ipv6.to_ipv4_mapped() {
+                    pod_data = pod_info.get(&IpAddr::V4(ipv4));
+                }
+            }
+        }
+        pod_data
+    }
+
+    /**
+     * Get given set of flows and enrich them with kubernetes metadata
+     */
+    pub fn enrich_flows(&mut self, agg_flows: &mut [AggregateResults]) -> u64 {
+        let start = Instant::now();
+        let mut enriched_this_run: u64 = 0;
+        let pod_info = self.pod_info_arc.lock().unwrap().clone();
+
+        for agg_flow in agg_flows.iter_mut() {
+            let local_pod_port_map = Self::get_pod_info(&pod_info, &agg_flow.flow.local_address);
+            let remote_pod_port_map = Self::get_pod_info(&pod_info, &agg_flow.flow.remote_address);
+
+            let (mut local_pod_info, mut remote_pod_info) = (None, None);
+
+            if agg_flow.flow.is_client_flow() {
+                // if this is a client flow, we can be sure of the remote end, but we can only be sure of the local only under the case
+                // when theres only one pod associated with the local IP
+                if let Some(local_port_map) = local_pod_port_map {
+                    if local_port_map.len() == 1 {
+                        // if there is only one pod associated with this IP we can be sure that this is the pod that is initiating the connection
+                        local_pod_info = local_port_map.values().next();
+                    }
+                }
+                if let Some(remote_port_map) = remote_pod_port_map {
+                    remote_pod_info = remote_port_map.get(&agg_flow.flow.remote_port.into());
+                }
+            } else {
+                // if this is a server flow, we can be sure of the local end, but we can only be sure of the remote only under the case
+                // when theres only one pod associated with the remote IP
+                if let Some(remote_port_map) = remote_pod_port_map {
+                    if remote_port_map.len() == 1 {
+                        // if there is only one pod associated with this IP we can be sure that this is the pod that is initiating the connection
+                        remote_pod_info = remote_port_map.values().next();
+                    }
+                }
+                if let Some(local_port_map) = local_pod_port_map {
+                    local_pod_info = local_port_map.get(&agg_flow.flow.local_port.into());
+                }
+            }
+
+            if local_pod_info.is_some() || remote_pod_info.is_some() {
+                agg_flow.flow.kubernetes_metadata = Some(FlowMetadata {
+                    local: local_pod_info.cloned(),
+                    remote: remote_pod_info.cloned(),
+                });
+                enriched_this_run += 1;
+            }
+        }
+        self.enriched_flows += enriched_this_run;
+        info!(
+            duration_micro = (Instant::now() - start).as_micros(),
+            total_flows = agg_flows.len(),
+            enriched_flows = enriched_this_run;
+            "Flow enrichment completed."
+        );
+        enriched_this_run
+    }
+
+    /**
+     * Get the name of the service representing the endpoint slice
+     */
+    fn get_service_name_from_endpoint_slice(endpoint_slice: &EndpointSlice) -> String {
+        // regular service names are stored under a metadata label, first try that
+        let service_name_from_labels = match endpoint_slice.metadata.labels.as_ref() {
+            Some(labels) => labels.get("kubernetes.io/service-name").cloned(),
+            None => None,
+        };
+
+        // if not, check owner references which denotes the owner service of this endpoint
+        match service_name_from_labels {
+            Some(service_name) => service_name.to_string(),
+            None => match endpoint_slice.owner_references().first() {
+                Some(owner_reference) => owner_reference.name.clone(),
+                None => "".to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        net::IpAddr,
+        panic::{self, AssertUnwindSafe},
+        str::FromStr,
+        sync::atomic::{AtomicBool, Ordering},
+        time::Duration,
+    };
+
+    use crate::{
+        events::network_event::{AggregateResults, FlowProperties, InetProtocol, NetworkStats},
+        kubernetes::flow_metadata::FlowMetadata,
+    };
+    use k8s_openapi::{
+        api::{
+            core::v1::{ContainerPort, ObjectReference, PodSpec, PodStatus},
+            discovery::v1::EndpointSlice,
+        },
+        apimachinery::pkg::apis::meta::v1::OwnerReference,
+    };
+    use kube::{api::ObjectMeta, core::ErrorResponse};
+
+    use super::*;
+    use super::{KubernetesMetadataCollector, PodInfo};
+
+    static TEST_POD_PORT: i32 = 100;
+
+    #[test]
+    fn test_no_data() {
+        assert!(true);
+    }
+
+    #[test]
+    fn test_get_service_name_from_endpoint_slice() {
+        let slice = EndpointSlice {
+            metadata: kube::api::ObjectMeta {
+                namespace: Some("test".to_string()),
+                labels: Some(std::collections::BTreeMap::from([(
+                    "kubernetes.io/service-name".to_string(),
+                    "test-service".to_string(),
+                )])),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let service_name =
+            KubernetesMetadataCollector::get_service_name_from_endpoint_slice(&slice);
+        assert_eq!(service_name, "test-service");
+
+        // test with owner references
+        let slice = EndpointSlice {
+            metadata: ObjectMeta {
+                namespace: Some("test".to_string()),
+                owner_references: Some(vec![OwnerReference {
+                    name: "test-service-owner".to_string(),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let service_name =
+            KubernetesMetadataCollector::get_service_name_from_endpoint_slice(&slice);
+        assert_eq!(service_name, "test-service-owner");
+    }
+
+    fn get_flow(agg_results: AggregateResults) -> FlowMetadata {
+        agg_results.flow.kubernetes_metadata.unwrap()
+    }
+
+    #[test]
+    fn test_setup_watchers_sanity() {
+        let result = panic::catch_unwind(AssertUnwindSafe(|| {
+            let mut collector = KubernetesMetadataCollector::new();
+            collector.setup_watchers();
+        }));
+
+        assert!(
+            result.is_ok(),
+            "setup_watchers() must not panic under any case"
+        );
+    }
+
+    fn create_pod_info(name: &str, ns: &str, srv: &str) -> PodInfo {
+        PodInfo {
+            name: name.to_string(),
+            namespace: ns.to_string(),
+            service_name: srv.to_string(),
+        }
+    }
+
+    fn create_agg_results(
+        local_port: u16,
+        remote_port: u16,
+        local_ip: Option<IpAddr>,
+        remote_ip: Option<IpAddr>,
+    ) -> AggregateResults {
+        AggregateResults {
+            flow: FlowProperties {
+                local_address: local_ip.unwrap_or("255.255.255.255".parse::<IpAddr>().unwrap()),
+                remote_address: remote_ip.unwrap_or("255.255.255.254".parse::<IpAddr>().unwrap()),
+                local_port,
+                remote_port,
+                kubernetes_metadata: None,
+                protocol: InetProtocol::TCP,
+            },
+            stats: NetworkStats {
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn test_enrich_flows() {
+        let pod_local = IpAddr::from_str("10.0.0.1").unwrap();
+        let pod_remote = IpAddr::from_str("10.0.0.2").unwrap();
+        let pod_local_mapped = IpAddr::from_str("::ffff:10.0.0.1").unwrap();
+        let pod_remote_mapped = IpAddr::from_str("::ffff:10.0.0.2").unwrap();
+        let pod_info_local = create_pod_info("pod-1", "ns-1", "service-1");
+        let pod_info_remote = create_pod_info("pod-2", "ns-2", "service-2");
+        let pod_info: HashMap<IpAddr, HashMap<i32, PodInfo>> = HashMap::from([
+            (pod_local, HashMap::from([(6666, pod_info_local.clone())])),
+            (pod_remote, HashMap::from([(6666, pod_info_remote.clone())])),
+        ]);
+        let mut flows: Vec<AggregateResults> = vec![
+            create_agg_results(0, 6666, Some(pod_local), Some(pod_remote)),
+            create_agg_results(0, 6666, None, Some(pod_remote)),
+            create_agg_results(0, 6666, Some(pod_local_mapped), None),
+            create_agg_results(0, 6666, None, Some(pod_remote_mapped)),
+        ];
+
+        let mut collector = KubernetesMetadataCollector::new();
+        collector.pod_info_arc = Arc::new(Mutex::new(pod_info));
+        assert_eq!(collector.enrich_flows(&mut flows), 4);
+        let local_flow = get_flow(flows[0].clone()).local.unwrap();
+        let remote_flow = get_flow(flows[0].clone()).remote.unwrap();
+        assert_eq!(local_flow, pod_info_local);
+        assert_eq!(remote_flow, pod_info_remote);
+
+        let local_flow_mapped = get_flow(flows[2].clone()).local.unwrap();
+        let remote_flow_mapped = get_flow(flows[3].clone()).remote.unwrap();
+        assert_eq!(local_flow_mapped, pod_info_local);
+        assert_eq!(remote_flow_mapped, pod_info_remote);
+    }
+
+    /**
+     * Do following verifications:
+     * 1. For a client flow, the remote pod is ALWAYS resolved if we have its pod info.
+     * 2. For a server flow, the local pod is ALWAYS resolved if we have its pod info.
+     * 3. For a client flow, if the local ip IP has a single port registered, local pod can be resolved.
+     * 4. For a server flow, if the remote ip IP has a single port registered, remote pod can be resolved.
+     * 5. For a client flow, if the local ip IP has multiple ports registered, we cant resolve the local pod
+     * 6. For a server flow, if the remote ip IP has multiple ports registered, we cant resolve the remote pod
+     */
+    #[test]
+    fn test_enrich_flows_multi_scenario() {
+        let mut collector = KubernetesMetadataCollector::new();
+        // Scenario 1: Verify, For a client flow, the remote pod is ALWAYS resolved if we have its pod info.
+        let pod_local = IpAddr::from_str("10.0.0.1").unwrap();
+        let pod_remote = IpAddr::from_str("10.0.0.2").unwrap();
+        let pod_info_local = create_pod_info("p-1", "ns-1", "s-1");
+        let pod_info_remote = create_pod_info("p-2", "ns-2", "s-2");
+        let polluter_pod_info = create_pod_info("x", "x", "x");
+        let pod_info: HashMap<IpAddr, HashMap<i32, PodInfo>> = HashMap::from([(
+            pod_remote,
+            HashMap::from([
+                // register multiple ports under this IP.
+                // we should still be able to resolve the 6666 one correctly
+                (6666, pod_info_remote.clone()),
+                (5555, polluter_pod_info.clone()),
+                (4444, polluter_pod_info.clone()),
+            ]),
+        )]);
+        // create a single client flow towards remote pod port 6666
+        let mut flows: Vec<AggregateResults> = vec![create_agg_results(
+            0,
+            6666,
+            Some(pod_local),
+            Some(pod_remote),
+        )];
+        collector.pod_info_arc = Arc::new(Mutex::new(pod_info));
+        assert_eq!(collector.enrich_flows(&mut flows), 1);
+        assert_eq!(get_flow(flows[0].clone()).remote.unwrap(), pod_info_remote);
+
+        // Scenario 2: Verify, For a server flow, the local pod is ALWAYS resolved if we have its pod info.
+        let pod_info: HashMap<IpAddr, HashMap<i32, PodInfo>> = HashMap::from([(
+            pod_local,
+            HashMap::from([
+                // register multiple ports under this IP.
+                // we should still be able to resolve the 1111 one correctly
+                (1111, pod_info_local.clone()),
+                (2222, polluter_pod_info.clone()),
+                (3333, polluter_pod_info.clone()),
+            ]),
+        )]);
+        // create a single client flow towards our (local) pod port 1111
+        let mut flows: Vec<AggregateResults> =
+            vec![create_agg_results(1111, 0, Some(pod_local), None)];
+        collector.pod_info_arc = Arc::new(Mutex::new(pod_info));
+        assert_eq!(collector.enrich_flows(&mut flows), 1);
+        assert_eq!(get_flow(flows[0].clone()).local.unwrap(), pod_info_local);
+
+        // Scenario 3: For a client flow, if the local ip IP has a single port registered, local pod can be resolved.
+        let pod_info: HashMap<IpAddr, HashMap<i32, PodInfo>> = HashMap::from([
+            (
+                pod_local,
+                HashMap::from([
+                    // register a single port under this IP.
+                    // we should still be able to resolve this one correctly in a client flow
+                    // because its the only one that could originate the flow
+                    (1111, pod_info_local.clone()),
+                ]),
+            ),
+            (
+                pod_remote,
+                HashMap::from([
+                    // register multiple ports under this IP.
+                    // we should still be able to resolve the 6666 one correctly
+                    (6666, pod_info_remote.clone()),
+                    (5555, polluter_pod_info.clone()),
+                    (4444, polluter_pod_info.clone()),
+                ]),
+            ),
+        ]);
+        // create a single client flow towards remote pod port 6666
+        let mut flows: Vec<AggregateResults> = vec![create_agg_results(
+            0,
+            6666,
+            Some(pod_local),
+            Some(pod_remote),
+        )];
+        collector.pod_info_arc = Arc::new(Mutex::new(pod_info));
+        assert_eq!(collector.enrich_flows(&mut flows), 1);
+        assert_eq!(get_flow(flows[0].clone()).local.unwrap(), pod_info_local);
+        assert_eq!(get_flow(flows[0].clone()).remote.unwrap(), pod_info_remote);
+
+        // Scenario 4: For a server flow, if the remote ip IP has a single port registered, remote pod can be resolved.
+        let pod_info: HashMap<IpAddr, HashMap<i32, PodInfo>> = HashMap::from([
+            (
+                pod_local,
+                HashMap::from([
+                    // register multiple ports under this IP.
+                    // we should still be able to resolve the 1111 one correctly
+                    (1111, pod_info_local.clone()),
+                    (2222, polluter_pod_info.clone()),
+                    (3333, polluter_pod_info.clone()),
+                ]),
+            ),
+            (
+                pod_remote,
+                HashMap::from([
+                    // register a single port under this IP.
+                    // we should still be able to resolve this one correctly in a server flow
+                    // because its the only one that could be on the remote end of flow
+                    (6666, pod_info_remote.clone()),
+                ]),
+            ),
+        ]);
+        let mut flows: Vec<AggregateResults> = vec![create_agg_results(
+            1111,
+            0,
+            Some(pod_local),
+            Some(pod_remote),
+        )];
+        collector.pod_info_arc = Arc::new(Mutex::new(pod_info));
+        assert_eq!(collector.enrich_flows(&mut flows), 1);
+        assert_eq!(get_flow(flows[0].clone()).local.unwrap(), pod_info_local);
+        assert_eq!(get_flow(flows[0].clone()).remote.unwrap(), pod_info_remote);
+
+        // Scenario 5: For a client flow, if the local ip IP has multiple ports registered, we cant resolve the local pod
+        let pod_info: HashMap<IpAddr, HashMap<i32, PodInfo>> = HashMap::from([
+            (
+                pod_local,
+                HashMap::from([
+                    // register multiple ports under this IP.
+                    // Since this is a client flow,
+                    // there is no way for us to know whether 1111 initiated the connection or 2222 or 3333 etc.
+                    // So we shouldnt resolve local pod under this case
+                    (1111, pod_info_local.clone()),
+                    (2222, polluter_pod_info.clone()),
+                    (3333, polluter_pod_info.clone()),
+                ]),
+            ),
+            (
+                pod_remote,
+                HashMap::from([
+                    // register multiple ports under this IP.
+                    // we should still be able to resolve the 6666 one correctly
+                    (6666, pod_info_remote.clone()),
+                    (5555, polluter_pod_info.clone()),
+                    (4444, polluter_pod_info.clone()),
+                ]),
+            ),
+        ]);
+        collector.pod_info_arc = Arc::new(Mutex::new(pod_info));
+        let mut flows: Vec<AggregateResults> = vec![create_agg_results(
+            0,
+            6666,
+            Some(pod_local),
+            Some(pod_remote),
+        )];
+        assert_eq!(collector.enrich_flows(&mut flows), 1);
+        assert_eq!(get_flow(flows[0].clone()).local, None);
+        assert_eq!(get_flow(flows[0].clone()).remote.unwrap(), pod_info_remote);
+
+        // Scenario 6: For a server flow, if the remote ip IP has multiple ports registered, we cant resolve the remote pod
+        let mut flows: Vec<AggregateResults> = vec![create_agg_results(
+            1111,
+            0,
+            Some(pod_local),
+            Some(pod_remote),
+        )];
+        assert_eq!(collector.enrich_flows(&mut flows), 1);
+        assert_eq!(get_flow(flows[0].clone()).local.unwrap(), pod_info_local);
+        assert_eq!(get_flow(flows[0].clone()).remote, None);
+    }
+
+    fn adress_to_podname(address: IpAddr) -> String {
+        format!("{}/{}", "pod-1", address.to_string())
+    }
+
+    fn create_test_pod(address: IpAddr) -> Pod {
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(adress_to_podname(address)),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                containers: vec![Container {
+                    name: "test-container".to_string(),
+                    ports: Some(vec![
+                        ContainerPort {
+                            container_port: TEST_POD_PORT,
+                            name: Some("test-port".to_string()),
+                            protocol: Some("TCP".to_string()),
+                            ..Default::default()
+                        },
+                        ContainerPort {
+                            container_port: TEST_POD_PORT + 1,
+                            name: Some("test-port".to_string()),
+                            protocol: Some("UDP".to_string()), // to verify that this is ignored
+                            ..Default::default()
+                        },
+                    ]),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            status: Some(PodStatus {
+                pod_ip: Some(address.to_string()),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn create_test_slice(address: IpAddr) -> EndpointSlice {
+        let mut endpoints = vec![];
+        endpoints.push(k8s_openapi::api::discovery::v1::Endpoint {
+            addresses: vec![address.to_string()],
+            conditions: None,
+            hostname: None,
+            target_ref: Some(ObjectReference {
+                api_version: Some("v1".to_string()),
+                kind: Some("pod".to_string()),
+                name: Some(adress_to_podname(address)),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            }),
+            node_name: None,
+            zone: None,
+            hints: None,
+            deprecated_topology: None,
+        });
+
+        EndpointSlice {
+            metadata: ObjectMeta {
+                namespace: Some("default".to_string()),
+                owner_references: Some(vec![OwnerReference {
+                    name: "test-service".to_string(),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            },
+            address_type: "IPv4".to_string(),
+            endpoints,
+            ports: Some(vec![
+                k8s_openapi::api::discovery::v1::EndpointPort {
+                    name: Some("test-port".to_string()),
+                    port: Some(TEST_POD_PORT),
+                    protocol: Some("TCP".to_string()),
+                    app_protocol: None,
+                },
+                k8s_openapi::api::discovery::v1::EndpointPort {
+                    name: Some("test-port2".to_string()),
+                    port: Some(TEST_POD_PORT),
+                    protocol: Some("UDP".to_string()), // UDP should be disregarded, for now at least
+                    app_protocol: None,
+                },
+                k8s_openapi::api::discovery::v1::EndpointPort {
+                    name: Some("test-port2".to_string()),
+                    port: Some(TEST_POD_PORT + 1),
+                    protocol: Some("UDP".to_string()), // UDP should be disregarded, for now at least
+                    app_protocol: None,
+                },
+            ]),
+        }
+    }
+
+    #[test]
+    fn test_handle_endpoint_slice_event() {
+        let collector = KubernetesMetadataCollector::new();
+        let adress = IpAddr::from_str("192.168.1.1").unwrap();
+        let slice = create_test_slice(adress);
+
+        // add the endpoint
+        let event = Ok(Event::Apply(slice.clone()));
+        KubernetesMetadataCollector::handle_endpoint_slice_event(
+            event,
+            collector.pod_info_arc.clone(),
+        );
+
+        // keep these scoped so that they unlock after using, otherwise the next "handle_endpoint_slice will wait for lock forever"
+        {
+            let pod_info = collector.pod_info_arc.lock().unwrap();
+            assert_eq!(
+                pod_info.get(&adress).unwrap().get(&TEST_POD_PORT),
+                Some(&PodInfo {
+                    name: adress_to_podname(adress),
+                    namespace: "default".to_string(),
+                    service_name: "test-service".to_string(),
+                })
+            );
+        }
+
+        // now delete it
+        let event = Ok(Event::Delete(slice));
+        KubernetesMetadataCollector::handle_endpoint_slice_event(
+            event,
+            collector.pod_info_arc.clone(),
+        );
+
+        {
+            let pod_info = collector.pod_info_arc.lock().unwrap();
+            assert!(!pod_info.contains_key(&adress));
+        }
+
+        // and do a final test to see if it is still empty after a no-op event
+        KubernetesMetadataCollector::handle_endpoint_slice_event(
+            Err(watcher::Error::NoResourceVersion),
+            collector.pod_info_arc.clone(),
+        );
+
+        // Verify that the function returns early and doesn't modify the maps
+        {
+            let pod_info = collector.pod_info_arc.lock().unwrap();
+            assert!(pod_info.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_handle_pod_event() {
+        let collector = KubernetesMetadataCollector::new();
+        let adress = IpAddr::from_str("192.168.1.1").unwrap();
+        let pod = create_test_pod(adress);
+
+        // add the endpoint
+        let event = Ok(Event::Apply(pod.clone()));
+        KubernetesMetadataCollector::handle_pod_event(event, collector.pod_info_arc.clone());
+        let pod_info = collector.pod_info_arc.lock().unwrap();
+        assert!(!pod_info.is_empty());
+        assert!(pod_info.iter().next().unwrap().1.len() == 1); // should only contain 1 port, no UDP
+    }
+
+    fn clone_resource_event<K>(event: &Result<Event<K>, Error>) -> Result<Event<K>, Error>
+    where
+        K: Resource + Clone + DeserializeOwned + Debug + Send + 'static + Metadata<Ty = ObjectMeta>,
+    {
+        match event {
+            Ok(Event::Apply(pod)) => Ok(Event::Apply(pod.clone())),
+            Ok(Event::Delete(pod)) => Ok(Event::Delete(pod.clone())),
+            Ok(Event::InitApply(pod)) => Ok(Event::InitApply(pod.clone())),
+            Ok(Event::Init) => Ok(Event::Init),
+            Ok(Event::InitDone) => Ok(Event::InitDone),
+            Err(_) => Err(watcher::Error::WatchError(ErrorResponse {
+                code: 404,
+                message: "1".to_string(),
+                reason: "2".to_string(),
+                status: "3".to_string(),
+            })),
+        }
+    }
+
+    #[test]
+    fn test_both_watchers_deadlock_free() {
+        let collector = KubernetesMetadataCollector::new();
+        let adress = IpAddr::from_str("192.168.1.1").unwrap();
+        let adress2 = IpAddr::from_str("192.168.1.2").unwrap();
+        let pod = create_test_pod(adress);
+        let pod2 = create_test_pod(adress2);
+        let slice = create_test_slice(adress);
+        let slice2 = create_test_slice(adress2);
+
+        let duration = Duration::from_millis(400);
+        let start = Instant::now();
+        let is_pod_watcher_finished = Arc::new(AtomicBool::new(false));
+        let is_pod_watcher_finished_clone = is_pod_watcher_finished.clone();
+
+        // start pod watcher and run events in a loop rapidly
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let pod_event_vector = vec![
+            Ok(Event::Apply(pod.clone())),
+            Ok(Event::Delete(pod.clone())),
+            Ok(Event::Delete(pod2.clone())),
+            Ok(Event::InitApply(pod2.clone())),
+            Err(watcher::Error::WatchError(ErrorResponse {
+                code: 404,
+                message: "1".to_string(),
+                reason: "2".to_string(),
+                status: "3".to_string(),
+            })),
+            Ok(Event::Delete(pod2.clone())),
+            Ok(Event::InitApply(pod.clone())),
+            Ok(Event::Apply(pod2.clone())),
+            Ok(Event::Init),
+            Err(watcher::Error::NoResourceVersion),
+        ];
+        let w1_pod_info_arc = collector.pod_info_arc.clone();
+        let pod_handle = runtime.spawn(async move {
+            while start.elapsed() < duration {
+                for pod_event in &pod_event_vector {
+                    KubernetesMetadataCollector::handle_pod_event(
+                        clone_resource_event(pod_event),
+                        w1_pod_info_arc.clone(),
+                    );
+                }
+            }
+            is_pod_watcher_finished.store(true, Ordering::SeqCst); // so that we can make sure slice ran after this
+        });
+
+        // start endpoint slice watcher and run events in a loop rapidly
+        let slice_event_vector = vec![
+            Ok(Event::Apply(slice.clone())),
+            Ok(Event::Delete(slice.clone())),
+            Ok(Event::Delete(slice2.clone())),
+            Ok(Event::InitApply(slice2.clone())),
+            Err(watcher::Error::WatchError(ErrorResponse {
+                code: 404,
+                message: "1".to_string(),
+                reason: "2".to_string(),
+                status: "3".to_string(),
+            })),
+            Ok(Event::Delete(slice2.clone())),
+            Ok(Event::InitApply(slice.clone())),
+            Ok(Event::Apply(slice2.clone())),
+            Ok(Event::Init),
+            Err(watcher::Error::NoResourceVersion),
+        ];
+        let w2_pod_info_arc = collector.pod_info_arc.clone();
+        let slice_handle = runtime.spawn(async move {
+            // make sure slices run one last time after pods watcher, otherwise pods watcher can remove & reinsert
+            // port entries for TEST_POD_PORT, depending on order of execution. Which would remove namespace & service_name fields from pod_info
+            loop {
+                let last_run = is_pod_watcher_finished_clone.load(Ordering::SeqCst);
+                for slice_event in &slice_event_vector {
+                    KubernetesMetadataCollector::handle_endpoint_slice_event(
+                        clone_resource_event(slice_event),
+                        w2_pod_info_arc.clone(),
+                    );
+                }
+                if last_run {
+                    break;
+                }
+            }
+        });
+
+        loop {
+            if pod_handle.is_finished() && slice_handle.is_finished() {
+                break;
+            }
+        }
+        // now we are sure both concluded. We can check what data remains.
+        // we apply items last, so we must verify that they exist
+        let pod_info = collector.pod_info_arc.lock().unwrap();
+        assert_eq!(pod_info.len(), 2);
+        assert_eq!(
+            pod_info.get(&adress).unwrap().get(&TEST_POD_PORT),
+            Some(&PodInfo {
+                name: adress_to_podname(adress),
+                namespace: "default".to_string(),
+                service_name: "test-service".to_string(),
+            })
+        );
+        assert_eq!(
+            pod_info.get(&adress2).unwrap().get(&TEST_POD_PORT),
+            Some(&PodInfo {
+                name: adress_to_podname(adress2),
+                namespace: "default".to_string(),
+                service_name: "test-service".to_string(),
+            })
+        );
+    }
+}

--- a/nfm-controller/src/kubernetes/mod.rs
+++ b/nfm-controller/src/kubernetes/mod.rs
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod flow_metadata;
+pub mod kubernetes_metadata_collector;

--- a/nfm-controller/src/kubernetes/remote_nat_resolver.rs
+++ b/nfm-controller/src/kubernetes/remote_nat_resolver.rs
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use log::error;
+use nfm_common::{SockContext, AF_INET, AF_INET6};
+
+// only allow reading up to certain number of entries as this is very slow
+pub const CONNTRACK_MAX_TRACK_COUNT: usize = 5000;
+// each conntrack entry is around 230/325 bytes (ipv4/ipv6)
+pub const CONNTRACK_READER_BUF_SIZE: usize = 5000 * 325;
+
+#[derive(Debug, Clone)]
+pub struct RemoteNatEntry {
+    pub remote_ip_actual: IpAddr,
+    pub remote_port_actual: u16,
+}
+
+#[derive(Eq, Hash, PartialEq)]
+pub struct RemoteNatLookupEntry {
+    pub local_ip: IpAddr,
+    pub local_port: u16,
+}
+
+pub struct RemoteNatResolver {
+    remote_nat_map: HashMap<RemoteNatLookupEntry, RemoteNatEntry>,
+    conntrack_file_path: String,
+    pub remote_nat_entries_detected: u64,
+    pub unparsable_conntrack_entries_detected: u64,
+}
+
+impl Default for RemoteNatResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RemoteNatResolver {
+    pub fn new() -> Self {
+        Self {
+            remote_nat_map: HashMap::new(),
+            conntrack_file_path: String::from("/proc/net/nf_conntrack"),
+            remote_nat_entries_detected: 0,
+            unparsable_conntrack_entries_detected: 0,
+        }
+    }
+
+    pub fn new_with_custom_conntrack(conntrack_path: &str) -> Self {
+        Self {
+            remote_nat_map: HashMap::new(),
+            conntrack_file_path: String::from(conntrack_path),
+            remote_nat_entries_detected: 0,
+            unparsable_conntrack_entries_detected: 0,
+        }
+    }
+
+    fn insert(&mut self, key: RemoteNatLookupEntry, entry: RemoteNatEntry) {
+        self.remote_nat_map.insert(key, entry);
+    }
+
+    pub fn get_entry(&self, key: &RemoteNatLookupEntry) -> Option<&RemoteNatEntry> {
+        self.remote_nat_map.get(key)
+    }
+
+    pub fn get_entry_from_sock_context(
+        &self,
+        sock_context: &SockContext,
+    ) -> Option<&RemoteNatEntry> {
+        let local_address = match sock_context.address_family {
+            AF_INET => IpAddr::V4(Ipv4Addr::from(sock_context.local_ipv4)),
+            AF_INET6 => IpAddr::V6(Ipv6Addr::from(sock_context.local_ipv6)),
+            _ => return None,
+        };
+        self.remote_nat_map.get(&RemoteNatLookupEntry {
+            local_ip: local_address,
+            local_port: sock_context.local_port,
+        })
+    }
+
+    pub fn build_remote_nat_map(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let mut entry_count = 0;
+        let file = match std::fs::File::open(self.conntrack_file_path.clone()) {
+            Ok(file) => file,
+            Err(e) => {
+                error!(file_path = self.conntrack_file_path, error = e.to_string(); "Failed to open conntrack file");
+                return Err(e.into());
+            }
+        };
+        let reader = BufReader::with_capacity(CONNTRACK_READER_BUF_SIZE, file);
+        for line in reader.lines() {
+            match line {
+                Ok(line) => match self.parse_and_save_conntrack_line(&line) {
+                    Some(()) => (),
+                    None => {
+                        error!(line_str = line; "Conntrack line contains an unparsable entry");
+                        self.unparsable_conntrack_entries_detected += 1;
+                    }
+                },
+                Err(e) => {
+                    error!(error = e.to_string(); "Error reading conntrack line");
+                    return Err(e.into());
+                }
+            }
+            entry_count += 1;
+            if entry_count >= CONNTRACK_MAX_TRACK_COUNT {
+                break;
+            };
+        }
+        Ok(())
+    }
+
+    fn string_to_ipv4(decimal_ip: &str) -> Result<IpAddr, std::net::AddrParseError> {
+        let ip: std::net::Ipv4Addr = decimal_ip.parse()?;
+        Ok(IpAddr::V4(ip))
+    }
+
+    fn string_to_ipv6(hex_ipv6: &str) -> Result<IpAddr, std::net::AddrParseError> {
+        let ip: std::net::Ipv6Addr = hex_ipv6.parse()?;
+        Ok(IpAddr::V6(ip))
+    }
+
+    // What we are looking for are entries that have unmatching remote IPs we see and what remote party sees. For instance for following entry
+    // "ipv4 2 tcp 6 118 SYN_SENT src=172.19.107.118 dst=2.2.2.2 sport=33424 dport=80 src=192.168.23.16 dst=172.19.107.118 sport=80 dport=33424 mark=0 use=1"
+    // we send a packet to 2.2.2.2 but we expect 192.168.23.16 to send us responses
+    // for packets that we send to 2.2.2.2 netfilter changes 2.2.2.2 to 192.168.23.16 before it hits the wire
+    // and for reverse direction it changes src-ip of the packets arriving from 192.168.23.16 to 2.2.2.2
+    // our purpose is to detect these entries
+    fn parse_and_save_conntrack_line(&mut self, line: &str) -> Option<()> {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 14 {
+            // safety check
+            return Some(());
+        }
+        if parts[2] != "tcp" {
+            return Some(());
+        };
+        if parts[10].starts_with('[') {
+            // ipv4 2 tcp 6 118 SYN_SENT src=172.19.107.118 dst=2.2.2.2 sport=33424 dport=80 [UNREPLIED] src=2.2.2.2 dst=172.19.107.118 sport=80 dport=33424 mark=0 use=1
+            return Some(()); // means this isnt an established connection no need to track
+        }
+
+        let ip_version = parts[0].to_string();
+        let local_ip_that_sends_the_packet = parts[6].split('=').nth(1)?.to_string();
+        let local_port_that_sends_the_packet = parts[8].split('=').nth(1)?.parse().ok()?;
+        let remote_ip_we_think_we_send_to = parts[7].split('=').nth(1)?.to_string();
+        let remote_ip_that_hits_the_wire = parts[10].split('=').nth(1)?.to_string();
+        let remote_port_that_hits_the_wire = parts[12].split('=').nth(1)?.parse().ok()?;
+        if remote_ip_we_think_we_send_to != remote_ip_that_hits_the_wire {
+            let (local_ip, remote_ip) = match ip_version.as_str() {
+                "ipv4" => (
+                    Self::string_to_ipv4(&local_ip_that_sends_the_packet).unwrap(),
+                    Self::string_to_ipv4(&remote_ip_that_hits_the_wire).unwrap(),
+                ),
+                "ipv6" => (
+                    Self::string_to_ipv6(&local_ip_that_sends_the_packet).unwrap(),
+                    Self::string_to_ipv6(&remote_ip_that_hits_the_wire).unwrap(),
+                ),
+                _ => return None,
+            };
+            self.insert(
+                RemoteNatLookupEntry {
+                    local_ip,
+                    local_port: local_port_that_sends_the_packet,
+                },
+                RemoteNatEntry {
+                    remote_ip_actual: remote_ip,
+                    remote_port_actual: remote_port_that_hits_the_wire,
+                },
+            );
+            self.remote_nat_entries_detected += 1;
+        }
+        Some(())
+    }
+}

--- a/nfm-controller/src/lib.rs
+++ b/nfm-controller/src/lib.rs
@@ -1,0 +1,475 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod events;
+pub mod kubernetes;
+pub mod metadata;
+pub mod reports;
+pub mod utils;
+
+use aya::util::KernelVersion;
+use clap::{Parser, ValueEnum};
+use kubernetes::kubernetes_metadata_collector::KubernetesMetadataCollector;
+use log::{error, info};
+use metadata::eni::EniMetadataProvider;
+use metadata::env_metadata_provider::{MultiMetadataProvider, MultiMetadataProviderImpl};
+use metadata::host::HostMetadataProvider;
+use metadata::runtime_environment_metadata::RuntimeEnvironmentMetadataProvider;
+use reports::publisher::MultiPublisher;
+use reports::ReportCompression;
+use serde::Serialize;
+use signal_hook::consts::signal::{SIGINT, SIGQUIT, SIGTERM};
+use std::sync::{atomic::AtomicBool, Arc};
+use std::{fmt, str, time::Duration};
+use structured_logger::json::new_writer;
+
+use crate::events::{
+    event_filter::EventFilter,
+    event_filter_top_loss::EventFilterTopLoss,
+    event_provider::EventProvider,
+    event_provider_ebpf::EventProviderEbpf,
+    host_stats_provider::{HostStats, HostStatsProvider, HostStatsProviderImpl},
+    nat_resolver::{NatResolver, NatResolverImpl, NatResolverNoOp},
+    network_event::AggregateResults,
+};
+use crate::reports::publisher::ReportPublisher;
+use crate::reports::report::{NfmReport, ProcessStats, UsageStats};
+use crate::utils::{
+    event_timer, CpuUsageMonitor, EventTimer, MemoryInspector, ProcessMemoryInspector,
+    SystemBootClock,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+enum OnOff {
+    On,
+    Off,
+}
+
+impl fmt::Display for OnOff {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OnOff::On => write!(f, "on"),
+            OnOff::Off => write!(f, "off"),
+        }
+    }
+}
+
+// GRCOV_STOP_COVERAGE
+#[derive(Debug, Parser, Serialize)]
+#[command(name = "network-flow-monitor-agent", version, about, long_about = None)]
+pub struct Options {
+    // `/sys/fs/cgroup/unified` is used by systemd
+    // https://systemd.io/CGROUP_DELEGATION/#three-different-tree-setups-
+    /// Cgroup used to capture network events
+    #[clap(short, long, default_value = "/sys/fs/cgroup/unified")]
+    cgroup: String,
+
+    /// Max number of flows to report
+    #[clap(short, long, default_value_t = 500)]
+    top_k: usize,
+
+    /// The amount of time after which an inactive socket will no longer be tracked.
+    // A socket using a default exponential backoff count of 6 can be idle for up to 63 seconds.
+    // If this config knob is not long enough, such failing sockets will be evicted as stale before
+    // being observed as severed on the flow.
+    #[clap(short = 'v', long, default_value_t = 65, value_parser = clap::value_parser!(u64).range(1..=600))]
+    notrack_secs: u64,
+
+    /// Includes health and performance data about the agent in published reports.
+    #[clap(short, long, default_value_t = OnOff::On)]
+    usage_data: OnOff,
+
+    /// The amount of time between successive aggregation of results.
+    #[clap(short, long, default_value_t = 500, value_parser = clap::value_parser!(u64).range(100..=60000))]
+    aggregate_msecs: u64,
+
+    /// The amount of time between successive publishing of results.
+    #[clap(short = 's', long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..=600))]
+    publish_secs: u64,
+
+    /// The amount of time by which publish periods can vary.
+    #[clap(short, long, default_value_t = 5, value_parser = clap::value_parser!(u64).range(0..=600))]
+    jitter_secs: u64,
+
+    /// Endpoint to send reports to
+    #[clap(short = 'e', long, default_value = "")]
+    endpoint: String,
+
+    /// Region of the endpoint
+    #[clap(short = 'r', long, default_value = "")]
+    endpoint_region: String,
+
+    /// Enable log reports
+    #[clap(short = 'l', long, default_value_t = OnOff::Off)]
+    log_reports: OnOff,
+
+    /// Enable publish reports to the endpoint
+    #[clap(short = 'p', long, default_value_t = OnOff::On)]
+    publish_reports: OnOff,
+
+    /// Report compression (for endpoint publishing)
+    #[clap(short = 'z', long, default_value_t = ReportCompression::Gzip)]
+    report_compression: ReportCompression,
+
+    /// Include kubernetes metadata in published reports.
+    #[clap(short = 'k', long, default_value_t = OnOff::Off)]
+    kubernetes_metadata: OnOff,
+
+    /// Within reports, use IP addresses that are external to locally performed NAT.
+    #[clap(short = 'n', long, default_value_t = OnOff::Off)]
+    resolve_nat: OnOff,
+}
+
+pub fn check_kernel_version() -> Result<(), anyhow::Error> {
+    let version_actual = KernelVersion::current().unwrap();
+    let version_min_expected = KernelVersion::new(5, 8, 0);
+    if version_actual >= version_min_expected {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "Kernel version at or above {} expected, found {}",
+            version_min_expected,
+            version_actual
+        ))
+    }
+}
+
+pub fn on_load(opt: Options) -> Result<(), anyhow::Error> {
+    check_kernel_version()?;
+
+    // Initialize logging to stdout.  Log level can be set via env var RUST_LOG, and defaults to
+    // info.
+    structured_logger::Builder::new()
+        .with_default_writer(new_writer(std::io::stdout()))
+        .init();
+    info!(args:serde = opt; "Starting up");
+
+    // Load NFM objects
+    let event_provider =
+        match EventProviderEbpf::new(&opt.cgroup, opt.notrack_secs, SystemBootClock {}) {
+            Ok(prov) => prov,
+            Err(e) => {
+                return Err(e);
+            }
+        };
+    let nat_resolver: Box<dyn NatResolver> = if opt.resolve_nat == OnOff::On {
+        Box::new(NatResolverImpl::initialize())
+    } else {
+        Box::new(NatResolverNoOp {})
+    };
+    let event_filter = EventFilterTopLoss::new(opt.top_k.try_into().unwrap());
+    let publisher = MultiPublisher::from_options(&opt);
+    let metadata_provider = MultiMetadataProviderImpl {
+        eni_metadata: EniMetadataProvider::new(),
+        host_metadata: HostMetadataProvider::new(),
+        runtime_env_metadata: RuntimeEnvironmentMetadataProvider::new(),
+    };
+    let host_stats_provider = HostStatsProviderImpl::new();
+
+    do_work(
+        event_provider,
+        nat_resolver,
+        event_filter,
+        publisher,
+        metadata_provider,
+        host_stats_provider,
+        opt,
+    );
+
+    Ok(())
+}
+// GRCOV_BEGIN_COVERAGE
+
+fn do_work(
+    mut provider: impl EventProvider,
+    mut nat_resolver: Box<dyn NatResolver>,
+    mut event_filter: impl EventFilter<AggregateResults>,
+    publisher: impl ReportPublisher,
+    mut metadata_provider: impl MultiMetadataProvider,
+    mut host_stats_provider: impl HostStatsProvider,
+    opt: Options,
+) {
+    let memory_inspector = ProcessMemoryInspector::new();
+    let mut cpu_monitor = CpuUsageMonitor::start();
+    let mut timer = EventTimer::new(SystemBootClock {});
+
+    let aggregate_event = timer.add_event(
+        Duration::from_millis(opt.aggregate_msecs),
+        Duration::from_secs(0),
+    );
+    let publish_event = timer.add_event(
+        Duration::from_secs(opt.publish_secs),
+        Duration::from_secs(opt.jitter_secs),
+    );
+
+    // Register POSIX signals for which we want to exit gracefully.
+    let should_exit = Arc::new(AtomicBool::new(false));
+    signal_hook::flag::register(SIGINT, Arc::clone(&should_exit))
+        .expect("Failed to register SIGINT handler");
+    signal_hook::flag::register(SIGQUIT, Arc::clone(&should_exit))
+        .expect("Failed to register SIGQUIT handler");
+    signal_hook::flag::register(SIGTERM, Arc::clone(&should_exit))
+        .expect("Failed to register SIGTERM handler");
+    timer.set_exit_flag(should_exit);
+
+    let enable_usage_data = opt.usage_data == OnOff::On;
+    let mut failed_reports_count = 0;
+    let mut usage_stats = UsageStats::default();
+    let mut k8s_metadata_collector = KubernetesMetadataCollector::new();
+    if opt.kubernetes_metadata == OnOff::On {
+        k8s_metadata_collector.setup_watchers();
+    }
+
+    loop {
+        let event_id = timer.await_next_event();
+        if event_id == event_timer::EXIT_EVENT {
+            info!("Exiting");
+            return;
+        }
+
+        if event_id == aggregate_event {
+            nat_resolver.perform_aggregation_cycle();
+            provider.perform_aggregation_cycle(&nat_resolver);
+            nat_resolver.perform_eviction();
+        } else if event_id == publish_event {
+            // Add network stats to the report.
+            let mut report = NfmReport::new();
+            report.set_failed_reports(failed_reports_count);
+
+            let mut agg_flows = provider.network_stats();
+            if opt.kubernetes_metadata == OnOff::On {
+                k8s_metadata_collector.enrich_flows(&mut agg_flows);
+            }
+            report.set_network_stats(event_filter.filter_events(agg_flows));
+
+            // Add process stats to the report.
+            if enable_usage_data {
+                // Compute CPU usage then restart the monitor.
+                usage_stats.cpu_util = cpu_monitor.usage_ratio();
+                cpu_monitor = CpuUsageMonitor::start();
+
+                report.set_process_stats(ProcessStats {
+                    counters: provider.counters(),
+                    usage: vec![usage_stats],
+                });
+
+                // Reset stats for the next report.
+                usage_stats = UsageStats::default();
+            }
+
+            // Add metadata
+            metadata_provider.refresh();
+            report.set_env_metadata(metadata_provider.get_metadata());
+
+            host_stats_provider.set_network_devices(&metadata_provider.get_network_devices());
+            report.set_host_stats(host_stats_provider.get_stats());
+
+            if publisher.publish(&report) {
+                failed_reports_count = 0;
+            } else {
+                failed_reports_count += 1;
+            }
+        } else {
+            error!("Received unknown event ID: {event_id}");
+        }
+
+        // We'll publish the highest mem usage during the report period.
+        if enable_usage_data {
+            let (mem_used_kb, mem_used_ratio) = memory_inspector.usage();
+            usage_stats.mem_used_kb = usage_stats.mem_used_kb.max(mem_used_kb);
+            usage_stats.mem_used_ratio = usage_stats.mem_used_ratio.max(mem_used_ratio);
+            usage_stats.sockets_tracked = usage_stats.sockets_tracked.max(provider.socket_count());
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::events::{
+        host_stats_provider::HostStats, nat_resolver::NatResolver, SockCache, SockOperationResult,
+    };
+    use metadata::env_metadata_provider::{
+        EnvMetadata, EnvMetadataProvider, MultiMetadataProvider, NetworkDevice,
+    };
+    use nfm_common::SockContext;
+    use reports::CountersOverall;
+
+    use std::{sync::Mutex, thread, time::Instant};
+
+    #[derive(Clone, Default)]
+    struct EventProviderNoOp {
+        calls: Arc<Mutex<u8>>,
+    }
+    #[derive(Clone, Default)]
+    struct NatResolverNoOp {
+        calls: Arc<Mutex<u8>>,
+    }
+    #[derive(Clone, Default)]
+    struct EventFilterNoOp {
+        calls: Arc<Mutex<u8>>,
+    }
+    #[derive(Clone, Default)]
+    struct PublisherNoOp {
+        calls: Arc<Mutex<u8>>,
+    }
+    #[derive(Clone, Default)]
+    struct MultiMetadataProviderNoOp {
+        calls: Arc<Mutex<u8>>,
+    }
+    #[derive(Clone, Default)]
+    struct HostStatsProviderNoOp {
+        calls: Arc<Mutex<u8>>,
+    }
+
+    impl EventProvider for EventProviderNoOp {
+        fn perform_aggregation_cycle(&mut self, _nat_resolver: &Box<dyn NatResolver>) {
+            let mut calls = self.calls.lock().unwrap();
+            *calls = (*calls).saturating_add(1);
+        }
+        fn network_stats(&mut self) -> Vec<AggregateResults> {
+            let mut calls = self.calls.lock().unwrap();
+            *calls = (*calls).saturating_add(1);
+
+            vec![]
+        }
+        fn counters(&mut self) -> CountersOverall {
+            CountersOverall::default()
+        }
+        fn socket_count(&self) -> u64 {
+            0
+        }
+    }
+
+    impl NatResolver for NatResolverNoOp {
+        fn perform_aggregation_cycle(&mut self) {
+            let mut calls = self.calls.lock().unwrap();
+            *calls = (*calls).saturating_add(1);
+        }
+        fn perform_eviction(&mut self) {}
+        fn get_beyond_nat_entry(&self, _sock_context: &SockContext) -> Option<SockContext> {
+            None
+        }
+        fn store_beyond_nat_entries(&self, _sock_cache: &mut SockCache) -> SockOperationResult {
+            SockOperationResult::default()
+        }
+        fn num_entries(&self) -> usize {
+            0
+        }
+    }
+
+    impl EventFilter<AggregateResults> for EventFilterNoOp {
+        fn filter_events(&mut self, _events: Vec<AggregateResults>) -> Vec<AggregateResults> {
+            let mut calls = self.calls.lock().unwrap();
+            *calls = (*calls).saturating_add(1);
+            vec![]
+        }
+    }
+
+    impl ReportPublisher for PublisherNoOp {
+        fn publish(&self, _report: &NfmReport) -> bool {
+            let mut calls = self.calls.lock().unwrap();
+            *calls = (*calls).saturating_add(1);
+            true
+        }
+    }
+
+    impl MultiMetadataProvider for MultiMetadataProviderNoOp {
+        fn get_network_devices(&mut self) -> Vec<NetworkDevice> {
+            vec![]
+        }
+    }
+
+    impl EnvMetadataProvider for MultiMetadataProviderNoOp {
+        fn refresh(&mut self) {
+            let mut calls = self.calls.lock().unwrap();
+            *calls = (*calls).saturating_add(1);
+        }
+        fn get_metadata(&self) -> EnvMetadata {
+            let mut calls = self.calls.lock().unwrap();
+            *calls = (*calls).saturating_add(1);
+            EnvMetadata::default()
+        }
+    }
+
+    impl HostStatsProvider for HostStatsProviderNoOp {
+        fn set_network_devices(&mut self, _net_devices: &[NetworkDevice]) {
+            let mut calls = self.calls.lock().unwrap();
+            *calls = (*calls).saturating_add(1);
+        }
+
+        fn get_stats(&mut self) -> HostStats {
+            let mut calls = self.calls.lock().unwrap();
+            *calls = (*calls).saturating_add(1);
+            HostStats::default()
+        }
+    }
+
+    #[test]
+    fn test_do_work() {
+        let event_provider = EventProviderNoOp::default();
+        let nat_resolver = NatResolverNoOp::default();
+        let event_filter = EventFilterNoOp::default();
+        let publisher = PublisherNoOp::default();
+        let metadata_provider = MultiMetadataProviderNoOp::default();
+        let host_stats_provider = HostStatsProviderNoOp::default();
+
+        // Clone the struct to pass it to the thread
+        let event_provider_clone = event_provider.clone();
+        let nat_resolver_clone = nat_resolver.clone();
+        let event_filter_clone = event_filter.clone();
+        let publisher_clone = publisher.clone();
+        let metadata_provider_clone = metadata_provider.clone();
+        let host_stats_provider_clone = host_stats_provider.clone();
+
+        thread::spawn(move || {
+            do_work(
+                event_provider_clone,
+                Box::new(nat_resolver_clone),
+                event_filter_clone,
+                publisher_clone,
+                metadata_provider_clone,
+                host_stats_provider_clone,
+                Options {
+                    log_reports: OnOff::Off,
+                    publish_reports: OnOff::Off,
+                    endpoint: "a".to_string(),
+                    endpoint_region: "b".to_string(),
+                    cgroup: "c".to_string(),
+                    top_k: 100,
+                    notrack_secs: 0,
+                    usage_data: OnOff::On,
+                    aggregate_msecs: 0,
+                    publish_secs: 0,
+                    jitter_secs: 0,
+                    report_compression: ReportCompression::None,
+                    kubernetes_metadata: OnOff::On,
+                    resolve_nat: OnOff::On,
+                },
+            );
+        });
+
+        let duration = Duration::from_millis(2000);
+        let start = Instant::now();
+        while start.elapsed() < duration {
+            // allow thread start to be delayed for 2sec at worst, to prevent failures at test
+            if *event_provider.calls.lock().unwrap() >= 1
+                && *nat_resolver.calls.lock().unwrap() >= 1
+                && *event_filter.calls.lock().unwrap() >= 1
+                && *publisher.calls.lock().unwrap() >= 1
+                && *metadata_provider.calls.lock().unwrap() >= 1
+                && *host_stats_provider.calls.lock().unwrap() >= 1
+            {
+                return; // success
+            };
+        }
+        assert!(false); // failure
+    }
+
+    #[test]
+    fn test_on_off_display() {
+        assert_eq!(OnOff::On.to_string(), "on");
+        assert_eq!(OnOff::Off.to_string(), "off");
+    }
+}

--- a/nfm-controller/src/main.rs
+++ b/nfm-controller/src/main.rs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use nfm_agent::{on_load, Options};
+
+fn main() -> Result<(), anyhow::Error> {
+    on_load(Options::parse())
+}

--- a/nfm-controller/src/metadata/eni.rs
+++ b/nfm-controller/src/metadata/eni.rs
@@ -1,0 +1,321 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::env_metadata_provider::{EnvMetadata, EnvMetadataProvider, NetworkDevice};
+use crate::reports::report::ReportValue;
+use crate::utils::{CommandRunner, RealCommandRunner};
+use aws_config::imds::Client;
+
+use hashbrown::HashMap;
+use log::{error, warn};
+
+const KEY_INSTANCE_ID: &str = "instance-id";
+const KEY_INSTANCE_TYPE: &str = "instance-type";
+
+/// Metadata provider related to AWS. Only supports IMDSv2.
+pub struct EniMetadataProvider {
+    pub(crate) client: Client,
+    pub(crate) instance_id: String,
+    pub(crate) instance_type: String,
+    pub(crate) network: Vec<NetworkInterfaceInfo>,
+    pub(crate) command_runner: Box<dyn CommandRunner>,
+}
+
+#[derive(Debug)]
+#[cfg_attr(test, derive(Default))]
+pub(crate) struct NetworkInterfaceInfo {
+    pub(crate) mac: String,
+    pub(crate) interface_id: String,
+}
+
+impl EniMetadataProvider {
+    pub fn new() -> EniMetadataProvider {
+        let client = Client::builder().build();
+        let instance_id = retrieve_instance_id(&client);
+        let instance_type = retrieve_instance_type(&client);
+        let network = retrieve_network_information(&client);
+        EniMetadataProvider {
+            client,
+            instance_id,
+            instance_type,
+            network,
+            command_runner: Box::new(RealCommandRunner {}),
+        }
+    }
+
+    // Gets the network devices associated with the current host.
+    pub fn get_network_devices(&mut self) -> Vec<NetworkDevice> {
+        let mut mac_to_device: HashMap<String, String> = HashMap::new();
+
+        let output = self.command_runner.run("ip", &["-br", "link"]);
+        if let Err(err) = output {
+            error!(error = err.to_string(); "Failed to get IP link device names");
+            return vec![];
+        }
+
+        for line in String::from_utf8_lossy(&output.unwrap().stdout).lines() {
+            let parts = line.split_ascii_whitespace().collect::<Vec<_>>();
+            if parts.len() == 4 {
+                mac_to_device.insert(parts[2].to_string(), parts[0].to_string());
+            }
+        }
+
+        let mut net_devices: Vec<NetworkDevice> = Vec::new();
+        for net_info in &self.network {
+            if let Some(dev_name) = mac_to_device.get(&net_info.mac) {
+                net_devices.push(NetworkDevice {
+                    device_name: dev_name.clone(),
+                    interface_id: net_info.interface_id.clone(),
+                });
+            }
+        }
+
+        net_devices
+    }
+}
+
+impl Default for EniMetadataProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EnvMetadataProvider for EniMetadataProvider {
+    fn refresh(&mut self) {
+        if self.instance_id.is_empty() {
+            self.instance_id = retrieve_instance_id(&self.client);
+        }
+        if self.instance_type.is_empty() {
+            self.instance_type = retrieve_instance_type(&self.client);
+        }
+        self.network = retrieve_network_information(&self.client);
+    }
+
+    fn get_metadata(&self) -> EnvMetadata {
+        let mut metadata = EnvMetadata::new();
+
+        // Instance metadata
+        metadata.insert(
+            KEY_INSTANCE_ID.into(),
+            ReportValue::String(self.instance_id.clone()),
+        );
+        metadata.insert(
+            KEY_INSTANCE_TYPE.into(),
+            ReportValue::String(self.instance_type.clone()),
+        );
+
+        metadata
+    }
+}
+
+fn retrieve_imds_metadata(client: &aws_config::imds::Client, path: String) -> String {
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(err) => {
+            error!(error = err.to_string(); "Error creating tokio runtime");
+            return "".into();
+        }
+    };
+
+    match rt.block_on(client.get(&path)) {
+        Ok(instance_id) => instance_id.into(),
+        Err(err) => {
+            error!(error = err.to_string(), path = path; "Error retrieving imds metadata");
+            "".into()
+        }
+    }
+}
+
+fn retrieve_instance_id(client: &aws_config::imds::Client) -> String {
+    retrieve_imds_metadata(client, "/latest/meta-data/instance-id".to_string())
+}
+
+fn retrieve_instance_type(client: &aws_config::imds::Client) -> String {
+    retrieve_imds_metadata(client, "/latest/meta-data/instance-type".to_string())
+}
+
+fn retrieve_network_information(client: &aws_config::imds::Client) -> Vec<NetworkInterfaceInfo> {
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(err) => {
+            error!(error = err.to_string(); "Error creating tokio runtime");
+            return vec![];
+        }
+    };
+
+    rt.block_on(async {
+        match client
+            .get("/latest/meta-data/network/interfaces/macs/")
+            .await
+        {
+            Ok(macs) => {
+                let mut network_information = vec![];
+                let macs = String::from(macs);
+                for mac in macs.split('\n') {
+                    // There is trailing backslash in each line.
+                    let mut mac = mac.to_string();
+                    if !mac.is_empty() && mac.ends_with('/') {
+                        mac.pop();
+                    }
+
+                    network_information.extend(retrieve_mac_information(client, mac).await)
+                }
+                network_information
+            }
+            Err(err) => {
+                error!(error = err.to_string(); "Error retrieving network information");
+                vec![]
+            }
+        }
+    })
+}
+
+async fn retrieve_mac_information(
+    client: &aws_config::imds::Client,
+    mac: String,
+) -> Vec<NetworkInterfaceInfo> {
+    vec![NetworkInterfaceInfo {
+        mac: mac.clone(),
+        interface_id: get_mac_attribute(client, &mac, "interface-id").await,
+    }]
+}
+
+async fn get_mac_attribute(
+    client: &aws_config::imds::Client,
+    mac: &String,
+    attribute: &str,
+) -> String {
+    match client
+        .get(format!("/latest/meta-data/network/interfaces/macs/{mac}/{attribute}").as_str())
+        .await
+    {
+        Ok(attribute) => attribute.into(),
+        Err(err) => {
+            warn!(error = err.to_string(); "Error retrieving {attribute} for {mac}");
+            "".to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::utils::FakeCommandRunner;
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::{ExitStatus, Output};
+
+    #[test]
+    fn test_instance_id() {
+        let mut ec2_provider = EniMetadataProvider::default();
+        ec2_provider.refresh();
+        let metadata = ec2_provider.get_metadata();
+        assert!(metadata.contains_key("instance-id"));
+    }
+
+    #[test]
+    fn test_network_information() {
+        let ec2_provider = EniMetadataProvider {
+            client: Client::builder().build(),
+            instance_id: "the-instance-id".into(),
+            instance_type: "the-instance-type".into(),
+            network: vec![NetworkInterfaceInfo {
+                mac: "the-mac".into(),
+                interface_id: "the-interface-id".into(),
+            }],
+            command_runner: Box::new(FakeCommandRunner::new()),
+        };
+        let metadata = ec2_provider.get_metadata();
+
+        assert_eq!(metadata.len(), 2);
+        assert_eq!(
+            metadata.get("instance-id").unwrap(),
+            &ReportValue::String("the-instance-id".into())
+        );
+        assert_eq!(
+            metadata.get("instance-type").unwrap(),
+            &ReportValue::String("the-instance-type".into())
+        );
+    }
+
+    #[test]
+    fn test_network_in_ec2() {
+        if !running_on_ec2() {
+            // If are not running on EC2, ignore test
+            return;
+        }
+        let mut ec2_provider = EniMetadataProvider::new();
+        ec2_provider.refresh();
+        let metadata = ec2_provider.get_metadata();
+
+        assert!(!metadata.is_empty());
+        assert!(metadata.contains_key("instance-id"));
+
+        let network_info = retrieve_network_information(&Client::builder().build());
+        for network in network_info {
+            assert!(!network.mac.is_empty());
+            assert!(network.interface_id.starts_with("eni-"));
+        }
+    }
+
+    #[test]
+    fn test_get_network_devices() {
+        let mut fake_runner = FakeCommandRunner::new();
+        fake_runner.add_expectation(
+            "ip",
+            &["-br", "link"],
+            Ok(Output {
+                status: ExitStatus::from_raw(0),
+                stdout: r#"
+                    lo               UNKNOWN        11:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP> 
+                    eth1             UP             22:00:00:00:00:00 <BROADCAST,MULTICAST,UP,LOWER_UP> 
+                    docker0          DOWN           33:00:00:00:00:00 <NO-CARRIER,BROADCAST,MULTICAST,UP> 
+                    eth2             UP             44:00:00:00:00:00 <BROADCAST,MULTICAST,UP,LOWER_UP> 
+                "#
+                .as_bytes()
+                .to_vec(),
+                stderr: vec![],
+            }),
+        );
+
+        let net_infos: Vec<NetworkInterfaceInfo> = vec![
+            NetworkInterfaceInfo {
+                mac: "22:00:00:00:00:00".to_string(),
+                interface_id: "ifc-id1".to_string(),
+                ..Default::default()
+            },
+            NetworkInterfaceInfo {
+                mac: "44:00:00:00:00:00".to_string(),
+                interface_id: "ifc-id2".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let mut eni_provider = EniMetadataProvider {
+            client: Client::builder().build(),
+            instance_id: "inst-id1".to_string(),
+            instance_type: "the-instance-type".into(),
+            network: net_infos,
+            command_runner: Box::new(fake_runner.clone()),
+        };
+
+        let expected_net_devs: Vec<NetworkDevice> = vec![
+            NetworkDevice {
+                interface_id: "ifc-id1".to_string(),
+                device_name: "eth1".to_string(),
+            },
+            NetworkDevice {
+                interface_id: "ifc-id2".to_string(),
+                device_name: "eth2".to_string(),
+            },
+        ];
+
+        let actual_net_devs = eni_provider.get_network_devices();
+        assert_eq!(actual_net_devs, expected_net_devs);
+        assert!(fake_runner.expectations.lock().unwrap().is_empty());
+    }
+
+    fn running_on_ec2() -> bool {
+        !retrieve_instance_id(&Client::builder().build()).is_empty()
+            && !retrieve_network_information(&Client::builder().build()).is_empty()
+    }
+}

--- a/nfm-controller/src/metadata/env_metadata_provider.rs
+++ b/nfm-controller/src/metadata/env_metadata_provider.rs
@@ -1,0 +1,133 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metadata::runtime_environment_metadata::RuntimeEnvironmentMetadataProvider;
+use crate::reports::report::ReportValue;
+use crate::EniMetadataProvider;
+use crate::HostMetadataProvider;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct EnvMetadata(Vec<(String, ReportValue)>);
+
+impl EnvMetadata {
+    pub fn new() -> Self {
+        EnvMetadata(Vec::new())
+    }
+    pub fn from(vec: Vec<(String, ReportValue)>) -> Self {
+        EnvMetadata(vec)
+    }
+    pub fn insert(&mut self, key: String, value: ReportValue) {
+        self.0.push((key, value));
+    }
+    pub fn enumerate(&self) -> impl Iterator<Item = &(String, ReportValue)> {
+        self.0.iter()
+    }
+    pub fn extend(&mut self, other: EnvMetadata) {
+        self.0.extend(other.0);
+    }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.0.iter().any(|(k, _)| k == key)
+    }
+    pub fn get(&self, key: &str) -> Option<&ReportValue> {
+        self.0
+            .iter()
+            .find_map(|(k, v)| if k == key { Some(v) } else { None })
+    }
+}
+
+impl Default for EnvMetadata {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub trait EnvMetadataProvider {
+    fn refresh(&mut self);
+    fn get_metadata(&self) -> EnvMetadata;
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+pub struct NetworkDevice {
+    pub device_name: String,
+    pub interface_id: String,
+}
+
+pub trait MultiMetadataProvider: EnvMetadataProvider {
+    fn get_network_devices(&mut self) -> Vec<NetworkDevice>;
+}
+
+pub struct MultiMetadataProviderImpl {
+    pub eni_metadata: EniMetadataProvider,
+    pub host_metadata: HostMetadataProvider,
+    pub runtime_env_metadata: RuntimeEnvironmentMetadataProvider,
+}
+
+impl MultiMetadataProvider for MultiMetadataProviderImpl {
+    fn get_network_devices(&mut self) -> Vec<NetworkDevice> {
+        self.eni_metadata.get_network_devices()
+    }
+}
+
+impl EnvMetadataProvider for MultiMetadataProviderImpl {
+    fn refresh(&mut self) {
+        self.eni_metadata.refresh();
+        self.host_metadata.refresh();
+        self.runtime_env_metadata.refresh();
+    }
+
+    fn get_metadata(&self) -> EnvMetadata {
+        let mut metadata = EnvMetadata::new();
+        metadata.extend(self.eni_metadata.get_metadata());
+        metadata.extend(self.host_metadata.get_metadata());
+        metadata.extend(self.runtime_env_metadata.get_metadata());
+
+        metadata
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::metadata::eni::NetworkInterfaceInfo;
+    use crate::utils::FakeCommandRunner;
+    use aws_config::imds::Client;
+
+    #[test]
+    fn test_multi_metadata_provider() {
+        let eni_metadata = EniMetadataProvider {
+            client: Client::builder().build(),
+            instance_id: "the-instance-id".into(),
+            instance_type: "the-instance-type".into(),
+            network: vec![NetworkInterfaceInfo {
+                mac: "the-mac".into(),
+                interface_id: "the-interface-id".into(),
+            }],
+            command_runner: Box::new(FakeCommandRunner::new()),
+        };
+        let host_metadata = HostMetadataProvider::default();
+        let runtime_env_metadata = RuntimeEnvironmentMetadataProvider::default();
+        let mut mmp = MultiMetadataProviderImpl {
+            eni_metadata,
+            host_metadata,
+            runtime_env_metadata,
+        };
+
+        let multi_md = mmp.get_metadata();
+        assert!(multi_md.contains_key("instance-id"));
+        assert!(multi_md.contains_key("machine-id"));
+        assert!(multi_md.contains_key("instance-type"));
+        assert!(multi_md.contains_key("compute_platform"));
+
+        mmp.refresh();
+        assert!(mmp.get_metadata().len() >= 4);
+    }
+}

--- a/nfm-controller/src/metadata/host.rs
+++ b/nfm-controller/src/metadata/host.rs
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+
+use crate::metadata::env_metadata_provider::{EnvMetadata, EnvMetadataProvider};
+use crate::reports::report::ReportValue;
+
+pub struct HostMetadataProvider {
+    machine_id: String,
+}
+
+impl HostMetadataProvider {
+    pub fn new() -> Self {
+        Self {
+            machine_id: get_machine_id(),
+        }
+    }
+}
+
+impl Default for HostMetadataProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EnvMetadataProvider for HostMetadataProvider {
+    fn refresh(&mut self) {
+        if self.machine_id.is_empty() {
+            self.machine_id = get_machine_id();
+        }
+    }
+
+    fn get_metadata(&self) -> EnvMetadata {
+        EnvMetadata::from(vec![(
+            "machine-id".into(),
+            ReportValue::String(self.machine_id.clone()),
+        )])
+    }
+}
+
+fn get_machine_id() -> String {
+    // https://man7.org/linux/man-pages/man5/machine-id.5.html
+    fs::read_to_string("/etc/machine-id")
+        .unwrap_or("".to_string())
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_machine_id() {
+        let mut ec2_provider = HostMetadataProvider::default();
+        ec2_provider.refresh();
+        let metadata = ec2_provider.get_metadata();
+        assert_eq!(metadata.len(), 1);
+        assert!(metadata.contains_key("machine-id"));
+
+        assert!(metadata.enumerate().any(|(key, value)| {
+            if key != "machine-id" {
+                return false;
+            }
+            if let ReportValue::String(str_value) = value {
+                return !str_value.is_empty() && !str_value.ends_with('\n');
+            }
+            false
+        }));
+    }
+}

--- a/nfm-controller/src/metadata/k8s_metadata.rs
+++ b/nfm-controller/src/metadata/k8s_metadata.rs
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env;
+
+use serde::{Deserialize, Serialize};
+
+use crate::reports::report::ReportValue;
+
+pub const ENV_K8S_NODE_NAME: &str = "K8S_NODE_NAME";
+pub const ENV_EKS_CLUSTER_NAME: &str = "EKS_CLUSTER_NAME";
+
+#[derive(Clone, Debug, Serialize, PartialEq, Deserialize)]
+pub struct K8sMetadata {
+    pub node_name: Option<ReportValue>,
+    pub cluster_name: Option<ReportValue>,
+}
+
+impl Default for K8sMetadata {
+    fn default() -> Self {
+        K8sMetadata {
+            node_name: {
+                if let Ok(node_name) = env::var(ENV_K8S_NODE_NAME) {
+                    Some(ReportValue::String(node_name))
+                } else {
+                    None
+                }
+            },
+            cluster_name: {
+                if let Ok(node_name) = env::var(ENV_EKS_CLUSTER_NAME) {
+                    Some(ReportValue::String(node_name))
+                } else {
+                    None
+                }
+            },
+        }
+    }
+}
+
+impl K8sMetadata {
+    pub fn new(node_name: &str, cluster_name: &str) -> Self {
+        K8sMetadata {
+            node_name: Some(ReportValue::String(node_name.to_string())),
+            cluster_name: Some(ReportValue::String(cluster_name.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    pub static UNIT_TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+    #[macro_export]
+    macro_rules! acquire_test_lock {
+        () => {
+            let _lock = crate::metadata::k8s_metadata::tests::UNIT_TEST_MUTEX
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap();
+        };
+    }
+
+    #[test]
+    fn test_no_data() {
+        acquire_test_lock!();
+
+        let k8s_metadata = K8sMetadata::default();
+        assert_eq!(k8s_metadata.node_name, None);
+        assert_eq!(k8s_metadata.cluster_name, None);
+    }
+
+    pub fn unset_k8s_env_vars() {
+        env::remove_var(ENV_K8S_NODE_NAME);
+        env::remove_var(ENV_EKS_CLUSTER_NAME);
+    }
+
+    pub fn set_k8s_eks_env_vars() {
+        env::set_var(ENV_K8S_NODE_NAME, "k8s-node-name");
+        env::set_var(ENV_EKS_CLUSTER_NAME, "eks-cluster-name");
+    }
+
+    pub fn set_k8s_vanilla_env_vars() {
+        env::set_var(ENV_K8S_NODE_NAME, "k8s-node-name");
+        env::remove_var(ENV_EKS_CLUSTER_NAME);
+    }
+
+    #[test]
+    fn test_some_data() {
+        acquire_test_lock!();
+
+        set_k8s_eks_env_vars();
+        let k8s_metadata = K8sMetadata::default();
+        unset_k8s_env_vars();
+        assert_eq!(
+            k8s_metadata.node_name,
+            Some(ReportValue::String("k8s-node-name".to_string()))
+        );
+        assert_eq!(
+            k8s_metadata.cluster_name,
+            Some(ReportValue::String("eks-cluster-name".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_service_metadata_new() {
+        let k8s_metadata = K8sMetadata::new("node_name", "cluster_name");
+        assert_eq!(
+            k8s_metadata.node_name,
+            Some(ReportValue::String("node_name".into()))
+        );
+        assert_eq!(
+            k8s_metadata.cluster_name,
+            Some(ReportValue::String("cluster_name".into()))
+        );
+    }
+}

--- a/nfm-controller/src/metadata/mod.rs
+++ b/nfm-controller/src/metadata/mod.rs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod eni;
+pub mod env_metadata_provider;
+pub mod host;
+pub mod k8s_metadata;
+pub mod runtime_environment_metadata;
+pub mod service_metadata;

--- a/nfm-controller/src/metadata/runtime_environment_metadata.rs
+++ b/nfm-controller/src/metadata/runtime_environment_metadata.rs
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env;
+
+use crate::metadata::env_metadata_provider::{EnvMetadata, EnvMetadataProvider};
+use crate::reports::report::ReportValue;
+use std::convert::From;
+
+const KEY_COMPUTE_PLATFORM: &str = "compute_platform";
+
+#[derive(Debug, Clone, PartialEq)]
+/// Represents the underlying hardware fabric that the agent runs on, plus orchestration platform if applicable
+/// Only EC2 based right now, will contain Fargate in future
+pub enum ComputePlatform {
+    Ec2Plain,
+    Ec2K8sEks,     // Elastic Kubernetes Service from AWS
+    Ec2K8sVanilla, // Plain/vanilla Kubernetes
+}
+
+// To convert enum to string
+impl std::fmt::Display for ComputePlatform {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ComputePlatform::Ec2Plain => write!(f, "EC2_PLAIN"),
+            ComputePlatform::Ec2K8sEks => write!(f, "EC2_K8S_EKS"),
+            ComputePlatform::Ec2K8sVanilla => write!(f, "EC2_K8S_VANILLA"),
+        }
+    }
+}
+
+pub struct RuntimeEnvironmentMetadataProvider {
+    compute_platform: ComputePlatform,
+}
+
+impl From<ComputePlatform> for RuntimeEnvironmentMetadataProvider {
+    fn from(compute_platform: ComputePlatform) -> Self {
+        RuntimeEnvironmentMetadataProvider { compute_platform }
+    }
+}
+
+impl RuntimeEnvironmentMetadataProvider {
+    pub fn new() -> Self {
+        Self {
+            compute_platform: Self::get_compute_platform(),
+        }
+    }
+
+    fn get_compute_platform() -> ComputePlatform {
+        if env::var(super::k8s_metadata::ENV_EKS_CLUSTER_NAME).is_ok() {
+            ComputePlatform::Ec2K8sEks
+        } else if env::var(super::k8s_metadata::ENV_K8S_NODE_NAME).is_ok() {
+            ComputePlatform::Ec2K8sVanilla
+        } else {
+            ComputePlatform::Ec2Plain
+        }
+    }
+}
+
+impl Default for RuntimeEnvironmentMetadataProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EnvMetadataProvider for RuntimeEnvironmentMetadataProvider {
+    fn refresh(&mut self) {
+        // runtime environment is static, no need to refresh
+    }
+
+    fn get_metadata(&self) -> EnvMetadata {
+        EnvMetadata::from(vec![(
+            KEY_COMPUTE_PLATFORM.into(),
+            ReportValue::String(self.compute_platform.to_string()),
+        )])
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::metadata::k8s_metadata;
+
+    use super::*;
+    use std::sync::Mutex;
+
+    #[test]
+    fn test_k8s_eks_env() {
+        crate::acquire_test_lock!();
+
+        k8s_metadata::tests::set_k8s_eks_env_vars();
+
+        let mut rm_provider = RuntimeEnvironmentMetadataProvider::default();
+        rm_provider.refresh();
+        let metadata = rm_provider.get_metadata();
+        assert_eq!(metadata.len(), 1);
+        if let ReportValue::String(str_value) =
+            metadata.get(&KEY_COMPUTE_PLATFORM.to_string()).unwrap()
+        {
+            assert!(str_value.eq(&ComputePlatform::Ec2K8sEks.to_string()));
+        }
+
+        k8s_metadata::tests::unset_k8s_env_vars();
+    }
+
+    #[test]
+    fn test_k8s_vanilla_env() {
+        crate::acquire_test_lock!();
+        k8s_metadata::tests::set_k8s_vanilla_env_vars();
+
+        let mut rm_provider = RuntimeEnvironmentMetadataProvider::default();
+        rm_provider.refresh();
+        let metadata = rm_provider.get_metadata();
+        assert_eq!(metadata.len(), 1);
+        if let ReportValue::String(str_value) =
+            metadata.get(&KEY_COMPUTE_PLATFORM.to_string()).unwrap()
+        {
+            assert!(str_value.eq(&ComputePlatform::Ec2K8sVanilla.to_string()));
+        }
+        k8s_metadata::tests::unset_k8s_env_vars();
+    }
+
+    #[test]
+    fn test_ec2_env() {
+        crate::acquire_test_lock!();
+
+        k8s_metadata::tests::unset_k8s_env_vars();
+
+        let mut rm_provider = RuntimeEnvironmentMetadataProvider::default();
+        rm_provider.refresh();
+        let metadata = rm_provider.get_metadata();
+        assert_eq!(metadata.len(), 1);
+        if let ReportValue::String(str_value) =
+            metadata.get(&KEY_COMPUTE_PLATFORM.to_string()).unwrap()
+        {
+            assert!(str_value.eq(&ComputePlatform::Ec2Plain.to_string()));
+        }
+    }
+}

--- a/nfm-controller/src/metadata/service_metadata.rs
+++ b/nfm-controller/src/metadata/service_metadata.rs
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use log::info;
+use serde::{Deserialize, Serialize};
+use shadow_rs::shadow;
+
+use crate::reports::report::ReportValue;
+
+shadow!(build);
+
+const PROJECT_NAME: &str = "network-flow-monitor";
+
+#[derive(Clone, Debug, Serialize, PartialEq, Deserialize)]
+pub struct ServiceMetadata {
+    pub name: ReportValue,
+    pub version: ReportValue,
+    pub build_ts: ReportValue,
+}
+
+impl Default for ServiceMetadata {
+    fn default() -> Self {
+        // See: https://github.com/baoyachi/shadow-rs/
+        ServiceMetadata::new(PROJECT_NAME, build::PKG_VERSION, build::BUILD_TIME_3339)
+    }
+}
+
+impl ServiceMetadata {
+    pub fn new(name: &str, version: &str, build_time: &str) -> Self {
+        let metadata = ServiceMetadata {
+            name: ReportValue::String(name.into()),
+            version: ReportValue::String(version.into()),
+            build_ts: ReportValue::String(build_time.into()),
+        };
+        info!(metadata:serde = metadata; "Service metadata");
+        metadata
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_service_metadata_default() {
+        let service_metadata = ServiceMetadata::default();
+
+        assert_eq!(
+            service_metadata.name,
+            ReportValue::String(PROJECT_NAME.into())
+        );
+        assert_eq!(
+            service_metadata.version,
+            ReportValue::String(build::PKG_VERSION.into())
+        );
+        assert_eq!(
+            service_metadata.build_ts,
+            ReportValue::String(build::BUILD_TIME_3339.into())
+        );
+    }
+
+    #[test]
+    fn test_service_metadata_new() {
+        let service_metadata = ServiceMetadata::new("test_name", "test_version", "test_build_ts");
+        assert_eq!(
+            service_metadata.name,
+            ReportValue::String("test_name".into())
+        );
+        assert_eq!(
+            service_metadata.version,
+            ReportValue::String("test_version".into())
+        );
+        assert_eq!(
+            service_metadata.build_ts,
+            ReportValue::String("test_build_ts".into())
+        );
+    }
+}

--- a/nfm-controller/src/reports/mod.rs
+++ b/nfm-controller/src/reports/mod.rs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod publisher;
+mod publisher_endpoint;
+pub mod report;
+pub mod report_otlp;
+
+pub use publisher_endpoint::ReportCompression;
+pub use report::{CountersOverall, ProcessCounters};

--- a/nfm-controller/src/reports/publisher.rs
+++ b/nfm-controller/src/reports/publisher.rs
@@ -1,0 +1,210 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    reports::report::NfmReport,
+    utils::{clock::RealTimeClock, credentials::get_credentials_provider},
+    OnOff, Options,
+};
+use log::info;
+
+pub use super::publisher_endpoint::ReportPublisherOTLP;
+
+pub trait ReportPublisher {
+    /// Publish a report and return true if it was successful.
+    fn publish(&self, report: &NfmReport) -> bool;
+}
+
+pub struct ReportPublisherLog {}
+
+impl ReportPublisherLog {
+    pub fn new() -> Self {
+        ReportPublisherLog {}
+    }
+}
+
+impl Default for ReportPublisherLog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReportPublisher for ReportPublisherLog {
+    fn publish(&self, report: &NfmReport) -> bool {
+        info!(report:serde = report; "Publishing report");
+        true
+    }
+}
+
+pub struct MultiPublisher {
+    publishers: Vec<Box<dyn ReportPublisher + Send>>,
+}
+
+pub struct MultiPublisherBuilder {
+    publishers: Vec<Box<dyn ReportPublisher + Send>>,
+}
+
+impl MultiPublisher {
+    pub fn builder() -> MultiPublisherBuilder {
+        MultiPublisherBuilder {
+            publishers: Vec::new(),
+        }
+    }
+
+    pub(crate) fn from_options(opt: &Options) -> Self {
+        let mut publisher_builder = MultiPublisher::builder();
+        if opt.log_reports == OnOff::On {
+            publisher_builder.with_publisher(Box::new(ReportPublisherLog::new()));
+        }
+        if opt.publish_reports == OnOff::On {
+            assert!(
+                !opt.endpoint.is_empty() && !opt.endpoint_region.is_empty(),
+                "endpoint and endpoint-region must be specified when publish-reports is on"
+            );
+            publisher_builder.with_publisher(Box::new(ReportPublisherOTLP::new(
+                opt.endpoint.clone(),
+                opt.endpoint_region.clone(),
+                get_credentials_provider(),
+                RealTimeClock {},
+                opt.report_compression,
+            )));
+        };
+        publisher_builder.build()
+    }
+}
+
+impl MultiPublisherBuilder {
+    pub fn with_publisher(&mut self, publisher: Box<dyn ReportPublisher + Send>) {
+        self.publishers.push(publisher);
+    }
+
+    pub fn build(self) -> MultiPublisher {
+        MultiPublisher {
+            publishers: self.publishers,
+        }
+    }
+}
+
+impl ReportPublisher for MultiPublisher {
+    fn publish(&self, report: &NfmReport) -> bool {
+        let mut success = true;
+        for publisher in &self.publishers {
+            success &= publisher.publish(report);
+        }
+        success
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use log::Log;
+    use std::sync::Mutex;
+
+    use crate::{
+        reports::{publisher::ReportPublisherLog, report::NfmReport, ReportCompression},
+        OnOff, Options,
+    };
+
+    use super::{MultiPublisher, ReportPublisher};
+
+    struct MockLogger {
+        pub message: Mutex<String>,
+    }
+    impl Log for MockLogger {
+        fn enabled(&self, _metadata: &log::Metadata) -> bool {
+            true
+        }
+
+        fn flush(&self) {}
+
+        fn log(&self, record: &log::Record) {
+            let mut x = self.message.lock().unwrap();
+            *x = record.args().to_string();
+        }
+    }
+
+    #[test]
+    fn test_log_publish() {
+        let logger = Box::leak(Box::new(MockLogger {
+            message: Mutex::new("".to_string()),
+        }));
+
+        std::env::set_var("RUST_LOG", "info");
+        let _ = log::set_logger(logger);
+        log::set_max_level(log::LevelFilter::Info);
+
+        let publisher = ReportPublisherLog::default();
+        publisher.publish(&NfmReport::new());
+
+        assert_eq!(
+            "Publishing report".to_string(),
+            logger.message.lock().unwrap().to_string()
+        );
+    }
+
+    struct MockPublisher {
+        report: NfmReport,
+    }
+
+    impl ReportPublisher for MockPublisher {
+        fn publish(&self, report: &NfmReport) -> bool {
+            assert_eq!(report, &self.report);
+            true
+        }
+    }
+
+    #[test]
+    fn test_multi_publish() {
+        let report = NfmReport::new();
+        let publisher1 = MockPublisher {
+            report: report.clone(),
+        };
+        let publisher2 = MockPublisher {
+            report: report.clone(),
+        };
+
+        let mut builder = MultiPublisher::builder();
+        builder.with_publisher(Box::new(publisher1));
+        builder.with_publisher(Box::new(publisher2));
+        let publisher = builder.build();
+
+        publisher.publish(&report);
+    }
+
+    #[test]
+    fn test_build_multi_publisher() {
+        // Only log
+        let opt = create_options(OnOff::On, OnOff::Off);
+        let publisher = MultiPublisher::from_options(&opt);
+        assert_eq!(publisher.publishers.len(), 1);
+
+        // Only endpoint
+        let opt = create_options(OnOff::Off, OnOff::On);
+        let publisher = MultiPublisher::from_options(&opt);
+        assert_eq!(publisher.publishers.len(), 1);
+
+        // Both publishers
+        let opt = create_options(OnOff::On, OnOff::On);
+        let publisher = MultiPublisher::from_options(&opt);
+        assert_eq!(publisher.publishers.len(), 2);
+    }
+
+    fn create_options(with_log: OnOff, with_endpoint: OnOff) -> Options {
+        Options {
+            log_reports: with_log,
+            publish_reports: with_endpoint,
+            endpoint: "a".to_string(),
+            endpoint_region: "b".to_string(),
+            cgroup: "c".to_string(),
+            top_k: 100,
+            notrack_secs: 0,
+            usage_data: OnOff::Off,
+            aggregate_msecs: 100,
+            publish_secs: 30,
+            jitter_secs: 0,
+            report_compression: ReportCompression::None,
+            kubernetes_metadata: OnOff::On,
+            resolve_nat: OnOff::On,
+        }
+    }
+}

--- a/nfm-controller/src/reports/publisher_endpoint.rs
+++ b/nfm-controller/src/reports/publisher_endpoint.rs
@@ -1,0 +1,690 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::reports::report_otlp::NfmReportOTLP;
+use crate::ReportPublisher;
+use crate::{
+    reports::report::NfmReport,
+    utils::{timespec_to_nsec, Clock},
+};
+use aws_credential_types::provider::ProvideCredentials;
+use clap::ValueEnum;
+use log::{error, info, warn};
+use reqwest::blocking::Client;
+use serde::Serialize;
+use std::fmt;
+use std::io::prelude::Write;
+use tokio::time::Duration;
+use url::Url;
+
+const NFM_SERVICE: &str = "networkflowmonitor";
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum ReportCompression {
+    None,
+    Gzip,
+}
+
+impl fmt::Display for ReportCompression {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReportCompression::None => write!(f, "none"),
+            ReportCompression::Gzip => write!(f, "gzip"),
+        }
+    }
+}
+
+pub struct ReportPublisherOTLP<P, C>
+where
+    P: ProvideCredentials,
+    C: Clock,
+{
+    client: Client,
+    endpoint: String,
+    region: String,
+    credentials_provider: P,
+    clock: C,
+    compression: ReportCompression,
+}
+
+impl<P, C> ReportPublisherOTLP<P, C>
+where
+    P: ProvideCredentials,
+    C: Clock,
+{
+    pub fn new(
+        endpoint: String,
+        region: String,
+        credentials_provider: P,
+        clock: C,
+        compression: ReportCompression,
+    ) -> Self {
+        ReportPublisherOTLP {
+            client: Client::builder().use_rustls_tls().build().unwrap(),
+            endpoint,
+            region,
+            credentials_provider,
+            clock,
+            compression,
+        }
+    }
+
+    fn build_headers(&self, datetime: chrono::DateTime<chrono::Utc>) -> reqwest::header::HeaderMap {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "X-Amz-Date",
+            datetime
+                .format("%Y%m%dT%H%M%SZ")
+                .to_string()
+                .parse()
+                .unwrap(),
+        );
+
+        headers.insert("host", get_host(&self.endpoint).parse().unwrap());
+        headers.insert("Content-Type", "application/x-protobuf".parse().unwrap());
+
+        match self.compression {
+            ReportCompression::None => {}
+            ReportCompression::Gzip => {
+                headers.insert("Content-Encoding", "gzip".parse().unwrap());
+            }
+        }
+
+        headers
+    }
+
+    fn build_report_body(&self, report: &NfmReport) -> Vec<u8> {
+        let timestamp_ns = timespec_to_nsec(self.clock.now());
+        let otel_report = NfmReportOTLP::build(report, timestamp_ns).unwrap();
+
+        match self.compression {
+            ReportCompression::None => otel_report,
+            ReportCompression::Gzip => {
+                let mut encoder =
+                    flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+                encoder.write_all(&otel_report).unwrap();
+                encoder.finish().unwrap()
+            }
+        }
+    }
+}
+
+impl<P, C> ReportPublisher for ReportPublisherOTLP<P, C>
+where
+    P: ProvideCredentials,
+    C: Clock,
+{
+    fn publish(&self, report: &NfmReport) -> bool {
+        let timestamp_ns = timespec_to_nsec(self.clock.now());
+        let report_body = self.build_report_body(report);
+
+        /* ---------- Sigv4 signature ----------------- */
+        let datetime = chrono::DateTime::from_timestamp_nanos(timestamp_ns as i64);
+        let mut headers = self.build_headers(datetime);
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let credentials = match rt.block_on(self.credentials_provider.provide_credentials()) {
+            Ok(credentials) => credentials,
+            Err(e) => {
+                error!("Error getting credentials: {}", e);
+                return false;
+            }
+        };
+
+        if let Some(token) = credentials.session_token() {
+            headers.insert("X-Amz-Security-Token", token.parse().unwrap());
+        }
+
+        let aws_sign = aws_sign_v4::AwsSign::new(
+            "POST",
+            &self.endpoint,
+            &datetime,
+            &headers,
+            &self.region,
+            credentials.access_key_id(),
+            credentials.secret_access_key(),
+            NFM_SERVICE,
+            &report_body,
+        );
+        let signature = aws_sign.sign();
+        headers.insert(reqwest::header::AUTHORIZATION, signature.parse().unwrap());
+
+        /* ------------ HTTP request --------------------- */
+        let res = match self
+            .client
+            .post(&self.endpoint)
+            .timeout(Duration::from_secs(20))
+            .headers(headers.to_owned())
+            .body(report_body)
+            .send()
+        {
+            Ok(res) => res,
+            Err(e) => {
+                error!("Error sending request: {}", e);
+                return false;
+            }
+        };
+
+        /* --------- HTTP Response --------------- */
+        let status = res.status().as_u16();
+        info!(status = res.status().as_u16(); "HTTP request complete");
+        if status != 200 {
+            warn!(body = res.text().unwrap_or("Invalid body".to_string()); "Request body");
+            return false;
+        }
+        true
+    }
+}
+
+fn get_host(url: &str) -> String {
+    match Url::parse(url) {
+        Ok(url) => url.host().unwrap().to_string(),
+        Err(e) => {
+            error!("Error parsing url: {}", e);
+            "".to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::host_stats_provider::GroupedInterfaceStats;
+    use crate::events::host_stats_provider::NetworkInterfaceStats;
+    use crate::events::network_event::{AggregateResults, FlowProperties, NetworkStats};
+    use crate::kubernetes::flow_metadata::FlowMetadata;
+    use crate::kubernetes::kubernetes_metadata_collector::PodInfo;
+    use crate::metadata::env_metadata_provider::EnvMetadata;
+    use crate::metadata::k8s_metadata::K8sMetadata;
+    use crate::metadata::service_metadata::ServiceMetadata;
+    use crate::reports::report::{MetricHistogram, ReportValue};
+    use crate::reports::report_otlp::NfmReportOTLP;
+    use crate::reports::ProcessCounters;
+    use crate::utils::FakeClock;
+    use crate::HostStats;
+    use crate::ProcessStats;
+    use crate::UsageStats;
+    use nfm_common::network::SockContext;
+    use nfm_common::EventCounters;
+
+    use aws_credential_types::provider::SharedCredentialsProvider;
+    use aws_credential_types::Credentials;
+    use libc::{AF_INET, AF_INET6};
+    use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+    use prost::Message;
+    use rand::rngs::ThreadRng;
+    use rand::{Rng, RngCore};
+    use std::collections::HashSet;
+    use std::io::Read;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::TcpListener;
+
+    struct MockService {
+        listener: TcpListener,
+    }
+
+    impl MockService {
+        fn new(address: String) -> Option<Self> {
+            match futures::executor::block_on(TcpListener::bind(address)) {
+                Ok(listener) => Some(MockService { listener }),
+                Err(e) => {
+                    error!("Error binding to address: {}", e);
+                    None
+                }
+            }
+        }
+
+        // This method listen for a HTTP request and return a Vec<u8> per line.
+        async fn listen_one(&mut self) -> Vec<Vec<u8>> {
+            let mut request = self.listener.accept().await.unwrap();
+            let mut buf_reader = BufReader::new(&mut request.0);
+            let mut http_request = vec![];
+
+            let buffer = buf_reader.fill_buf().await.unwrap();
+            let mut current_line = vec![];
+            let mut body_started = false;
+
+            for char in buffer {
+                if body_started {
+                    current_line.push(*char);
+                    continue;
+                }
+
+                if *char == b'\n' {
+                    // remove the \r
+                    current_line.remove(current_line.len() - 1);
+                    if current_line.is_empty() {
+                        body_started = true;
+                    };
+
+                    http_request.push(current_line);
+                    current_line = vec![];
+                    continue;
+                }
+                current_line.push(*char);
+            }
+            http_request.push(current_line);
+
+            request
+                .0
+                .write_all(b"HTTP/1.1 200 OK\r\n\r\n")
+                .await
+                .unwrap();
+
+            http_request
+        }
+    }
+
+    #[test]
+    fn test_request() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut address = String::new();
+        let mut port = 8181;
+        let mut port_attempts = 5;
+        let mut mock_service = None;
+        while port_attempts > 0 {
+            address = format!("127.0.0.1:{}", port).to_string();
+            mock_service = rt.block_on(async { MockService::new(address.to_string()) });
+            if mock_service.is_some() {
+                break;
+            }
+            port_attempts -= 1;
+            port += 1;
+        }
+        assert!(port_attempts > 0, "Failed to find an available port");
+        let service_future = rt.spawn(async move { mock_service.unwrap().listen_one().await });
+
+        let creds = Credentials::new("AKID", "SECRET", Some("TOKEN".into()), None, "test");
+        let provider = SharedCredentialsProvider::new(creds);
+
+        let mock_clock = FakeClock {
+            now_us: 1718716821050,
+        };
+
+        let publisher = ReportPublisherOTLP::new(
+            format!("http://{}", address),
+            "us-west-1".to_string(),
+            provider,
+            mock_clock.clone(),
+            ReportCompression::None,
+        );
+        let mut report = NfmReport::new();
+
+        let context = SockContext {
+            is_client: false,
+            address_family: AF_INET as u32,
+            local_ipv4: 16909060,
+            remote_ipv4: 84281096,
+            local_ipv6: [0; 16],
+            remote_ipv6: [0; 16],
+            local_port: 443,
+            remote_port: 28015,
+            ..Default::default()
+        };
+        let stats = NetworkStats::default();
+
+        report.set_network_stats(vec![AggregateResults {
+            flow: FlowProperties::try_from(&context).unwrap(),
+            stats,
+        }]);
+
+        let timestamp_ns = timespec_to_nsec(mock_clock.now());
+        let expected_body = NfmReportOTLP::build(&report, timestamp_ns).unwrap();
+
+        publisher.publish(&report);
+        let http_request_res = rt.block_on(service_future);
+
+        let mut http_request = http_request_res.unwrap();
+        let actual_body = http_request.pop().unwrap();
+
+        assert_eq!(actual_body.len(), expected_body.len());
+        assert_eq!(
+            ExportMetricsServiceRequest::decode(actual_body.as_slice()).unwrap(),
+            ExportMetricsServiceRequest::decode(expected_body.as_slice()).unwrap(),
+        );
+
+        // Test related to the HTTP headers.
+        let mut headers_set = HashSet::<String>::new();
+        for line in http_request
+            .into_iter()
+            .map(|vec| String::from_utf8(vec).unwrap())
+        {
+            headers_set.insert(line);
+        }
+
+        assert!(headers_set.contains("POST / HTTP/1.1"));
+        assert!(headers_set.contains("host: 127.0.0.1"));
+        assert!(headers_set.contains("content-type: application/x-protobuf"));
+        assert!(headers_set.contains("x-amz-security-token: TOKEN"));
+
+        check_header_exists("authorization", &headers_set);
+    }
+
+    fn check_header_exists(header: &str, headers: &HashSet<String>) {
+        let mut found = false;
+        for element in headers {
+            if element.contains(header) {
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "header '{}' not found", header);
+    }
+
+    #[test]
+    fn test_get_host() {
+        assert_eq!(get_host("http://a.com/"), "a.com");
+        assert_eq!(get_host("http://a.b.com/"), "a.b.com");
+        assert_eq!(get_host("http://a.b.com/test"), "a.b.com");
+        assert_eq!(get_host("http://a.b.com:123/"), "a.b.com");
+        assert_eq!(get_host("http://a.b.com:123/test"), "a.b.com");
+        assert_eq!(get_host("non host"), "");
+    }
+
+    #[test]
+    fn test_compression_ec2_report_ipv4() {
+        let (num_flows, include_k8s) = (500, false);
+        run_compression_test(num_flows, AF_INET, include_k8s);
+    }
+
+    #[test]
+    fn test_compression_k8s_report_ipv4() {
+        let (num_flows, include_k8s) = (500, true);
+        run_compression_test(num_flows, AF_INET, include_k8s);
+    }
+
+    #[test]
+    fn test_compression_ec2_report_ipv6() {
+        let (num_flows, include_k8s) = (500, false);
+        run_compression_test(num_flows, AF_INET6, include_k8s);
+    }
+
+    #[test]
+    fn test_compression_k8s_report_ipv6() {
+        let (num_flows, include_k8s) = (500, true);
+        run_compression_test(num_flows, AF_INET6, include_k8s);
+    }
+
+    fn run_compression_test(num_flows: usize, address_family: i32, include_k8s: bool) {
+        let publisher_with_compression = build_publisher(ReportCompression::Gzip);
+        let publisher_no_compression = build_publisher(ReportCompression::None);
+
+        let report = build_report(num_flows, address_family, include_k8s);
+
+        let body_no_compression = publisher_no_compression.build_report_body(&report);
+        let body_with_compression = publisher_with_compression.build_report_body(&report);
+
+        // Aiming for a min 50% compression ratio.
+        assert!((body_no_compression.len() / 2) > body_with_compression.len());
+        assert_eq!(
+            body_no_compression,
+            decompress(ReportCompression::Gzip, &body_with_compression)
+        );
+
+        // Store files for external validation.
+        let addr_type = match address_family {
+            AF_INET => "ipv4",
+            AF_INET6 => "ipv6",
+            _ => panic!("Unknown addr family: {}", address_family),
+        };
+        let compute_type = if include_k8s { "k8s" } else { "ec2" };
+        let json_string = serde_json::to_string(&report).unwrap();
+        std::fs::create_dir_all("../target/report-samples/").unwrap();
+        store_sample_file(
+            format!(
+                "report-{}-{}-{}-flows.json",
+                num_flows, addr_type, compute_type
+            ),
+            json_string.as_bytes(),
+        );
+        store_sample_file(
+            format!(
+                "report-{}-{}-{}-flows.bin",
+                num_flows, addr_type, compute_type
+            ),
+            &body_no_compression,
+        );
+        store_sample_file(
+            format!(
+                "report-{}-{}-{}-flows.bin.gz",
+                num_flows, addr_type, compute_type
+            ),
+            &body_with_compression,
+        );
+    }
+
+    fn decompress(compression: ReportCompression, data: &Vec<u8>) -> Vec<u8> {
+        match compression {
+            ReportCompression::None => data.clone(),
+            ReportCompression::Gzip => {
+                let mut decoder = flate2::read::GzDecoder::new(data.as_slice());
+                let mut decompressed = Vec::new();
+                decoder.read_to_end(&mut decompressed).unwrap();
+                decompressed
+            }
+        }
+    }
+
+    fn store_sample_file(file_name: String, buf: &[u8]) {
+        let mut file =
+            std::fs::File::create(format!("../target/report-samples/{}", file_name)).unwrap();
+        std::io::Write::write_all(&mut file, buf).unwrap();
+    }
+
+    fn build_publisher(
+        compression: ReportCompression,
+    ) -> ReportPublisherOTLP<SharedCredentialsProvider, FakeClock> {
+        let creds = Credentials::new("AKID", "SECRET", Some("TOKEN".into()), None, "test");
+        let provider = SharedCredentialsProvider::new(creds);
+
+        let mock_clock = FakeClock {
+            now_us: 1718716821050,
+        };
+
+        ReportPublisherOTLP::new(
+            "http://localhost".to_string(),
+            "us-west-1".to_string(),
+            provider,
+            mock_clock.clone(),
+            compression,
+        )
+    }
+
+    fn build_report(num_flows: usize, address_family: i32, include_k8s: bool) -> NfmReport {
+        let mut report = NfmReport::new();
+        let mut aggregated_results = vec![];
+
+        let mut rng = rand::thread_rng();
+        for flow_idx in 0..num_flows {
+            let context = SockContext {
+                is_client: true,
+                address_family: address_family as u32,
+                local_ipv4: rng.next_u32(),
+                remote_ipv4: rng.next_u32(),
+                local_ipv6: rand_ipv6(&mut rng),
+                remote_ipv6: rand_ipv6(&mut rng),
+                local_port: 0,
+                remote_port: rand_service_port(&mut rng),
+                ..Default::default()
+            };
+
+            let stats = build_random_network_stats(&mut rng);
+            let mut flow = FlowProperties::try_from(&context).unwrap();
+            if include_k8s {
+                let service_name_mutator = flow_idx % 5;
+                let pod_name_mutator = flow_idx % 20;
+                flow.kubernetes_metadata = Some(FlowMetadata {
+                    local: Some(PodInfo {
+                        name: format!("nginx-deployment-59f8b7dc9-bzmfn-{}", pod_name_mutator),
+                        namespace: "default".to_string(),
+                        service_name: format!("nginx-service-{}", service_name_mutator),
+                    }),
+                    remote: Some(PodInfo {
+                        name: format!("nginx-doppelganger-9997cd54b-rz55s-{}", pod_name_mutator),
+                        namespace: "nfm".to_string(),
+                        service_name: format!("nginx-doppelganger-{}", service_name_mutator),
+                    }),
+                });
+            }
+
+            aggregated_results.push(AggregateResults { flow, stats });
+        }
+
+        report.set_network_stats(aggregated_results);
+        report.set_service_metadata(ServiceMetadata {
+            name: ReportValue::String("network-flow-monitor".into()),
+            version: ReportValue::String("1.0".into()),
+            build_ts: ReportValue::String("the-build-ts".into()),
+        });
+        report.set_env_metadata(build_env_metadata());
+        report.set_process_stats(build_process_stats());
+        report.set_host_stats(build_host_stats());
+        if include_k8s {
+            report.set_k8s_metadata(build_k8s_metadata());
+        }
+
+        report
+    }
+
+    fn build_env_metadata() -> EnvMetadata {
+        let mut env_metadata = EnvMetadata::default();
+        env_metadata.insert(
+            "instance_id".into(),
+            ReportValue::String("instance-id".into()),
+        );
+        env_metadata.insert(
+            "machine_id".into(),
+            ReportValue::String("machine-id".into()),
+        );
+        env_metadata
+    }
+
+    fn build_process_stats() -> ProcessStats {
+        let mut process_stats = ProcessStats::default();
+        process_stats.counters.event_related = EventCounters {
+            active_connect_events: 1,
+            active_established_events: 2,
+            passive_established_events: 3,
+            state_change_events: 4,
+            rtt_events: 5,
+            retrans_events: 6,
+            rto_events: 7,
+            other_events: 8,
+            socket_events: 9,
+            sockets_invalid: 10,
+            map_insertion_errors: 18,
+            rtts_invalid: 15,
+            set_flags_errors: 16,
+            other_errors: 17,
+        };
+        process_stats.counters.process_related = ProcessCounters::default();
+
+        process_stats.usage.push(UsageStats {
+            cpu_util: 0.040,
+            mem_used_kb: 512,
+            mem_used_ratio: 0.06,
+            sockets_tracked: 100,
+        });
+
+        process_stats
+    }
+
+    fn build_host_stats() -> HostStats {
+        let iface1_stats = GroupedInterfaceStats {
+            interface_id: "iface-id-1".to_string(),
+            stats: NetworkInterfaceStats {
+                bw_in_allowance_exceeded: 211,
+                bw_out_allowance_exceeded: 223,
+                conntrack_allowance_exceeded: 227,
+                linklocal_allowance_exceeded: 229,
+                pps_allowance_exceeded: 233,
+                conntrack_allowance_available: 239,
+            },
+        };
+        let mut iface2_stats = iface1_stats.clone();
+        iface2_stats.interface_id = "iface-id-2".to_string();
+        HostStats {
+            interface_stats: vec![iface1_stats, iface2_stats],
+        }
+    }
+
+    fn build_k8s_metadata() -> K8sMetadata {
+        K8sMetadata {
+            node_name: Some(ReportValue::String("k8s-node".into())),
+            cluster_name: Some(ReportValue::String("k8s-cluster".into())),
+        }
+    }
+
+    fn build_random_network_stats(rng: &mut ThreadRng) -> NetworkStats {
+        NetworkStats {
+            sockets_connecting: rand_cxn_count(rng),
+            sockets_established: rand_cxn_count(rng),
+            sockets_closing: rand_cxn_count(rng),
+            sockets_closed: rand_cxn_count(rng),
+            sockets_completed: rand_cxn_count(rng),
+            severed_connect: rand_cxn_count(rng),
+            severed_establish: rand_cxn_count(rng),
+            connect_attempts: rand_cxn_count(rng),
+            bytes_received: rand_byte_segment_count(rng),
+            bytes_delivered: rand_byte_segment_count(rng),
+            segments_received: rand_byte_segment_count(rng),
+            segments_delivered: rand_byte_segment_count(rng),
+            retrans_syn: rand_retrans_count(rng),
+            retrans_est: rand_retrans_count(rng),
+            retrans_close: rand_retrans_count(rng),
+            rtos_syn: rand_retrans_count(rng),
+            rtos_est: rand_retrans_count(rng),
+            rtos_close: rand_retrans_count(rng),
+            connect_us: MetricHistogram {
+                count: rand_cxn_count(rng),
+                min: rand_duration_us(rng),
+                max: rand_duration_us(rng),
+                sum: rand_duration_us(rng) as u64,
+            },
+            rtt_us: MetricHistogram {
+                count: rand_cxn_count(rng),
+                min: rand_duration_us(rng),
+                max: rand_duration_us(rng),
+                sum: rand_duration_us(rng) as u64,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: rand_cxn_count(rng),
+                min: rand_duration_us(rng),
+                max: rand_duration_us(rng),
+                sum: rand_duration_us(rng) as u64,
+            },
+        }
+    }
+
+    // Generate random values that are somewhat within realistic ranges we'd see in the field.
+
+    fn rand_ipv6(rng: &mut ThreadRng) -> [u8; 16] {
+        let mut bytes = [0; 16];
+        for i in 0..bytes.len() / 2 {
+            bytes[i] = rng.gen();
+        }
+
+        bytes
+    }
+
+    fn rand_service_port(rng: &mut ThreadRng) -> u16 {
+        rng.gen_range(1..100)
+    }
+
+    fn rand_cxn_count(rng: &mut ThreadRng) -> u32 {
+        rng.gen_range(0..1000000)
+    }
+
+    fn rand_duration_us(rng: &mut ThreadRng) -> u32 {
+        rng.gen_range(0..1000000)
+    }
+
+    fn rand_retrans_count(rng: &mut ThreadRng) -> u32 {
+        rng.gen_range(0..1000000)
+    }
+
+    fn rand_byte_segment_count(rng: &mut ThreadRng) -> u64 {
+        rng.gen_range(0..10_000_000_000)
+    }
+}

--- a/nfm-controller/src/reports/report.rs
+++ b/nfm-controller/src/reports/report.rs
@@ -1,0 +1,295 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metadata::k8s_metadata::K8sMetadata;
+use crate::metadata::service_metadata::ServiceMetadata;
+use crate::utils::report::to_value_pairs;
+use crate::HostStats;
+use crate::{
+    events::network_event::AggregateResults, metadata::env_metadata_provider::EnvMetadata,
+};
+use nfm_common::network::EventCounters;
+
+use serde::{Deserialize, Serialize};
+use serde_json;
+
+const REPORT_VERSION: &str = "1.1";
+
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(test, derive(Clone))]
+pub struct NfmReport {
+    pub network_stats: Vec<AggregateResults>,
+    pub process_stats: ProcessStats,
+    pub host_stats: HostStats,
+    pub env_metadata: EnvMetadata,
+    pub service_metadata: ServiceMetadata,
+    pub failed_reports: u32,
+    pub report_version: String,
+    pub k8s_metadata: K8sMetadata,
+}
+
+impl NfmReport {
+    pub fn new() -> Self {
+        Self {
+            network_stats: vec![],
+            process_stats: ProcessStats::default(),
+            host_stats: HostStats::default(),
+            env_metadata: EnvMetadata::default(),
+            service_metadata: ServiceMetadata::default(),
+            failed_reports: 0,
+            report_version: REPORT_VERSION.into(),
+            k8s_metadata: K8sMetadata::default(),
+        }
+    }
+
+    pub fn set_network_stats(&mut self, agg_stats: Vec<AggregateResults>) {
+        self.network_stats = agg_stats;
+    }
+
+    pub fn set_process_stats(&mut self, stats: ProcessStats) {
+        self.process_stats = stats;
+    }
+
+    pub fn set_host_stats(&mut self, stats: HostStats) {
+        self.host_stats = stats;
+    }
+
+    pub fn set_env_metadata(&mut self, metadata: EnvMetadata) {
+        self.env_metadata = metadata;
+    }
+
+    pub fn set_failed_reports(&mut self, failed_reports: u32) {
+        self.failed_reports = failed_reports;
+    }
+
+    pub fn set_service_metadata(&mut self, service_metadata: ServiceMetadata) {
+        self.service_metadata = service_metadata;
+    }
+
+    pub fn set_k8s_metadata(&mut self, k8s_metadata: K8sMetadata) {
+        self.k8s_metadata = k8s_metadata;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, PartialOrd, Serialize)]
+pub struct MetricHistogram {
+    pub count: u32,
+    pub min: u32,
+    pub max: u32,
+    pub sum: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ReportValue {
+    Float(f64),
+    UInt(u64),
+    Int(i64),
+    String(String),
+    Histogram(MetricHistogram),
+    Invalid,
+}
+
+impl From<&serde_json::Value> for ReportValue {
+    fn from(json_val: &serde_json::Value) -> Self {
+        match json_val {
+            serde_json::Value::Number(num) => {
+                if num.is_f64() {
+                    ReportValue::Float(num.as_f64().unwrap())
+                } else if num.is_i64() {
+                    ReportValue::Int(num.as_i64().unwrap())
+                } else if num.is_u64() {
+                    ReportValue::UInt(num.as_u64().unwrap())
+                } else {
+                    ReportValue::Invalid
+                }
+            }
+            serde_json::Value::String(s) => ReportValue::String(s.clone()),
+            _ => ReportValue::Invalid,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, PartialOrd, Serialize)]
+pub struct ProcessStats {
+    pub counters: CountersOverall,
+    pub usage: Vec<UsageStats>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, PartialOrd, Serialize)]
+pub struct CountersOverall {
+    pub event_related: EventCounters,
+    pub process_related: ProcessCounters,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, PartialOrd, Serialize)]
+pub struct ProcessCounters {
+    pub restarts: u64,
+    pub sockets_added: u64,
+    pub sockets_natd: u64,
+    pub sockets_stale: u64,
+
+    pub socket_deltas_completed: u64,
+    pub socket_deltas_missing_props: u64,
+    pub socket_deltas_above_limit: u64,
+
+    pub socket_agg_completed: u64,
+    pub socket_agg_missing_props: u64,
+    pub socket_agg_above_limit: u64,
+
+    pub socket_eviction_completed: u64,
+    pub socket_eviction_failed: u64,
+    pub remote_nat_reversal_errors: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, PartialOrd, Serialize)]
+pub struct UsageStats {
+    pub cpu_util: f64,
+    pub mem_used_kb: u64,
+    pub mem_used_ratio: f64,
+    pub sockets_tracked: u64,
+}
+
+impl ProcessStats {
+    pub fn enumerate_usage(&self) -> Vec<(String, ReportValue)> {
+        match self.usage.last() {
+            Some(usg) => to_value_pairs(usg),
+            None => vec![],
+        }
+    }
+
+    pub fn enumerate_counters(&self) -> Vec<(String, ReportValue)> {
+        let mut res = vec![];
+        res.extend(to_value_pairs(&self.counters.event_related));
+        res.extend(to_value_pairs(&self.counters.process_related));
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::events::host_stats_provider::{GroupedInterfaceStats, NetworkInterfaceStats};
+    use crate::events::network_event::{AggregateResults, FlowProperties, NetworkStats};
+    use crate::metadata::env_metadata_provider::EnvMetadata;
+    use crate::metadata::service_metadata::ServiceMetadata;
+    use crate::reports::report::{
+        MetricHistogram, NfmReport, ProcessStats, ReportValue, UsageStats,
+    };
+    use crate::HostStats;
+    use nfm_common::network::{SockContext, AF_INET};
+
+    use std::fs;
+
+    #[test]
+    fn test_build_report() {
+        let mut report = NfmReport::new();
+
+        let mut context = SockContext {
+            is_client: false,
+            address_family: AF_INET,
+            local_ipv4: 16909060,
+            remote_ipv4: 84281096,
+            local_ipv6: [0; 16],
+            remote_ipv6: [0; 16],
+            local_port: 443,
+            remote_port: 28015,
+            ..Default::default()
+        };
+        let stats = NetworkStats {
+            sockets_connecting: 4,
+            sockets_established: 3,
+            sockets_closing: 2,
+            sockets_closed: 1,
+
+            sockets_completed: 44,
+            severed_connect: 2,
+            severed_establish: 1,
+
+            connect_attempts: 14,
+            bytes_received: 43,
+            bytes_delivered: 47,
+            segments_received: 53,
+            segments_delivered: 59,
+
+            retrans_syn: 20,
+            retrans_est: 19,
+            retrans_close: 18,
+            rtos_syn: 17,
+            rtos_est: 16,
+            rtos_close: 15,
+
+            connect_us: MetricHistogram {
+                count: 2,
+                min: 12,
+                max: 13,
+                sum: 25,
+            },
+            rtt_us: MetricHistogram {
+                count: 3,
+                min: 14,
+                max: 15,
+                sum: 44,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: 4,
+                min: 16,
+                max: 17,
+                sum: 66,
+            },
+        };
+        let mut process_stats = ProcessStats::default();
+        process_stats.usage.push(UsageStats {
+            cpu_util: 0.040,
+            mem_used_kb: 512,
+            mem_used_ratio: 0.06,
+            sockets_tracked: 49,
+        });
+        let grouped_iface_stats = GroupedInterfaceStats {
+            interface_id: "iface-id-1".to_string(),
+            stats: NetworkInterfaceStats {
+                bw_in_allowance_exceeded: 211,
+                bw_out_allowance_exceeded: 223,
+                conntrack_allowance_exceeded: 227,
+                linklocal_allowance_exceeded: 229,
+                pps_allowance_exceeded: 233,
+                conntrack_allowance_available: 239,
+            },
+        };
+        let host_stats = HostStats {
+            interface_stats: vec![grouped_iface_stats],
+        };
+
+        // From the perspective of a server, the local port is the service port.
+        context.is_client = false;
+        let mut flow = FlowProperties::try_from(&context).unwrap();
+        let mut agg_results = AggregateResults {
+            flow,
+            stats: stats.clone(),
+        };
+        let mut env_metadata = EnvMetadata::default();
+        env_metadata.insert(
+            "instance_id".into(),
+            ReportValue::String("instance-id".into()),
+        );
+        report.set_network_stats(vec![agg_results]);
+        report.set_process_stats(process_stats);
+        report.set_host_stats(host_stats);
+        report.set_env_metadata(env_metadata);
+        report.set_service_metadata(ServiceMetadata::new("test-service", "1.0", "build-time"));
+
+        let expected: NfmReport =
+            serde_json::from_str(&fs::read_to_string("../test-data/report1.json").unwrap())
+                .unwrap();
+        assert_eq!(report, expected);
+
+        // From the perspective of a client, the remote port is the service port.
+        context.is_client = true;
+        flow = FlowProperties::try_from(&context).unwrap();
+        agg_results = AggregateResults { flow, stats };
+        report.set_network_stats(vec![agg_results]);
+
+        let expected: NfmReport =
+            serde_json::from_str(&fs::read_to_string("../test-data/report2.json").unwrap())
+                .unwrap();
+        assert_eq!(report, expected);
+    }
+}

--- a/nfm-controller/src/reports/report_otlp.rs
+++ b/nfm-controller/src/reports/report_otlp.rs
@@ -1,0 +1,620 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::reports::report::NfmReport;
+
+use log::error;
+use opentelemetry_proto::tonic::{
+    collector::metrics::v1::ExportMetricsServiceRequest,
+    common::v1::{any_value::Value, AnyValue, InstrumentationScope, KeyValue},
+    metrics::v1::{metric::Data, Metric, ResourceMetrics, ScopeMetrics},
+    metrics::v1::{
+        number_data_point, AggregationTemporality, Gauge, Histogram, HistogramDataPoint,
+        NumberDataPoint, Sum,
+    },
+    resource::v1::Resource,
+};
+use prost::Message;
+
+use super::report::ReportValue;
+
+const SCOPE_NAME_NETWORK_STAT: &str = "network_stats";
+const SCOPE_NAME_HOST_STAT: &str = "host_stats";
+const SCOPE_NAME_PROCESS_STAT: &str = "process_stats";
+const SCOPE_NAME_COUNTERS: &str = "counters";
+
+const METADATA_SERVICE_NAME: &str = "service.name";
+const METADATA_SERVICE_VERSION: &str = "service.version";
+const METADATA_AGENT_BUILD_TIME: &str = "agent.build_ts";
+
+const METADATA_K8S_NODE_NAME: &str = "k8s_node_name";
+const METADATA_K8S_EKS_CLUSTER_NAME: &str = "k8s_eks_cluster_name";
+
+pub struct NfmReportOTLP {}
+
+impl From<ReportValue> for Value {
+    fn from(report_val: ReportValue) -> Self {
+        match report_val {
+            ReportValue::Float(f) => Value::DoubleValue(f),
+            ReportValue::UInt(u) => Value::IntValue(u.try_into().unwrap_or(0)),
+            ReportValue::Int(i) => Value::IntValue(i),
+            ReportValue::String(s) => Value::StringValue(s),
+            ReportValue::Invalid => Value::StringValue("".to_string()),
+            ReportValue::Histogram(_) => panic!("Invalid conversion: Histogram to Otel Value"),
+        }
+    }
+}
+
+fn build_metric_histogram(
+    name: String,
+    timestamp_ns: u64,
+    value: ReportValue,
+) -> Result<Metric, String> {
+    let mut data_point = HistogramDataPoint {
+        time_unix_nano: timestamp_ns,
+        start_time_unix_nano: timestamp_ns,
+        count: 1,
+        ..Default::default()
+    };
+
+    match value {
+        ReportValue::Float(value) => {
+            data_point.sum = Some(value);
+        }
+        ReportValue::Int(value) => {
+            data_point.sum = Some(value as f64);
+        }
+        ReportValue::UInt(value) => {
+            data_point.sum = Some(value as f64);
+        }
+        ReportValue::Histogram(histo) => {
+            data_point.count = histo.count.into();
+            data_point.min = Some(histo.min.into());
+            data_point.max = Some(histo.max.into());
+            data_point.sum = Some(histo.sum as f64);
+        }
+        _ => {
+            return Err(format!("Unsupported value type {:?}", value).to_string());
+        }
+    }
+
+    let data = Data::Histogram(Histogram {
+        data_points: vec![data_point],
+        aggregation_temporality: AggregationTemporality::Delta.into(),
+    });
+    Ok(Metric {
+        name: name.to_string(),
+        data: Some(data),
+        ..Default::default()
+    })
+}
+
+fn build_metric_gauge(
+    name: String,
+    timestamp_ns: u64,
+    value: ReportValue,
+) -> Result<Metric, String> {
+    let mut data_point = NumberDataPoint {
+        time_unix_nano: timestamp_ns,
+        start_time_unix_nano: timestamp_ns,
+        ..Default::default()
+    };
+
+    match value {
+        ReportValue::Float(value) => {
+            data_point.value = Some(number_data_point::Value::AsDouble(value));
+        }
+        ReportValue::Int(value) => {
+            data_point.value = Some(number_data_point::Value::AsInt(value));
+        }
+        ReportValue::UInt(value) => {
+            data_point.value = Some(number_data_point::Value::AsInt(value as i64));
+        }
+        _ => {
+            return Err(format!("Unsupported value type {:?}", value).to_string());
+        }
+    }
+
+    let data = Data::Gauge(Gauge {
+        data_points: vec![data_point],
+    });
+    Ok(Metric {
+        name: name.to_string(),
+        data: Some(data),
+        ..Default::default()
+    })
+}
+
+fn build_metric_sum(name: String, timestamp_ns: u64, value: ReportValue) -> Result<Metric, String> {
+    let mut data_point = NumberDataPoint {
+        time_unix_nano: timestamp_ns,
+        start_time_unix_nano: timestamp_ns,
+        ..Default::default()
+    };
+
+    match value {
+        ReportValue::Float(value) => {
+            data_point.value = Some(number_data_point::Value::AsDouble(value));
+        }
+        ReportValue::Int(value) => {
+            data_point.value = Some(number_data_point::Value::AsInt(value));
+        }
+        ReportValue::UInt(value) => {
+            data_point.value = Some(number_data_point::Value::AsInt(value as i64));
+        }
+        _ => {
+            return Err(format!("Unsupported value type {:?}", value).to_string());
+        }
+    }
+
+    let data = Data::Sum(Sum {
+        data_points: vec![data_point],
+        aggregation_temporality: AggregationTemporality::Delta.into(),
+        is_monotonic: true,
+    });
+    Ok(Metric {
+        name: name.to_string(),
+        data: Some(data),
+        ..Default::default()
+    })
+}
+
+impl NfmReportOTLP {
+    fn add_network_stats(
+        report: &NfmReport,
+        timestamp_ns: u64,
+        resource_metrics: &mut ResourceMetrics,
+    ) {
+        for network_stat in &report.network_stats {
+            let mut scope_metrics = ScopeMetrics::default();
+
+            let mut scope = InstrumentationScope {
+                name: SCOPE_NAME_NETWORK_STAT.to_string(),
+                ..Default::default()
+            };
+
+            // Flow information will be in the scope
+            for (name, value) in network_stat.flow.enumerate() {
+                scope.attributes.push(KeyValue {
+                    key: name.to_string(),
+                    value: Some(AnyValue {
+                        value: Some(value.into()),
+                    }),
+                });
+            }
+
+            // List of metrics for the flow
+            scope_metrics.scope = Some(scope);
+            for (name, value) in network_stat.stats.enumerate() {
+                match build_metric_histogram(name, timestamp_ns, value) {
+                    Ok(metric) => scope_metrics.metrics.push(metric),
+                    Err(e) => error!(msg = e; "Error building metric"),
+                }
+            }
+
+            resource_metrics.scope_metrics.push(scope_metrics);
+        }
+    }
+
+    fn add_host_stats(
+        report: &NfmReport,
+        timestamp_ns: u64,
+        resource_metrics: &mut ResourceMetrics,
+    ) {
+        for grouped_stats in &report.host_stats.interface_stats {
+            let mut scope_metrics = ScopeMetrics::default();
+            let mut scope = InstrumentationScope {
+                name: SCOPE_NAME_HOST_STAT.to_string(),
+                ..Default::default()
+            };
+
+            // The scope will contain the interface ID.
+            scope.attributes.push(KeyValue {
+                key: "interface_id".to_string(),
+                value: Some(AnyValue {
+                    value: Some(Value::StringValue(grouped_stats.interface_id.clone())),
+                }),
+            });
+
+            // List of metrics for the flow
+            scope_metrics.scope = Some(scope);
+            for (name, value) in grouped_stats.stats.enumerate() {
+                match build_metric_sum(name, timestamp_ns, value) {
+                    Ok(metric) => scope_metrics.metrics.push(metric),
+                    Err(e) => error!(msg = e; "Error building metric"),
+                }
+            }
+
+            resource_metrics.scope_metrics.push(scope_metrics);
+        }
+    }
+
+    fn add_process_stats(
+        report: &NfmReport,
+        timestamp_ns: u64,
+        resource_metrics: &mut ResourceMetrics,
+    ) {
+        let mut scope_metrics = ScopeMetrics::default();
+
+        let scope = InstrumentationScope {
+            name: SCOPE_NAME_PROCESS_STAT.to_string(),
+            ..Default::default()
+        };
+        scope_metrics.scope = Some(scope);
+
+        for (name, value) in report.process_stats.enumerate_usage() {
+            match build_metric_gauge(name, timestamp_ns, value) {
+                Ok(metric) => scope_metrics.metrics.push(metric),
+                Err(e) => error!(msg = e; "Error building metric"),
+            }
+        }
+
+        resource_metrics.scope_metrics.push(scope_metrics);
+    }
+
+    fn add_counters(report: &NfmReport, timestamp_ns: u64, resource_metrics: &mut ResourceMetrics) {
+        let mut scope_metrics = ScopeMetrics::default();
+
+        let scope = InstrumentationScope {
+            name: SCOPE_NAME_COUNTERS.to_string(),
+            ..Default::default()
+        };
+        scope_metrics.scope = Some(scope);
+
+        for (name, value) in report.process_stats.enumerate_counters() {
+            match build_metric_sum(name, timestamp_ns, value) {
+                Ok(metric) => scope_metrics.metrics.push(metric),
+                Err(e) => error!(msg = e; "Error building metric"),
+            }
+        }
+
+        match build_metric_sum(
+            "publish_report_failed".to_owned(),
+            timestamp_ns,
+            ReportValue::UInt(report.failed_reports.into()),
+        ) {
+            Ok(metric) => scope_metrics.metrics.push(metric),
+            Err(e) => error!(msg = e; "Error building metric"),
+        }
+
+        resource_metrics.scope_metrics.push(scope_metrics);
+    }
+
+    fn add_resource_data(report: &NfmReport, resource_metrics: &mut ResourceMetrics) {
+        let mut resource = Resource::default();
+
+        // Env data
+        for (key, value) in report.env_metadata.enumerate() {
+            NfmReportOTLP::add_resource_entry(key, value, &mut resource);
+        }
+
+        // Service data. See: https://opentelemetry.io/docs/specs/semconv/resource/
+        NfmReportOTLP::add_resource_entry(
+            METADATA_SERVICE_NAME,
+            &report.service_metadata.name,
+            &mut resource,
+        );
+        NfmReportOTLP::add_resource_entry(
+            METADATA_SERVICE_VERSION,
+            &report.service_metadata.version,
+            &mut resource,
+        );
+        // Agent data
+        NfmReportOTLP::add_resource_entry(
+            METADATA_AGENT_BUILD_TIME,
+            &report.service_metadata.build_ts,
+            &mut resource,
+        );
+        NfmReportOTLP::add_resource_entry(
+            "report.version",
+            &ReportValue::String(report.report_version.clone()),
+            &mut resource,
+        );
+
+        // Kubernetes metadata
+        if let Some(node_name) = &report.k8s_metadata.node_name {
+            NfmReportOTLP::add_resource_entry(METADATA_K8S_NODE_NAME, node_name, &mut resource);
+        }
+        if let Some(cluster_name) = &report.k8s_metadata.cluster_name {
+            NfmReportOTLP::add_resource_entry(
+                METADATA_K8S_EKS_CLUSTER_NAME,
+                cluster_name,
+                &mut resource,
+            );
+        }
+
+        resource_metrics.resource = Some(resource);
+    }
+
+    fn add_resource_entry(key: &str, value: &ReportValue, resource: &mut Resource) {
+        resource.attributes.push(KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(value.clone().into()),
+            }),
+        });
+    }
+
+    fn build_export(report: &NfmReport, timestamp_ns: u64) -> ExportMetricsServiceRequest {
+        let mut resource_metrics = ResourceMetrics::default();
+        NfmReportOTLP::add_resource_data(report, &mut resource_metrics);
+        NfmReportOTLP::add_network_stats(report, timestamp_ns, &mut resource_metrics);
+        NfmReportOTLP::add_process_stats(report, timestamp_ns, &mut resource_metrics);
+        NfmReportOTLP::add_host_stats(report, timestamp_ns, &mut resource_metrics);
+        NfmReportOTLP::add_counters(report, timestamp_ns, &mut resource_metrics);
+
+        ExportMetricsServiceRequest {
+            resource_metrics: vec![resource_metrics],
+        }
+    }
+
+    pub fn build(report: &NfmReport, timestamp_us: u64) -> Result<Vec<u8>, String> {
+        let export = &NfmReportOTLP::build_export(report, timestamp_us);
+        let mut buf = Vec::with_capacity(export.encoded_len());
+
+        match export.encode(&mut buf) {
+            Ok(_) => Ok(buf),
+            Err(error) => Err(error.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+    use crate::events::host_stats_provider::{GroupedInterfaceStats, NetworkInterfaceStats};
+    use crate::events::network_event::{AggregateResults, FlowProperties, NetworkStats};
+    use crate::kubernetes::flow_metadata::FlowMetadata;
+    use crate::kubernetes::kubernetes_metadata_collector::PodInfo;
+    use crate::metadata::env_metadata_provider::{EnvMetadata, EnvMetadataProvider};
+    use crate::metadata::k8s_metadata::K8sMetadata;
+    use crate::metadata::runtime_environment_metadata::{
+        ComputePlatform, RuntimeEnvironmentMetadataProvider,
+    };
+    use crate::metadata::service_metadata::ServiceMetadata;
+    use crate::reports::report::{
+        MetricHistogram, NfmReport, ProcessCounters, ProcessStats, UsageStats,
+    };
+    use crate::HostStats;
+    use nfm_common::network::{EventCounters, SockContext, AF_INET};
+
+    #[test]
+    fn test_build_report_from_ec2_instance() {
+        build_and_save_report(ComputePlatform::Ec2Plain);
+    }
+
+    #[test]
+    fn test_build_report_from_k8s_vanilla_pod() {
+        build_and_save_report(ComputePlatform::Ec2K8sVanilla);
+    }
+
+    #[test]
+    fn test_build_report_from_k8s_eks_pod() {
+        build_and_save_report(ComputePlatform::Ec2K8sEks);
+    }
+
+    fn build_and_save_report(compute_platform: ComputePlatform) {
+        let context = SockContext {
+            is_client: false,
+            address_family: AF_INET,
+            local_ipv4: 16909060,
+            remote_ipv4: 84281096,
+            local_ipv6: [0; 16],
+            remote_ipv6: [0; 16],
+            local_port: 443,
+            remote_port: 28015,
+            ..Default::default()
+        };
+        let stats = NetworkStats {
+            sockets_connecting: 4,
+            sockets_established: 3,
+            sockets_closing: 2,
+            sockets_closed: 1,
+
+            sockets_completed: 44,
+            severed_connect: 2,
+            severed_establish: 1,
+
+            connect_attempts: 14,
+            bytes_received: 43,
+            bytes_delivered: 47,
+            segments_received: 53,
+            segments_delivered: 59,
+
+            retrans_syn: 20,
+            retrans_est: 19,
+            retrans_close: 18,
+            rtos_syn: 17,
+            rtos_est: 16,
+            rtos_close: 15,
+
+            connect_us: MetricHistogram {
+                count: 2,
+                min: 12,
+                max: 13,
+                sum: 25,
+            },
+            rtt_us: MetricHistogram {
+                count: 3,
+                min: 14,
+                max: 15,
+                sum: 44,
+            },
+            rtt_smoothed_us: MetricHistogram {
+                count: 4,
+                min: 16,
+                max: 17,
+                sum: 66,
+            },
+        };
+        let mut process_stats = ProcessStats::default();
+        process_stats.counters.event_related = EventCounters {
+            active_connect_events: 1,
+            active_established_events: 2,
+            passive_established_events: 3,
+            state_change_events: 4,
+            rtt_events: 5,
+            retrans_events: 6,
+            rto_events: 7,
+            other_events: 8,
+            socket_events: 9,
+            sockets_invalid: 10,
+            map_insertion_errors: 18,
+            rtts_invalid: 15,
+            set_flags_errors: 16,
+            other_errors: 17,
+        };
+        process_stats.counters.process_related = ProcessCounters::default();
+
+        process_stats.usage.push(UsageStats {
+            cpu_util: 0.040,
+            mem_used_kb: 512,
+            mem_used_ratio: 0.06,
+            sockets_tracked: 100,
+        });
+
+        let iface1_stats = GroupedInterfaceStats {
+            interface_id: "iface-id-1".to_string(),
+            stats: NetworkInterfaceStats {
+                bw_in_allowance_exceeded: 211,
+                bw_out_allowance_exceeded: 223,
+                conntrack_allowance_exceeded: 227,
+                linklocal_allowance_exceeded: 229,
+                pps_allowance_exceeded: 233,
+                conntrack_allowance_available: 239,
+            },
+        };
+        let mut iface2_stats = iface1_stats.clone();
+        iface2_stats.interface_id = "iface-id-2".to_string();
+        let host_stats = HostStats {
+            interface_stats: vec![iface1_stats, iface2_stats],
+        };
+
+        let mut flow = FlowProperties::try_from(&context).unwrap();
+        if compute_platform != ComputePlatform::Ec2Plain {
+            flow.kubernetes_metadata = Some(FlowMetadata {
+                local: Some(PodInfo {
+                    name: "local-pod".to_string(),
+                    namespace: "local-namespace".to_string(),
+                    service_name: "local-service".to_string(),
+                }),
+                remote: Some(PodInfo {
+                    name: "remote-pod".to_string(),
+                    namespace: "remote-namespace".to_string(),
+                    service_name: "remote-service".to_string(),
+                }),
+            });
+        }
+        let agg_results = AggregateResults { flow, stats };
+        let mut env_metadata = EnvMetadata::default();
+        env_metadata.insert(
+            "instance_id".into(),
+            ReportValue::String("instance-id".into()),
+        );
+        env_metadata.insert(
+            "machine_id".into(),
+            ReportValue::String("machine-id".into()),
+        );
+        env_metadata.extend(
+            RuntimeEnvironmentMetadataProvider::from(compute_platform.clone()).get_metadata(),
+        );
+
+        let mut report = NfmReport::new();
+        report.set_network_stats(vec![agg_results]);
+        report.set_process_stats(process_stats);
+        report.set_env_metadata(env_metadata);
+        report.set_host_stats(host_stats);
+        report.set_failed_reports(10);
+        report.set_service_metadata(ServiceMetadata::new("agent-service", "0.1.0", "build-time"));
+
+        match compute_platform {
+            ComputePlatform::Ec2K8sEks => {
+                report.set_k8s_metadata(K8sMetadata {
+                    node_name: Some(ReportValue::String("k8s-node".into())),
+                    cluster_name: Some(ReportValue::String("k8s-cluster".into())),
+                });
+            }
+            ComputePlatform::Ec2K8sVanilla => {
+                report.set_k8s_metadata(K8sMetadata {
+                    node_name: Some(ReportValue::String("k8s-node".into())),
+                    cluster_name: None,
+                });
+            }
+            ComputePlatform::Ec2Plain => {
+                report.set_k8s_metadata(K8sMetadata {
+                    node_name: None,
+                    cluster_name: None,
+                });
+            }
+        }
+
+        let timestamp_us = 1718716821050000;
+        let built_report = NfmReportOTLP::build(&report, timestamp_us).unwrap();
+
+        // Parse the OTLP request
+        let actual_report = ExportMetricsServiceRequest::decode(built_report.as_slice()).unwrap();
+        assert_eq!(built_report, actual_report.encode_to_vec());
+
+        let compute_type = match compute_platform {
+            ComputePlatform::Ec2Plain => "ec2",
+            ComputePlatform::Ec2K8sEks => "k8s-eks",
+            ComputePlatform::Ec2K8sVanilla => "k8s-vanilla",
+        };
+        let expected_report: ExportMetricsServiceRequest = serde_json::from_reader(
+            fs::File::open(format!("../test-data/report-{compute_type}-otel.json")).unwrap(),
+        )
+        .unwrap();
+
+        // Save the serialized protobuf file for external validation.
+        let output_filename = format!("report-1-{compute_type}-flow.bin");
+        let mut buf = Vec::new();
+        actual_report.encode(&mut buf).unwrap();
+        fs::create_dir_all("../target/report-samples/").unwrap();
+        let mut file =
+            fs::File::create(format!("../target/report-samples/{}", output_filename)).unwrap();
+        std::io::Write::write_all(&mut file, &buf).unwrap();
+
+        assert_reports_eq(actual_report, expected_report);
+    }
+
+    fn assert_reports_eq(
+        mut actual_report: ExportMetricsServiceRequest,
+        mut expected_report: ExportMetricsServiceRequest,
+    ) {
+        // Note that serde serializes an object to JSON by creating, an `Object` variant of the
+        // `serde_json::Value` enum, whose contents are a `serde_json::Map`.  By default, the order
+        // of iterating a map's contents is not preserved, and we end up with a flaky unit test by
+        // asserting equality between actual_report and expected_report.  We could enable serde's
+        // "preserve_order" feature, but that can lead to someone taking a dependency on field
+        // order in production, which we don't want.  Hence we instead explicitly compare the
+        // fields of the Otel reports, which includes a sort of the metrics vector.
+
+        assert_eq!(actual_report.resource_metrics.len(), 1);
+        assert_eq!(expected_report.resource_metrics.len(), 1);
+        assert_eq!(
+            &actual_report.resource_metrics[0].resource,
+            &expected_report.resource_metrics[0].resource,
+        );
+        assert_eq!(
+            &actual_report.resource_metrics[0].schema_url,
+            &expected_report.resource_metrics[0].schema_url
+        );
+
+        let actual_len = actual_report.resource_metrics[0].scope_metrics.len();
+        let expected_len = expected_report.resource_metrics[0].scope_metrics.len();
+        assert_eq!(actual_len, expected_len);
+        assert!(expected_len > 0);
+
+        for i in 0..expected_len {
+            let actual = &mut actual_report.resource_metrics[0].scope_metrics[i];
+            let expected = &mut expected_report.resource_metrics[0].scope_metrics[i];
+            actual.metrics.sort_by(|a, b| a.name.cmp(&b.name));
+            expected.metrics.sort_by(|a, b| a.name.cmp(&b.name));
+
+            assert_eq!(actual, expected, "index {}", i);
+            assert!(expected.metrics.len() > 0, "index {}", i);
+        }
+    }
+}

--- a/nfm-controller/src/sock_diag.rs
+++ b/nfm-controller/src/sock_diag.rs
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use netlink_packet_core::{
+    NetlinkHeader, NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST,
+};
+use netlink_packet_sock_diag::{
+    constants::*,
+    inet::{ExtensionFlags, InetRequest, SocketId, StateFlags},
+    SockDiagMessage,
+};
+use netlink_sys::{protocols::NETLINK_SOCK_DIAG, Socket, SocketAddr};
+
+fn main() {
+    let mut socket = Socket::new(NETLINK_SOCK_DIAG).unwrap();
+    let _port_number = socket.bind_auto().unwrap().port_number();
+    socket.connect(&SocketAddr::new(0, 0)).unwrap();
+
+    let mut nl_hdr = NetlinkHeader::default();
+    nl_hdr.flags = NLM_F_REQUEST | NLM_F_DUMP;
+    let mut packet = NetlinkMessage::new(
+        nl_hdr,
+        SockDiagMessage::InetRequest(InetRequest {
+            family: AF_INET,
+            protocol: IPPROTO_TCP,
+            extensions: ExtensionFlags::INFO | ExtensionFlags::SKMEMINFO,
+            states: StateFlags::all(),
+            socket_id: SocketId::new_v4(),
+        })
+        .into(),
+    );
+
+    packet.finalize();
+
+    let mut buf = vec![0; packet.header.length as usize];
+
+    // Before calling serialize, it is important to check that the buffer in
+    // which we're emitting is big enough for the packet, other
+    // `serialize()` panics.
+    assert_eq!(buf.len(), packet.buffer_len());
+
+    packet.serialize(&mut buf[..]);
+
+    println!(">>> {packet:?}");
+    if let Err(e) = socket.send(&buf[..], 0) {
+        println!("SEND ERROR {e}");
+        return;
+    }
+
+    let mut receive_buffer = vec![0; 4096];
+    let mut offset = 0;
+    while let Ok(size) = socket.recv(&mut &mut receive_buffer[..], 0) {
+        loop {
+            let bytes = &receive_buffer[offset..];
+            let rx_packet =
+                <NetlinkMessage<SockDiagMessage>>::deserialize(bytes).unwrap();
+            println!("<<< {rx_packet:?}");
+
+            match rx_packet.payload {
+                NetlinkPayload::Noop => {}
+                NetlinkPayload::InnerMessage(
+                    SockDiagMessage::InetResponse(response),
+                ) => {
+                    println!("{response:#?}");
+                }
+                NetlinkPayload::Done(_) => {
+                    println!("Done!");
+                    return;
+                }
+                _ => return,
+            }
+
+            offset += rx_packet.header.length as usize;
+            if offset == size || rx_packet.header.length == 0 {
+                offset = 0;
+                break;
+            }
+        }
+    }
+}

--- a/nfm-controller/src/utils/clock.rs
+++ b/nfm-controller/src/utils/clock.rs
@@ -1,0 +1,274 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use libc::{
+    c_int, clock_gettime, timespec, CLOCK_BOOTTIME, CLOCK_PROCESS_CPUTIME_ID, CLOCK_REALTIME,
+};
+use std::mem;
+use std::time::Duration;
+
+pub trait Clock: Send {
+    fn now(&self) -> timespec;
+
+    fn now_us(&self) -> u64 {
+        timespec_to_us(self.now())
+    }
+
+    fn sleep(&mut self, span: Duration) {
+        std::thread::sleep(span);
+    }
+}
+
+pub struct ProcessClock;
+pub struct SystemBootClock;
+pub struct RealTimeClock;
+
+// A clock used to deterimistically control time in unit tests.
+#[derive(Clone, Default)]
+pub struct FakeClock {
+    pub now_us: u64,
+}
+
+impl Clock for ProcessClock {
+    fn now(&self) -> timespec {
+        clock_time(CLOCK_PROCESS_CPUTIME_ID)
+    }
+}
+
+impl Clock for SystemBootClock {
+    fn now(&self) -> timespec {
+        clock_time(CLOCK_BOOTTIME)
+    }
+}
+
+impl Clock for FakeClock {
+    fn now(&self) -> timespec {
+        timespec {
+            tv_sec: self.now_us as i64 / 1_000_000,
+            tv_nsec: (self.now_us as i64 % 1_000_000) * 1000,
+        }
+    }
+
+    fn now_us(&self) -> u64 {
+        self.now_us
+    }
+
+    fn sleep(&mut self, span: Duration) {
+        self.now_us += span.as_micros() as u64;
+    }
+}
+
+impl Clock for RealTimeClock {
+    fn now(&self) -> timespec {
+        clock_time(CLOCK_REALTIME)
+    }
+}
+
+// Gets the amount of time that has elapsed from a point in the past until the given clock's now.
+const NSEC_PER_SEC: i64 = 1_000_000_000;
+pub fn clock_delta<T: Clock + ?Sized>(clock: &T, past: timespec) -> timespec {
+    let now = clock.now();
+    let mut sec_adjustment = 0;
+    let mut nsec_adjustment = 0;
+    if now.tv_nsec < past.tv_nsec {
+        sec_adjustment = -1;
+        nsec_adjustment = NSEC_PER_SEC;
+    }
+    let spec = timespec {
+        tv_sec: now.tv_sec - past.tv_sec + sec_adjustment,
+        tv_nsec: now.tv_nsec - past.tv_nsec + nsec_adjustment,
+    };
+    assert!(
+        spec.tv_sec >= 0 && spec.tv_nsec >= 0,
+        "now: sec={} nsec={}; past: sec={} nsec={}",
+        now.tv_sec,
+        now.tv_nsec,
+        past.tv_sec,
+        past.tv_nsec,
+    );
+
+    spec
+}
+
+pub fn timespec_to_us(spec: timespec) -> u64 {
+    spec.tv_sec as u64 * 1_000_000 + spec.tv_nsec as u64 / 1000
+}
+
+pub fn timespec_to_nsec(spec: timespec) -> u64 {
+    (spec.tv_sec * NSEC_PER_SEC + spec.tv_nsec) as u64
+}
+
+// Gets the current time measured by the given clock type.
+fn clock_time(clock_type: c_int) -> timespec {
+    let mut spec: timespec = unsafe { mem::zeroed() };
+    let result = unsafe { clock_gettime(clock_type, &mut spec) };
+    if result != 0 {
+        spec.tv_sec = 0;
+        spec.tv_nsec = 0;
+    }
+
+    spec
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use libc::timespec;
+
+    #[test]
+    fn test_timespec_to_nsec() {
+        let mut spec = timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        assert_eq!(timespec_to_nsec(spec), 0);
+
+        spec.tv_nsec = 1;
+        assert_eq!(timespec_to_nsec(spec), 1);
+
+        spec.tv_nsec = 1000;
+        assert_eq!(timespec_to_nsec(spec), 1000);
+
+        spec.tv_sec = 1979;
+        assert_eq!(timespec_to_nsec(spec), 1_979_000_001_000);
+    }
+
+    #[test]
+    fn test_timespec_to_us() {
+        let mut spec = timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        assert_eq!(timespec_to_us(spec), 0);
+
+        spec.tv_nsec = 1;
+        assert_eq!(timespec_to_us(spec), 0);
+
+        spec.tv_nsec = 1_000_000;
+        assert_eq!(timespec_to_us(spec), 1000);
+
+        spec.tv_sec = 1979;
+        assert_eq!(timespec_to_us(spec), 1_979_001_000);
+    }
+
+    #[test]
+    fn test_process_clock() {
+        test_clock(&ProcessClock {});
+    }
+
+    #[test]
+    fn test_fake_clock() {
+        test_clock(&FakeClock { now_us: 1_000_000 });
+    }
+
+    #[test]
+    fn test_boot_clock() {
+        let mut clock = SystemBootClock {};
+        test_clock(&clock);
+
+        let start = clock.now_us();
+        clock.sleep(Duration::from_millis(100));
+        let end = clock.now_us();
+        assert!(
+            end - start > 95,
+            "Expected to sleep roughly 100 ms, slept {} ms",
+            end - start
+        );
+    }
+
+    #[test]
+    fn test_fake_clock_sleep() {
+        let mut clock = FakeClock::default();
+        assert_eq!(clock.now_us(), 0);
+
+        clock.sleep(Duration::from_micros(0));
+        assert_eq!(clock.now_us(), 0);
+
+        clock.sleep(Duration::from_micros(19));
+        assert_eq!(clock.now_us(), 19);
+
+        clock.sleep(Duration::from_micros(3));
+        assert_eq!(clock.now_us(), 22);
+
+        clock.sleep(Duration::from_micros(0));
+        assert_eq!(clock.now_us(), 22);
+    }
+
+    #[test]
+    fn test_real_time_clock() {
+        test_clock(&RealTimeClock {});
+    }
+
+    #[test]
+    fn test_real_time_clock_againts_utc() {
+        assert_eq!(
+            RealTimeClock {}.now().tv_sec,
+            chrono::Utc::now().timestamp()
+        );
+    }
+
+    fn test_clock<T: Clock>(clock: &T) {
+        // Validate our clock's time is not zero, and does not decrease.
+        let mut last_time = clock.now_us();
+        assert!(last_time > 0);
+        for _ in 1..100 {
+            let new_time = clock.now_us();
+            assert!(new_time >= last_time);
+            last_time = new_time;
+        }
+    }
+
+    #[test]
+    fn test_clock_delta() {
+        let past_time = timespec {
+            tv_sec: 1,
+            tv_nsec: 2_000_000,
+        };
+
+        let clock = FakeClock { now_us: 2001000 };
+        let current_time = clock.now();
+
+        let expected = timespec {
+            tv_sec: 2,
+            tv_nsec: 1_000_000,
+        };
+        assert_eq!(current_time.tv_sec, expected.tv_sec);
+        assert_eq!(current_time.tv_nsec, expected.tv_nsec);
+
+        // Test with a higher nanosec in the past.
+        let actual = clock_delta(&clock, past_time);
+        let expected = timespec {
+            tv_sec: 0,
+            tv_nsec: 999_000_000,
+        };
+        assert_eq!(actual.tv_sec, expected.tv_sec);
+        assert_eq!(actual.tv_nsec, expected.tv_nsec);
+
+        // Test with a lower nanosec in the past.
+        let past_time = timespec {
+            tv_sec: 1,
+            tv_nsec: 900_000,
+        };
+        let actual = clock_delta(&clock, past_time);
+        let expected = timespec {
+            tv_sec: 1,
+            tv_nsec: 100_000,
+        };
+        assert_eq!(actual.tv_sec, expected.tv_sec);
+        assert_eq!(actual.tv_nsec, expected.tv_nsec);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_clock_delta_panic() {
+        // Test with a larger time in the past, which should fail.
+        let past_time = timespec {
+            tv_sec: 3,
+            tv_nsec: 2_000_000,
+        };
+
+        let clock = FakeClock { now_us: 2001 };
+        clock_delta(&clock, past_time);
+    }
+}

--- a/nfm-controller/src/utils/command_runner.rs
+++ b/nfm-controller/src/utils/command_runner.rs
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use hashbrown::HashMap;
+use std::process::{Command, Output};
+use std::sync::{Arc, Mutex};
+
+pub trait CommandRunner {
+    fn run(&mut self, cmd: &str, args: &[&str]) -> std::io::Result<Output>;
+}
+
+#[derive(Default)]
+pub struct RealCommandRunner;
+
+impl CommandRunner for RealCommandRunner {
+    fn run(&mut self, cmd: &str, args: &[&str]) -> std::io::Result<Output> {
+        Command::new(cmd).args(args).output()
+    }
+}
+
+/* A command runner used for controlled unit tests.
+ *
+ * Usage:
+ *      // Add many command expectations.
+ *      let mut fake_runner = FakeCommandRunner::new();
+ *      fake_runner.add_expectation("command1", args1, Ok(Output {...}));
+ *      fake_runner.add_expectation("command2", args2, Ok(Output {...}));
+ *
+ *      // Share the command runner with other objects by cloning it.
+ *      ... fake_runner.clone() ...
+ *
+ *      // Do work.
+ *
+ *      // Confirm all commands were run.
+ *      assert!(fake_runner.expectations.lock().unwrap().is_empty());
+ *
+ */
+#[derive(Clone, Default)]
+pub struct FakeCommandRunner {
+    pub expectations: Arc<Mutex<HashMap<String, std::io::Result<Output>>>>,
+}
+
+impl FakeCommandRunner {
+    pub fn new() -> Self {
+        Self {
+            expectations: Default::default(),
+        }
+    }
+
+    pub fn add_expectation(&mut self, cmd: &str, args: &[&str], result: std::io::Result<Output>) {
+        self.expectations
+            .lock()
+            .unwrap()
+            .insert(Self::full_command(cmd, args), result);
+    }
+
+    fn full_command(cmd: &str, args: &[&str]) -> String {
+        let mut parts = vec![cmd];
+        parts.extend_from_slice(args);
+        parts.join(" ")
+    }
+}
+
+impl CommandRunner for FakeCommandRunner {
+    fn run(&mut self, cmd: &str, args: &[&str]) -> std::io::Result<Output> {
+        let full_cmd = Self::full_command(cmd, args);
+        self.expectations.lock().unwrap().remove(&full_cmd).unwrap()
+    }
+}

--- a/nfm-controller/src/utils/conntrack_listener.rs
+++ b/nfm-controller/src/utils/conntrack_listener.rs
@@ -1,0 +1,394 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use log::info;
+use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
+use netlink_packet_netfilter::{
+    constants::NFNLGRP_CONNTRACK_NEW,
+    nfconntrack::{nlas::ConnectionProperties, ConnectionNla, NfConntrackMessage},
+    NetfilterMessage, NetfilterMessageInner,
+};
+use netlink_sys::{constants::NETLINK_NETFILTER, Socket};
+use std::convert::TryFrom;
+use std::io::ErrorKind;
+
+// 425984 Bytes of space can store 333 messages. (default for c5.4xlarge kubernetes host env / can be less or more for others)
+// Meaning for 500msec agg period we can only receive up to 666 new conntrack events per second with that size.
+// Setting this to target 10k connections per second -> (425984) * (10000 / 666) = 6396156 Bytes.
+// Cost of reading each entry is around 2.5us, so 10k entries will cost 25ms per second (2.5% load for a single core)
+// Rounding up to nearest 4096 -> 6397952, i.e. 6.4MByte-ish
+const SOCKET_RX_BUF_DESIRED_SIZE: usize = 6397952;
+
+#[derive(Clone, Debug)]
+pub struct ConntrackEntry {
+    pub original: ConnectionProperties,
+    pub reply: ConnectionProperties,
+}
+
+impl ConntrackEntry {
+    pub fn was_natd(&self) -> bool {
+        Self::reverse(&self.reply) != self.original
+    }
+
+    fn reverse(cxn: &ConnectionProperties) -> ConnectionProperties {
+        ConnectionProperties {
+            src_ip: cxn.dst_ip,
+            dst_ip: cxn.src_ip,
+            src_port: cxn.dst_port,
+            dst_port: cxn.src_port,
+            protocol: cxn.protocol,
+        }
+    }
+}
+
+pub trait ConntrackProvider {
+    fn get_new_entries(&mut self) -> Result<Vec<ConntrackEntry>, String>;
+}
+
+pub struct ConntrackListener {
+    socket: Socket,
+    rx_buf: Vec<u8>,
+}
+
+impl ConntrackListener {
+    pub fn initialize() -> Self {
+        // Create our non-blocking socket.
+        let mut socket = Socket::new(NETLINK_NETFILTER).expect("Failed to create netlink socket");
+        socket
+            .set_non_blocking(true)
+            .expect("Failed to set netlink socket properties");
+
+        // Attempt to increase the receive buffer, but take what the kernel clamps us to.
+        let initial_rx_buf_size = socket
+            .get_rx_buf_sz()
+            .expect("Failed to get buf size of netlink socket");
+        let desired_rx_buf_size = SOCKET_RX_BUF_DESIRED_SIZE;
+
+        socket
+            .set_rx_buf_sz(desired_rx_buf_size)
+            .expect("Failed to set netlink socket buf size");
+        let actual_rx_buf_size = socket
+            .get_rx_buf_sz()
+            .expect("Failed to get buf size of netlink socket");
+
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize };
+        info!(page_size, initial_rx_buf_size, desired_rx_buf_size, actual_rx_buf_size; "Configured conntrack socket buffer.");
+
+        let rx_buf: Vec<u8> = vec![0; actual_rx_buf_size];
+
+        // Subscribe to conntrack events.
+        socket.bind_auto().unwrap();
+        socket.add_membership(NFNLGRP_CONNTRACK_NEW).unwrap();
+
+        Self { socket, rx_buf }
+    }
+
+    fn parse_connection_properties(
+        msg: NetlinkMessage<NetfilterMessage>,
+    ) -> Result<(ConnectionProperties, ConnectionProperties), String> {
+        let mut orig_opt: Option<ConnectionProperties> = None;
+        let mut reply_opt: Option<ConnectionProperties> = None;
+
+        if let NetlinkPayload::<NetfilterMessage>::InnerMessage(imsg) = msg.payload {
+            if let NetfilterMessageInner::NfConntrack(NfConntrackMessage::ConnectionNew(nlas)) =
+                imsg.inner
+            {
+                for nla in nlas {
+                    match nla {
+                        ConnectionNla::TupleOrig(tuple) => {
+                            match ConnectionProperties::try_from(tuple) {
+                                Ok(cxn) => orig_opt = Some(cxn),
+                                Err(e) => {
+                                    return Err(format!(
+                                        "Failed to extract original connection properties: {:?}",
+                                        e
+                                    ));
+                                }
+                            }
+                        }
+                        ConnectionNla::TupleReply(tuple) => {
+                            match ConnectionProperties::try_from(tuple) {
+                                Ok(cxn) => reply_opt = Some(cxn),
+                                Err(e) => {
+                                    return Err(format!(
+                                        "Failed to extract reply connection properties: {:?}",
+                                        e
+                                    ));
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        match (orig_opt, reply_opt) {
+            (Some(orig), Some(reply)) => Ok((orig, reply)),
+            _ => Err("Connection properties not found".to_string()),
+        }
+    }
+}
+
+impl ConntrackProvider for ConntrackListener {
+    fn get_new_entries(&mut self) -> Result<Vec<ConntrackEntry>, String> {
+        let mut events = Vec::<ConntrackEntry>::new();
+
+        loop {
+            let flags: i32 = 0;
+            match self.socket.recv(&mut &mut self.rx_buf[..], flags) {
+                Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                    break;
+                }
+                Err(e) => {
+                    return Err(format!("Failed to read from netlink socket: {:?}", e));
+                }
+                _ => {}
+            }
+
+            let msg = match NetlinkMessage::<NetfilterMessage>::deserialize(&self.rx_buf[..]) {
+                Ok(m) => m,
+                Err(_) => {
+                    // We failed to parse the netlink message.
+                    // TODO: Should we track occurrences are record a throttled log messge?
+                    continue;
+                }
+            };
+
+            match Self::parse_connection_properties(msg) {
+                Ok((original, reply)) => {
+                    events.push(ConntrackEntry { original, reply });
+                }
+                Err(_) => {
+                    // The message was not a valid pair of 5-tuples.
+                    // TODO: Should we track occurrences are record a throttled log messge?
+                }
+            }
+        }
+
+        Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::utils::{conntrack_listener::ConntrackEntry, ConntrackListener};
+
+    use netlink_packet_core::NetlinkMessage;
+    use netlink_packet_netfilter::{nfconntrack::nlas::ConnectionProperties, NetfilterMessage};
+    use std::net::IpAddr;
+    use std::str::FromStr;
+
+    #[rustfmt::skip]
+    static NL_NF_CONNTRACK_NEW_PKT: [u8; 196] = [
+        // Start NetlinkHeader
+        0xc4, 0x00, 0x00, 0x00,   // len
+        0x00, 0x01,               // msg type NFNL_SUBSYS_* << 8 | <subtype>
+                                  // e.g NFNL_SUBSYS_CTNETLINK << 8 | IPCTNL_MSG_CT_NEW == 256
+        0x00, 0x06,               // flags
+        0x00, 0x00, 0x00, 0x00,   // seq num
+        0x00, 0x00, 0x00, 0x00,   // port id
+
+        // Start NfGenMsg
+        0x02,                     // addr family AF_INET* (ipv4)
+        0x00,                     // nf_version
+        0x00, 0x00,               // resource id
+
+        0x34, 0x00,               // len
+        0x01, 0x80,               // type NLA_F_NESTED | CTA_TUPLE_ORIG
+
+        0x14, 0x00,               // len
+        0x01, 0x80,               // type NLA_F_NESTED | CTA_TUPLE_IP
+        0x08, 0x00,               // len
+        0x01, 0x00,               // type CTA_IP_V4_SRC
+        0x01, 0x02, 0x03, 0x04,   // val ip
+        0x08, 0x00,               // len
+        0x02, 0x00,               // type CTA_IP_V4_DST
+        0x05, 0x06, 0x07, 0x08,   // val ip
+
+        0x1c, 0x00,               // len
+        0x02, 0x80,               // type CTA_TUPLE_PROTO
+        0x05, 0x00,               // len
+        0x01, 0x00,               // type CTA_PROTO_NUM
+        0x06,                     // val TCP
+        0x00, 0x00, 0x00,         // padding
+        0x06, 0x00,               // len
+        0x02, 0x00,               // type CTA_PROTO_SRC_PORT
+        0x16, 0x2e,               // val port
+        0x00, 0x00,               // padding
+        0x06, 0x00,               // len
+        0x03, 0x00,               // type CTA_PROTO_DST_PORT
+        0x01, 0xbb,               // val port
+        0x00, 0x00,               // padding
+
+        0x34, 0x00,               // len
+        0x02, 0x80,               // type NLA_F_NESTED | CTA_TUPLE_REPLY
+
+        0x14, 0x00,               // len
+        0x01, 0x80,               // type NLA_F_NESTED | CTA_TUPLE_IP
+        0x08, 0x00,               // len
+        0x01, 0x00,               // type CTA_IP_V4_SRC
+        0x09, 0x08, 0x07, 0x06,   // val ip
+        0x08, 0x00,               // len
+        0x02, 0x00,               // type CTA_IP_V4_DST
+        0x05, 0x04, 0x03, 0x02,   // val ip
+
+        0x1c, 0x00,               // len
+        0x02, 0x80,               // type CTA_TUPLE_PROTO
+        0x05, 0x00,               // len
+        0x01, 0x00,               // type CTA_PROTO_NUM
+        0x06,                     // val TCP
+        0x00, 0x00, 0x00,         // padding
+        0x06, 0x00,               // len
+        0x02, 0x00,               // type CTA_PROTO_SRC_PORT
+        0x26, 0x94,               // val port
+        0x00, 0x00,               // padding
+        0x06, 0x00,               // len
+        0x03, 0x00,               // type CTA_PROTO_DST_PORT
+        0x04, 0xd2,               // val port
+        0x00, 0x00,               // padding
+
+        0x08, 0x00,               // len
+        0x0c, 0x00,               // type CTA_ID
+        0x44, 0x75, 0x09, 0x81,   //
+
+        0x08, 0x00,               // len
+        0x03, 0x00,               // type CTA_STATUS
+        0x00, 0x00, 0x01, 0x88,
+
+        0x08, 0x00,               // len
+        0x07, 0x00,               // type CTA_TIMEOUT
+        0x00, 0x00, 0x00, 0x78,   // val 120,sec
+
+        0x30, 0x00,               // len
+        0x04, 0x80,               // type NLA_F_NESTED | CTA_PROTOINFO
+        0x2c, 0x00,               // len
+        0x01, 0x80,               // type NLA_F_NESTED | CTA_PROTOINFO_TCP
+        0x05, 0x00,               // len
+        0x01, 0x00,               // type CTA_PROTOINFO_TCP_STATE
+        0x01,                     // val (syn sent)
+        0x00, 0x00, 0x00,         // padding
+        0x05, 0x00,               // len
+        0x02, 0x00,               // type CTA_PROTOINFO_TCP_FLAGS_ORIGINAL
+        0x07,                     // val
+        0x00, 0x00, 0x00,         // padding
+        0x05, 0x00,               // len
+        0x03, 0x00,               // type CTA_PROTOINFO_TCP_FLAGS_REPLY
+        0x00,                     // val
+        0x00, 0x00, 0x00,
+
+        0x06, 0x00,               // len
+        0x04, 0x00,
+        0x03, 0x00,
+        0x00, 0x00,               // padding
+
+        0x06, 0x00,               // len
+        0x05, 0x00,
+        0x00, 0x00,
+        0x00, 0x00,               // padding
+    ];
+
+    #[test]
+    fn test_parse_conntrack_message_new() {
+        let nlnf_message =
+            NetlinkMessage::<NetfilterMessage>::deserialize(&NL_NF_CONNTRACK_NEW_PKT[..]).unwrap();
+
+        let (actual_original, actual_reply) =
+            ConntrackListener::parse_connection_properties(nlnf_message).unwrap();
+
+        let expected_original = ConnectionProperties {
+            src_ip: IpAddr::from_str("1.2.3.4").unwrap(),
+            dst_ip: IpAddr::from_str("5.6.7.8").unwrap(),
+            src_port: 5678,
+            dst_port: 443,
+            protocol: libc::IPPROTO_TCP as u8,
+        };
+        let expected_reply = ConnectionProperties {
+            src_ip: IpAddr::from_str("9.8.7.6").unwrap(),
+            dst_ip: IpAddr::from_str("5.4.3.2").unwrap(),
+            src_port: 9876,
+            dst_port: 1234,
+            protocol: libc::IPPROTO_TCP as u8,
+        };
+
+        assert_eq!(actual_original, expected_original);
+        assert_eq!(actual_reply, expected_reply);
+    }
+
+    #[test]
+    fn test_netlink_deserialize_error() {
+        #[rustfmt::skip]
+        let mut rx_buf: [u8; 20] = [
+            // Start NetlinkHeader
+            0x15, 0x00, 0x00, 0x00,   // Specify a length 1 byte longer than the actual buffer
+            0x00, 0x01,               // msg type
+            0x00, 0x06,               // flags
+            0x00, 0x00, 0x00, 0x00,   // seq num
+            0x00, 0x00, 0x00, 0x00,   // port id
+
+            // Start NfGenMsg
+            0x02,                     // addr family AF_INET*
+            0x00,                     // nf_version
+            0x00, 0x00,               // resource id
+        ];
+
+        let nlnf_message = NetlinkMessage::<NetfilterMessage>::deserialize(&rx_buf[..]);
+        assert!(nlnf_message.is_err());
+
+        // Try again with the appropriate length.
+        rx_buf[0] = rx_buf.len() as u8;
+        let nlnf_message = NetlinkMessage::<NetfilterMessage>::deserialize(&rx_buf[..]);
+        assert!(nlnf_message.is_ok());
+    }
+
+    #[test]
+    fn test_conntrack_props_reverse() {
+        let expected = ConnectionProperties {
+            src_ip: IpAddr::from_str("1.2.3.4").unwrap(),
+            dst_ip: IpAddr::from_str("5.6.7.8").unwrap(),
+            src_port: 1234,
+            dst_port: 5678,
+            protocol: libc::IPPROTO_TCP as u8,
+        };
+
+        let actual = ConntrackEntry::reverse(&ConnectionProperties {
+            src_ip: IpAddr::from_str("5.6.7.8").unwrap(),
+            dst_ip: IpAddr::from_str("1.2.3.4").unwrap(),
+            src_port: 5678,
+            dst_port: 1234,
+            protocol: libc::IPPROTO_TCP as u8,
+        });
+
+        assert_eq!(actual, expected);
+        assert!(ConntrackEntry::reverse(&actual) != expected);
+        assert_eq!(
+            ConntrackEntry::reverse(&ConntrackEntry::reverse(&actual)),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_conntrack_entry_was_natd() {
+        let mut entry = ConntrackEntry {
+            original: ConnectionProperties {
+                src_ip: IpAddr::from_str("1.2.3.4").unwrap(),
+                dst_ip: IpAddr::from_str("5.6.7.8").unwrap(),
+                src_port: 1234,
+                dst_port: 5678,
+                protocol: libc::IPPROTO_TCP as u8,
+            },
+            reply: ConnectionProperties {
+                src_ip: IpAddr::from_str("5.6.7.8").unwrap(),
+                dst_ip: IpAddr::from_str("1.2.3.4").unwrap(),
+                src_port: 5678,
+                dst_port: 1234,
+                protocol: libc::IPPROTO_TCP as u8,
+            },
+        };
+
+        // Test the negative case, then the positive case.
+        assert!(!entry.was_natd());
+        entry.reply.src_port += 1;
+        assert!(entry.was_natd());
+    }
+}

--- a/nfm-controller/src/utils/cpu.rs
+++ b/nfm-controller/src/utils/cpu.rs
@@ -1,0 +1,131 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::utils::clock::{clock_delta, timespec_to_nsec, Clock, ProcessClock, SystemBootClock};
+
+use libc::timespec;
+use log::{error, info};
+use std::fs;
+
+// store CPU count statically instead of re-reading everytime, its not going to change, ever.
+static CPU_CORE_COUNT: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+fn get_core_count_from_cpuinfo() -> usize {
+    let mut core_count = 1;
+    if let Ok(contents) = fs::read_to_string("/proc/cpuinfo") {
+        let core_count_cpuinfo = contents
+            .lines()
+            .filter(|line| line.starts_with("processor"))
+            .count();
+        if core_count_cpuinfo > core_count {
+            core_count = core_count_cpuinfo;
+            info!(core_count; "Acquired processor CPU core count from /proc/cpuinfo");
+        }
+    }
+    core_count
+}
+
+// Gets the total amount of available CPU cores across the whole physical die
+pub fn get_total_cpu_core_count() -> usize {
+    *CPU_CORE_COUNT.get_or_init(|| {
+        match sys_info::cpu_num() {
+            Ok(num_logical_cores) => {
+                info!(num_logical_cores; "Acquired processor CPU core count from sys_info");
+                num_logical_cores.try_into().unwrap()
+            }
+            Err(_) => {
+                error!("Failed to acquire processor CPU core count from sys_info, falling back to /proc/cpuinfo");
+                get_core_count_from_cpuinfo()
+            }
+        }
+    })
+}
+
+pub struct CpuUsageMonitor {
+    process_clock: ProcessClock,
+    boot_clock: SystemBootClock,
+    process_start: timespec,
+    boot_start: timespec,
+    num_cpus: usize,
+}
+
+impl CpuUsageMonitor {
+    pub fn start() -> Self {
+        let (process_clock, boot_clock) = (ProcessClock {}, SystemBootClock {});
+        let (process_start, boot_start) = (process_clock.now(), boot_clock.now());
+        Self {
+            process_clock,
+            boot_clock,
+            process_start,
+            boot_start,
+            num_cpus: get_total_cpu_core_count(),
+        }
+    }
+
+    pub fn usage_ratio(&self) -> f64 {
+        let consumed = timespec_to_nsec(self.process_duration()) as f64;
+        let elapsed = timespec_to_nsec(self.total_duration()) as f64;
+
+        consumed / self.num_cpus as f64 / elapsed
+    }
+
+    // Gets the user and system time consumed by the current process across all logical cores since
+    // this monitor was started.
+    fn process_duration(&self) -> timespec {
+        clock_delta(&self.process_clock, self.process_start)
+    }
+
+    // Gets the time that has elapsed since this monitor was started.
+    fn total_duration(&self) -> timespec {
+        clock_delta(&self.boot_clock, self.boot_start)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::CpuUsageMonitor;
+    use std::{thread, time};
+
+    #[test]
+    fn test_cpu_usage() {
+        // Do no work, and validate CPU usage is less than 100%.
+        let mut cpu_monitor = CpuUsageMonitor::start();
+        thread::sleep(time::Duration::from_millis(1000));
+        let low_usage_ratio = cpu_monitor.usage_ratio();
+        assert!(
+            low_usage_ratio < 1.0,
+            "expected < 1.0, got {}",
+            low_usage_ratio
+        );
+
+        // Do lots of work, and validate CPU usage is greater than 0%.
+        cpu_monitor = CpuUsageMonitor::start();
+        let mut x: f64 = 101.0;
+        for _ in 0..1_000_000 {
+            x = x * 107.0 / 103.0;
+        }
+        let high_usage_ratio = cpu_monitor.usage_ratio();
+        assert!(
+            high_usage_ratio > 0.0,
+            "expected > 0.0, got {}",
+            high_usage_ratio
+        );
+        assert!(
+            high_usage_ratio <= 1.0,
+            "expected <= 1.0, got {}",
+            high_usage_ratio
+        );
+    }
+
+    #[test]
+    fn test_core_count_reader_cpuinfo() {
+        let core_count = super::get_core_count_from_cpuinfo();
+        assert!(core_count > 1 && core_count < 16384); // valid for all modern cpus, and for a foreseeable future
+    }
+
+    #[test]
+    fn test_core_count_reader_sys_info() {
+        let core_count = super::get_total_cpu_core_count();
+        assert!(core_count > 1 && core_count < 16384); // valid for all modern cpus, and for a foreseeable future
+    }
+}

--- a/nfm-controller/src/utils/credentials.rs
+++ b/nfm-controller/src/utils/credentials.rs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use aws_config::BehaviorVersion;
+use aws_credential_types::provider::ProvideCredentials;
+
+pub fn get_credentials_provider() -> impl ProvideCredentials {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(aws_config::load_defaults(BehaviorVersion::latest()))
+        .credentials_provider()
+        .expect("error getting credential provider")
+}

--- a/nfm-controller/src/utils/event_timer.rs
+++ b/nfm-controller/src/utils/event_timer.rs
@@ -1,0 +1,399 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::utils::Clock;
+
+use log::debug;
+use rand::Rng;
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::sync::{
+    atomic::{AtomicBool, Ordering as AtomicOrd},
+    Arc,
+};
+use std::time::Duration;
+
+pub type EventId = u32;
+pub const EXIT_EVENT: EventId = 0;
+pub const UNKNOWN_EVENT: EventId = u32::MAX;
+
+pub struct EventTimer<T: Clock> {
+    clock: T,
+    last_id: EventId,
+    events: BinaryHeap<PeriodicEvent>,
+    exit_flag: Option<Arc<AtomicBool>>,
+}
+
+impl<T: Clock> EventTimer<T> {
+    pub fn new(clock: T) -> Self {
+        EventTimer {
+            clock,
+            last_id: EXIT_EVENT,
+            events: BinaryHeap::new(),
+            exit_flag: None,
+        }
+    }
+
+    pub fn set_exit_flag(&mut self, flag: Arc<AtomicBool>) {
+        self.exit_flag = Some(flag);
+    }
+
+    fn create_event(&mut self, period: Duration, jitter: Duration) -> PeriodicEvent {
+        self.last_id += 1;
+        let mut event = PeriodicEvent {
+            id: self.last_id,
+            period_us: period.as_micros().try_into().unwrap(),
+            jitter_us: jitter.as_micros().try_into().unwrap(),
+            next_invocation: 0,
+        };
+        event.choose_next_invocation(self.clock.now_us());
+        event
+    }
+
+    // Returns a new event ID to be invoked at a cadence of the given period +/- jitter. And an initial extra delay
+    pub fn add_event(&mut self, period: Duration, jitter: Duration) -> EventId {
+        let event = self.create_event(period, jitter);
+        self.events.push(event);
+        self.last_id
+    }
+
+    // Returns a new event ID to be invoked at a cadence of the given period +/- jitter. And an initial extra delay
+    pub fn add_event_with_delay(
+        &mut self,
+        period: Duration,
+        jitter: Duration,
+        delay: Duration,
+    ) -> EventId {
+        let mut event = self.create_event(period, jitter);
+        event.next_invocation += delay.as_micros() as u64;
+        self.events.push(event);
+
+        self.last_id
+    }
+
+    // Sleeps until returning the next event ID that should be invoked.
+    pub fn await_next_event(&mut self) -> EventId {
+        let next_event = self.events.pop();
+
+        if let Some(mut event) = next_event {
+            let event_id = event.id;
+
+            let now = self.clock.now_us();
+            if event.next_invocation > now && self.try_sleep(event.next_invocation, now).is_err() {
+                return EXIT_EVENT;
+            }
+            event.choose_next_invocation(self.clock.now_us());
+            self.events.push(event);
+
+            event_id
+        } else {
+            EXIT_EVENT
+        }
+    }
+
+    fn try_sleep(&mut self, until_us: u64, mut now_us: u64) -> Result<(), String> {
+        let mut span = Duration::from_micros(until_us - now_us);
+        debug!("Waiting {span:?} until the next event...");
+
+        while until_us > now_us {
+            let sleep_fragment_us = (until_us - now_us).min(1_000_000);
+            span = Duration::from_micros(sleep_fragment_us);
+            self.clock.sleep(span);
+
+            now_us += sleep_fragment_us;
+            if let Some(exit_flag) = &self.exit_flag {
+                if exit_flag.load(AtomicOrd::Relaxed) {
+                    return Err("should exit".to_string());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct PeriodicEvent {
+    id: EventId,
+    period_us: u64,
+    jitter_us: u64,
+    next_invocation: u64,
+}
+
+impl PeriodicEvent {
+    /*
+     * Sets this event's next invocation to be within +/- jitter one period from now.
+     *
+     *     now       next period
+     *      v            v
+     *      |------------|------------|
+     *                |-----| <-- jitter range
+     */
+    fn choose_next_invocation(&mut self, now_us: u64) {
+        let rand_jitter: u64 = if self.jitter_us > 0 {
+            rand::thread_rng().gen_range(0..self.jitter_us * 2)
+        } else {
+            0
+        };
+        self.next_invocation = now_us + self.period_us - self.jitter_us + rand_jitter;
+    }
+}
+
+impl Eq for PeriodicEvent {}
+
+impl PartialEq for PeriodicEvent {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl PartialOrd for PeriodicEvent {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PeriodicEvent {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Order events by the time of their next invocation.
+        match self.next_invocation.cmp(&other.next_invocation) {
+            Ordering::Less => Ordering::Greater,
+            Ordering::Equal => Ordering::Equal,
+            Ordering::Greater => Ordering::Less,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use libc::timespec;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering as AtomicOrd},
+        Arc,
+    };
+
+    use super::*;
+    use crate::utils::{Clock, FakeClock, SystemBootClock};
+
+    #[test]
+    fn test_event_timer() {
+        let mut timer = EventTimer::new(FakeClock::default());
+        let (period_us, jitter_us) = (100, 5);
+        let id1 = timer.add_event(
+            Duration::from_micros(period_us),
+            Duration::from_micros(jitter_us),
+        );
+        assert!(id1 > EXIT_EVENT);
+
+        let (period_us, jitter_us) = (40, 2);
+        let id2 = timer.add_event(
+            Duration::from_micros(period_us),
+            Duration::from_micros(jitter_us),
+        );
+
+        let (period_us, jitter_us) = (110, 5);
+        let id3 = timer.add_event(
+            Duration::from_micros(period_us),
+            Duration::from_micros(jitter_us),
+        );
+
+        // Confirm events are retrieved in the following order.
+        let event_ids = vec![id2, id2, id1, id3, id2, id2];
+        for expected_id in event_ids {
+            let actual_id = timer.await_next_event();
+            assert_eq!(actual_id, expected_id);
+        }
+
+        // Ensure the elapsed time is within our jitter bounds (4 periods of even #2).
+        let (elapsed_min, elapsed_max) = (38 * 4, 42 * 4);
+        let now = timer.clock.now_us();
+        assert!(now >= elapsed_min && now <= elapsed_max);
+    }
+
+    #[test]
+    fn test_event_timer_delay() {
+        let mut timer = EventTimer::new(FakeClock::default());
+        let start_us = timer.clock.now_us();
+        let (period_us, jitter_us, delay) = (100, 0, 500);
+        let id1 = timer.add_event_with_delay(
+            Duration::from_micros(period_us),
+            Duration::from_micros(jitter_us),
+            Duration::from_micros(delay),
+        );
+        assert!(id1 > EXIT_EVENT);
+
+        let found_id = timer.await_next_event();
+        assert_eq!(found_id, id1);
+
+        let elapsed_us = timer.clock.now_us() - start_us;
+        assert!(elapsed_us >= 600, "Expected elapsed_us={elapsed_us} > 600");
+    }
+
+    #[test]
+    fn test_event_timer_system_clock() {
+        let clock = SystemBootClock {};
+        let start_us = clock.now_us();
+
+        let mut timer = EventTimer::new(SystemBootClock {});
+        let (period_us, jitter_us) = (100, 0);
+        let event_id = timer.add_event(
+            Duration::from_micros(period_us),
+            Duration::from_micros(jitter_us),
+        );
+        let found_id = timer.await_next_event();
+        assert_eq!(found_id, event_id);
+
+        let elapsed_us = clock.now_us() - start_us;
+        assert!(elapsed_us >= 100, "Expected elapsed_us={elapsed_us} > 100");
+    }
+
+    #[test]
+    fn test_event_timer_empty() {
+        let mut timer = EventTimer::new(FakeClock::default());
+        for _ in 0..10 {
+            assert_eq!(EXIT_EVENT, timer.await_next_event());
+        }
+        assert_eq!(0, timer.clock.now_us());
+    }
+
+    #[test]
+    fn test_next_event_invocation() {
+        let mut event = PeriodicEvent {
+            id: 0,
+            period_us: 0,
+            jitter_us: 0,
+            next_invocation: 0,
+        };
+
+        let mut now_us = 0;
+
+        // Test an empty period & jitter.
+        event.choose_next_invocation(now_us);
+        assert_eq!(event.next_invocation, 0);
+
+        // Test a period with no jitter.
+        event.period_us = 1979;
+        event.choose_next_invocation(now_us);
+        assert_eq!(event.next_invocation, 1979);
+
+        // Test a repeat.
+        event.choose_next_invocation(now_us);
+        assert_eq!(event.next_invocation, 1979);
+
+        now_us = 2049;
+        event.choose_next_invocation(now_us);
+        assert_eq!(event.next_invocation, 2049 + 1979);
+
+        // Test a period with jitter.  Every result must be within jitter of the next period.
+        now_us = 12300;
+        event.period_us = 50;
+        event.jitter_us = 5;
+        for _ in 0..20 {
+            event.choose_next_invocation(now_us);
+            assert!(
+                event.next_invocation >= 12345 && event.next_invocation <= 12355,
+                "{} is outside expected bounds",
+                event.next_invocation
+            );
+        }
+    }
+
+    struct FakeNoSleepClock {
+        now_us: u64,
+    }
+    impl Clock for FakeNoSleepClock {
+        fn now_us(&self) -> u64 {
+            self.now_us
+        }
+
+        fn sleep(&mut self, _span: Duration) {
+            // Ignore sleep
+        }
+
+        fn now(&self) -> timespec {
+            timespec {
+                tv_sec: self.now_us as i64 / 1_000_000,
+                tv_nsec: (self.now_us as i64 % 1_000_000) * 1000,
+            }
+        }
+    }
+
+    #[test]
+    fn test_event_invocation_in_the_past() {
+        // Found a bug where the event is not added back to the
+        // event list when event.next_invocation <= now
+
+        const MAX_TIME_US: u64 = 1000;
+        const EVENT_PERIOD: u64 = 100;
+        let clock = FakeNoSleepClock {
+            now_us: MAX_TIME_US,
+        };
+
+        let mut timer = EventTimer::new(clock);
+
+        // Create an event manually to control the next execution time.
+        let event_id = 1;
+        let event = PeriodicEvent {
+            id: event_id,
+            period_us: EVENT_PERIOD,
+            jitter_us: 0,
+            next_invocation: 0,
+        };
+        timer.events.push(event);
+
+        // Retrieve the event using the regular logic.
+        let found_id = timer.await_next_event();
+        assert_eq!(found_id, event_id);
+
+        // Check that the event was added back.
+        assert_eq!(timer.events.len(), 1);
+
+        // Test the same again to validate the full flow
+        let found_id = timer.await_next_event();
+        assert_eq!(found_id, event_id);
+        assert_eq!(timer.events.len(), 1);
+    }
+
+    #[test]
+    fn test_try_sleep() {
+        let mut timer = EventTimer::new(FakeClock::default());
+        let should_exit = Arc::new(AtomicBool::new(false));
+        timer.set_exit_flag(Arc::clone(&should_exit));
+
+        // Confirm sleep succeeds when not interrupted.
+        let now_us = timer.clock.now_us();
+        let sleep_until_us = now_us + 10;
+        assert!(timer.try_sleep(sleep_until_us, now_us).is_ok());
+
+        // Confirm sleep does not succeed when we are interrupted.
+        let now_us = timer.clock.now_us();
+        let sleep_until_us = now_us + 10;
+        should_exit.store(true, AtomicOrd::Relaxed);
+        assert!(timer.try_sleep(sleep_until_us, now_us).is_err());
+
+        // Test returning to successful sleep.
+        let now_us = timer.clock.now_us();
+        let sleep_until_us = now_us + 10;
+        should_exit.store(false, AtomicOrd::Relaxed);
+        assert!(timer.try_sleep(sleep_until_us, now_us).is_ok());
+
+        // Confirm successful sleep when no flag is set.
+        let mut timer = EventTimer::new(FakeClock::default());
+        let now_us = timer.clock.now_us();
+        let sleep_until_us = now_us + 10;
+        assert!(timer.try_sleep(sleep_until_us, now_us).is_ok());
+    }
+
+    #[test]
+    fn test_interrupted_await_next_event() {
+        let mut timer = EventTimer::new(FakeClock::default());
+        let should_exit = Arc::new(AtomicBool::new(true));
+        timer.set_exit_flag(Arc::clone(&should_exit));
+
+        let (period_us, jitter_us) = (100, 0);
+        let _ = timer.add_event(
+            Duration::from_micros(period_us),
+            Duration::from_micros(jitter_us),
+        );
+        assert_eq!(timer.await_next_event(), EXIT_EVENT);
+    }
+}

--- a/nfm-controller/src/utils/memory_inspector.rs
+++ b/nfm-controller/src/utils/memory_inspector.rs
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use log::{error, info};
+use procfs::{process::Process, Current, Meminfo};
+
+const BYTES_PER_KB: u64 = 1024;
+
+pub trait MemoryInspector {
+    // Returns a tuple of used KB and its ratio of total memory.
+    fn usage(&self) -> (u64, f64);
+}
+
+pub struct ProcessMemoryInspector {
+    pid: u32,
+    total_kb: u64,
+}
+
+#[allow(clippy::new_without_default)]
+impl ProcessMemoryInspector {
+    pub fn new() -> Self {
+        let total_kb = match Meminfo::current() {
+            Ok(meminfo) => meminfo.mem_total / BYTES_PER_KB,
+            Err(e) => {
+                // TODO: Increment counter on mem retrieval error.
+                error!(error = e.to_string(); "Failed to retrieve total memory");
+                0
+            }
+        };
+        info!(total_kb = total_kb; "Retrieved total system memory");
+
+        Self {
+            pid: std::process::id(),
+            total_kb,
+        }
+    }
+}
+
+impl MemoryInspector for ProcessMemoryInspector {
+    fn usage(&self) -> (u64, f64) {
+        if let Ok(process) = Process::new(self.pid as i32) {
+            let used_kb = match process.stat() {
+                Ok(stat) => stat.rss * procfs::page_size() / BYTES_PER_KB,
+                Err(e) => {
+                    // TODO: Increment counter on mem retrieval error.
+                    error!(error = e.to_string(); "Failed to retrieve process memory");
+                    0
+                }
+            };
+
+            (used_kb, used_kb as f64 / self.total_kb as f64)
+        } else {
+            (0, 0.0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_process_memory_inspector() {
+        let inspector = ProcessMemoryInspector::new();
+        let (mem_used, mem_ratio_used) = inspector.usage();
+        assert!(mem_used > 0);
+        assert!(mem_ratio_used < 0.10);
+    }
+}

--- a/nfm-controller/src/utils/mod.rs
+++ b/nfm-controller/src/utils/mod.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod clock;
+pub mod command_runner;
+pub mod conntrack_listener;
+pub mod cpu;
+pub mod credentials;
+pub mod event_timer;
+pub mod memory_inspector;
+pub mod report;
+
+pub use clock::{timespec_to_nsec, timespec_to_us, Clock, FakeClock, SystemBootClock};
+pub use command_runner::{CommandRunner, FakeCommandRunner, RealCommandRunner};
+pub use conntrack_listener::ConntrackListener;
+pub use cpu::CpuUsageMonitor;
+pub use event_timer::EventTimer;
+pub use memory_inspector::{MemoryInspector, ProcessMemoryInspector};

--- a/nfm-controller/src/utils/report.rs
+++ b/nfm-controller/src/utils/report.rs
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Serialize;
+
+use crate::reports::report::ReportValue;
+
+pub fn to_value_pairs<T: Serialize>(item: &T) -> Vec<(String, ReportValue)> {
+    let item_serialized = serde_json::to_value(item).unwrap();
+    let key_value_map = item_serialized.as_object().unwrap();
+    key_value_map
+        .iter()
+        .filter_map(|(k, v)| {
+            // Serialize only primitive types into the report.
+            if !v.is_object() && !v.is_array() {
+                Some((k.clone(), v.into()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[macro_export]
+macro_rules! add_histogram_to_report {
+    ($self:ident, $field:ident, $vec:expr) => {
+        $vec.push((
+            stringify!($field).to_string(),
+            ReportValue::Histogram($self.$field),
+        ));
+    };
+}

--- a/test-data/report-ec2-otel.json
+++ b/test-data/report-ec2-otel.json
@@ -1,0 +1,1532 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "instance_id",
+            "value": {
+              "stringValue": "instance-id"
+            }
+          },
+          {
+            "key": "machine_id",
+            "value": {
+              "stringValue": "machine-id"
+            }
+          },
+          {
+            "key": "compute_platform",
+            "value": {
+              "stringValue": "EC2_PLAIN"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "agent-service"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "0.1.0"
+            }
+          },
+          {
+            "key": "agent.build_ts",
+            "value": {
+              "stringValue": "build-time"
+            }
+          },
+          {
+            "key": "report.version",
+            "value": {
+              "stringValue": "1.1"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeMetrics": [
+        {
+          "scope": {
+            "name": "network_stats",
+            "version": "",
+            "attributes": [
+              {
+                "key": "local_address",
+                "value": {
+                  "stringValue": "1.2.3.4"
+                }
+              },
+              {
+                "key": "local_port",
+                "value": {
+                  "intValue": "443"
+                }
+              },
+              {
+                "key": "protocol",
+                "value": {
+                  "stringValue": "TCP"
+                }
+              },
+              {
+                "key": "remote_address",
+                "value": {
+                  "stringValue": "5.6.7.8"
+                }
+              },
+              {
+                "key": "remote_port",
+                "value": {
+                  "intValue": "0"
+                }
+              }
+            ],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "bytes_delivered",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 47.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "bytes_received",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 43.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "connect_attempts",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 14.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "retrans_close",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 18.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "retrans_est",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 19.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "retrans_syn",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 20.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtos_close",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 15.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtos_est",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 16.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtos_syn",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 17.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "segments_delivered",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 59.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "segments_received",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 53.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "severed_connect",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 2.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "severed_establish",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 1.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_closed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 1.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_closing",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 2.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 44.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_connecting",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 4.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_established",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 3.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "connect_us",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 2,
+                    "sum": 25.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": 12.0,
+                    "max": 13.0
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtt_us",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 3,
+                    "sum": 44.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": 14.0,
+                    "max": 15.0
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtt_smoothed_us",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 4,
+                    "sum": 66.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": 16.0,
+                    "max": 17.0
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "process_stats",
+            "version": "",
+            "attributes": [],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "cpu_util",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asDouble": 0.04
+                  }
+                ]
+              }
+            },
+            {
+              "name": "mem_used_kb",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 512
+                  }
+                ]
+              }
+            },
+            {
+              "name": "mem_used_ratio",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asDouble": 0.06
+                  }
+                ]
+              }
+            },
+            {
+              "name": "sockets_tracked",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 100
+                  }
+                ]
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "host_stats",
+            "version": "",
+            "attributes": [
+              {
+                "key": "interface_id",
+                "value": {
+                  "stringValue": "iface-id-1"
+                }
+              }
+            ],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "bw_in_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 211
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "bw_out_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 223
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_available",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 239
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 227
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "linklocal_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 229
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "pps_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 233
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "host_stats",
+            "version": "",
+            "attributes": [
+              {
+                "key": "interface_id",
+                "value": {
+                  "stringValue": "iface-id-2"
+                }
+              }
+            ],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "bw_in_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 211
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "bw_out_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 223
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_available",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 239
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 227
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "linklocal_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 229
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "pps_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 233
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "counters",
+            "version": "",
+            "attributes": [],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "active_connect_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 1
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "active_established_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 2
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "map_insertion_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 18
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "other_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 17
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "other_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 8
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "passive_established_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 3
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "retrans_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 6
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "rto_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 7
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "rtt_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 5
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "rtts_invalid",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 15
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "set_flags_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 16
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 9
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_invalid",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 10
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "state_change_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 4
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "remote_nat_reversal_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "restarts",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_agg_above_limit",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_agg_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_agg_missing_props",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_deltas_above_limit",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_deltas_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_deltas_missing_props",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_eviction_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_eviction_failed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_added",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_natd",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_stale",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "publish_report_failed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 10
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            }
+          ],
+          "schemaUrl": ""
+        }
+      ],
+      "schemaUrl": ""
+    }
+  ]
+}

--- a/test-data/report-k8s-eks-otel.json
+++ b/test-data/report-k8s-eks-otel.json
@@ -1,0 +1,1580 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "instance_id",
+            "value": {
+              "stringValue": "instance-id"
+            }
+          },
+          {
+            "key": "machine_id",
+            "value": {
+              "stringValue": "machine-id"
+            }
+          },
+          {
+            "key": "compute_platform",
+            "value": {
+              "stringValue": "EC2_K8S_EKS"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "agent-service"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "0.1.0"
+            }
+          },
+          {
+            "key": "agent.build_ts",
+            "value": {
+              "stringValue": "build-time"
+            }
+          },
+          {
+            "key": "report.version",
+            "value": {
+              "stringValue": "1.1"
+            }
+          },
+          {
+            "key": "k8s_node_name",
+            "value": {
+              "stringValue": "k8s-node"
+            }
+          },
+          {
+            "key": "k8s_eks_cluster_name",
+            "value": {
+              "stringValue": "k8s-cluster"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeMetrics": [
+        {
+          "scope": {
+            "name": "network_stats",
+            "version": "",
+            "attributes": [
+              {
+                "key": "local_address",
+                "value": {
+                  "stringValue": "1.2.3.4"
+                }
+              },
+              {
+                "key": "local_port",
+                "value": {
+                  "intValue": "443"
+                }
+              },
+              {
+                "key": "protocol",
+                "value": {
+                  "stringValue": "TCP"
+                }
+              },
+              {
+                "key": "remote_address",
+                "value": {
+                  "stringValue": "5.6.7.8"
+                }
+              },
+              {
+                "key": "remote_port",
+                "value": {
+                  "intValue": "0"
+                }
+              },
+              {
+                "key": "local_pod_name",
+                "value": {
+                  "stringValue": "local-pod"
+                }
+              },
+              {
+                "key": "local_pod_namespace",
+                "value": {
+                  "stringValue": "local-namespace"
+                }
+              },
+              {
+                "key": "local_pod_service",
+                "value": {
+                  "stringValue": "local-service"
+                }
+              },
+              {
+                "key": "remote_pod_name",
+                "value": {
+                  "stringValue": "remote-pod"
+                }
+              },
+              {
+                "key": "remote_pod_namespace",
+                "value": {
+                  "stringValue": "remote-namespace"
+                }
+              },
+              {
+                "key": "remote_pod_service",
+                "value": {
+                  "stringValue": "remote-service"
+                }
+              }
+            ],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "bytes_delivered",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 47.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "bytes_received",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 43.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "connect_attempts",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 14.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "retrans_close",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 18.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "retrans_est",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 19.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "retrans_syn",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 20.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtos_close",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 15.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtos_est",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 16.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtos_syn",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 17.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "segments_delivered",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 59.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "segments_received",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 53.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "severed_connect",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 2.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "severed_establish",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 1.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_closed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 1.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_closing",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 2.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 44.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_connecting",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 4.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_established",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 3.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "connect_us",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 2,
+                    "sum": 25.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": 12.0,
+                    "max": 13.0
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtt_us",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 3,
+                    "sum": 44.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": 14.0,
+                    "max": 15.0
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtt_smoothed_us",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 4,
+                    "sum": 66.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": 16.0,
+                    "max": 17.0
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "process_stats",
+            "version": "",
+            "attributes": [],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "cpu_util",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asDouble": 0.04
+                  }
+                ]
+              }
+            },
+            {
+              "name": "mem_used_kb",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 512
+                  }
+                ]
+              }
+            },
+            {
+              "name": "mem_used_ratio",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asDouble": 0.06
+                  }
+                ]
+              }
+            },
+            {
+              "name": "sockets_tracked",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 100
+                  }
+                ]
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "host_stats",
+            "version": "",
+            "attributes": [
+              {
+                "key": "interface_id",
+                "value": {
+                  "stringValue": "iface-id-1"
+                }
+              }
+            ],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "bw_in_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 211
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "bw_out_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 223
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_available",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 239
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 227
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "linklocal_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 229
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "pps_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 233
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "host_stats",
+            "version": "",
+            "attributes": [
+              {
+                "key": "interface_id",
+                "value": {
+                  "stringValue": "iface-id-2"
+                }
+              }
+            ],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "bw_in_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 211
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "bw_out_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 223
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_available",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 239
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 227
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "linklocal_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 229
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "pps_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 233
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "counters",
+            "version": "",
+            "attributes": [],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "active_connect_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 1
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "active_established_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 2
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "map_insertion_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 18
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "other_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 17
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "other_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 8
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "passive_established_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 3
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "retrans_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 6
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "rto_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 7
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "rtt_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 5
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "rtts_invalid",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 15
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "set_flags_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 16
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 9
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_invalid",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 10
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "state_change_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 4
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "remote_nat_reversal_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "restarts",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_agg_above_limit",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_agg_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_agg_missing_props",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_deltas_above_limit",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_deltas_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_deltas_missing_props",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_eviction_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_eviction_failed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_added",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_natd",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_stale",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "publish_report_failed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 10
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            }
+          ],
+          "schemaUrl": ""
+        }
+      ],
+      "schemaUrl": ""
+    }
+  ]
+}

--- a/test-data/report-k8s-vanilla-otel.json
+++ b/test-data/report-k8s-vanilla-otel.json
@@ -1,0 +1,1574 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "instance_id",
+            "value": {
+              "stringValue": "instance-id"
+            }
+          },
+          {
+            "key": "machine_id",
+            "value": {
+              "stringValue": "machine-id"
+            }
+          },
+          {
+            "key": "compute_platform",
+            "value": {
+              "stringValue": "EC2_K8S_VANILLA"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "agent-service"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "0.1.0"
+            }
+          },
+          {
+            "key": "agent.build_ts",
+            "value": {
+              "stringValue": "build-time"
+            }
+          },
+          {
+            "key": "report.version",
+            "value": {
+              "stringValue": "1.1"
+            }
+          },
+          {
+            "key": "k8s_node_name",
+            "value": {
+              "stringValue": "k8s-node"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeMetrics": [
+        {
+          "scope": {
+            "name": "network_stats",
+            "version": "",
+            "attributes": [
+              {
+                "key": "local_address",
+                "value": {
+                  "stringValue": "1.2.3.4"
+                }
+              },
+              {
+                "key": "local_port",
+                "value": {
+                  "intValue": "443"
+                }
+              },
+              {
+                "key": "protocol",
+                "value": {
+                  "stringValue": "TCP"
+                }
+              },
+              {
+                "key": "remote_address",
+                "value": {
+                  "stringValue": "5.6.7.8"
+                }
+              },
+              {
+                "key": "remote_port",
+                "value": {
+                  "intValue": "0"
+                }
+              },
+              {
+                "key": "local_pod_name",
+                "value": {
+                  "stringValue": "local-pod"
+                }
+              },
+              {
+                "key": "local_pod_namespace",
+                "value": {
+                  "stringValue": "local-namespace"
+                }
+              },
+              {
+                "key": "local_pod_service",
+                "value": {
+                  "stringValue": "local-service"
+                }
+              },
+              {
+                "key": "remote_pod_name",
+                "value": {
+                  "stringValue": "remote-pod"
+                }
+              },
+              {
+                "key": "remote_pod_namespace",
+                "value": {
+                  "stringValue": "remote-namespace"
+                }
+              },
+              {
+                "key": "remote_pod_service",
+                "value": {
+                  "stringValue": "remote-service"
+                }
+              }
+            ],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "bytes_delivered",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 47.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "bytes_received",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 43.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "connect_attempts",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 14.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "retrans_close",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 18.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "retrans_est",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 19.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "retrans_syn",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 20.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtos_close",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 15.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtos_est",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 16.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtos_syn",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 17.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "segments_delivered",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 59.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "segments_received",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 53.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "severed_connect",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 2.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "severed_establish",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 1.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_closed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 1.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_closing",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 2.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 44.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_connecting",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 4.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "sockets_established",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 1,
+                    "sum": 3.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": null,
+                    "max": null
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "connect_us",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 2,
+                    "sum": 25.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": 12.0,
+                    "max": 13.0
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtt_us",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 3,
+                    "sum": 44.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": 14.0,
+                    "max": 15.0
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            },
+            {
+              "name": "rtt_smoothed_us",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "count": 4,
+                    "sum": 66.0,
+                    "bucketCounts": [],
+                    "explicitBounds": [],
+                    "exemplars": [],
+                    "flags": 0,
+                    "min": 16.0,
+                    "max": 17.0
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "process_stats",
+            "version": "",
+            "attributes": [],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "cpu_util",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asDouble": 0.04
+                  }
+                ]
+              }
+            },
+            {
+              "name": "mem_used_kb",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 512
+                  }
+                ]
+              }
+            },
+            {
+              "name": "mem_used_ratio",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asDouble": 0.06
+                  }
+                ]
+              }
+            },
+            {
+              "name": "sockets_tracked",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 100
+                  }
+                ]
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "host_stats",
+            "version": "",
+            "attributes": [
+              {
+                "key": "interface_id",
+                "value": {
+                  "stringValue": "iface-id-1"
+                }
+              }
+            ],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "bw_in_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 211
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "bw_out_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 223
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_available",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 239
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 227
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "linklocal_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 229
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "pps_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 233
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "host_stats",
+            "version": "",
+            "attributes": [
+              {
+                "key": "interface_id",
+                "value": {
+                  "stringValue": "iface-id-2"
+                }
+              }
+            ],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "bw_in_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 211
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "bw_out_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 223
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_available",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 239
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "conntrack_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 227
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "linklocal_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 229
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "pps_allowance_exceeded",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 233
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            }
+          ],
+          "schemaUrl": ""
+        },
+        {
+          "scope": {
+            "name": "counters",
+            "version": "",
+            "attributes": [],
+            "droppedAttributesCount": 0
+          },
+          "metrics": [
+            {
+              "name": "active_connect_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 1
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "active_established_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 2
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "map_insertion_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 18
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "other_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 17
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "other_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 8
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "passive_established_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 3
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "retrans_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 6
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "rto_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 7
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "rtt_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 5
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "rtts_invalid",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 15
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "set_flags_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 16
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 9
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_invalid",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 10
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "state_change_events",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 4
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "remote_nat_reversal_errors",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "restarts",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_agg_above_limit",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_agg_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_agg_missing_props",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_deltas_above_limit",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_deltas_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_deltas_missing_props",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_eviction_completed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "socket_eviction_failed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_added",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_natd",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "sockets_stale",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 0
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "publish_report_failed",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 10
+                  }
+                ],
+                "aggregationTemporality": 1,
+                "isMonotonic": true
+              }
+            }
+          ],
+          "schemaUrl": ""
+        }
+      ],
+      "schemaUrl": ""
+    }
+  ]
+}

--- a/test-data/report1.json
+++ b/test-data/report1.json
@@ -1,0 +1,135 @@
+{
+  "network_stats": [
+    {
+      "flow": {
+        "protocol": "TCP",
+        "local_address": "1.2.3.4",
+        "remote_address": "5.6.7.8",
+        "local_port": 443,
+        "remote_port": 0
+      },
+      "stats": {
+        "sockets_connecting": 4,
+        "sockets_established": 3,
+        "sockets_closing": 2,
+        "sockets_closed": 1,
+        "sockets_completed": 44,
+        "severed_connect": 2,
+        "severed_establish": 1,
+        "connect_attempts": 14,
+        "bytes_received": 43,
+        "bytes_delivered": 47,
+        "segments_received": 53,
+        "segments_delivered": 59,
+        "retrans_syn": 20,
+        "retrans_est": 19,
+        "retrans_close": 18,
+        "rtos_syn": 17,
+        "rtos_est": 16,
+        "rtos_close": 15,
+        "connect_us": {
+            "count": 2,
+            "min": 12,
+            "max": 13,
+            "sum": 25
+        },
+        "rtt_us": {
+            "count": 3,
+            "min": 14,
+            "max": 15,
+            "sum": 44
+        },
+        "rtt_smoothed_us": {
+            "count": 4,
+            "min": 16,
+            "max": 17,
+            "sum": 66
+        }
+      }
+    }
+  ],
+  "process_stats": {
+    "counters": {
+      "event_related": {
+        "active_connect_events": 0,
+        "active_established_events": 0,
+        "passive_established_events": 0,
+        "state_change_events": 0,
+        "rtt_events": 0,
+        "retrans_events": 0,
+        "rto_events": 0,
+        "other_events": 0,
+        "socket_events": 0,
+        "sockets_invalid": 0,
+        "map_insertion_errors": 0,
+        "rtts_invalid": 0,
+        "set_flags_errors": 0,
+        "other_errors": 0
+      },
+      "process_related": {
+        "remote_nat_reversal_errors": 0,
+        "restarts": 0,
+        "sockets_added": 0,
+        "sockets_natd": 0,
+        "sockets_stale": 0,
+        "sockets_aggregated": 0,
+        "socket_deltas_completed": 0,
+        "socket_deltas_missing_props": 0,
+        "socket_deltas_above_limit": 0,
+        "socket_agg_completed": 0,
+        "socket_agg_missing_props": 0,
+        "socket_agg_above_limit": 0,
+        "socket_eviction_completed": 0,
+        "socket_eviction_failed": 0
+      }
+    },
+    "usage": [
+      {
+        "cpu_util": 0.04,
+        "mem_used_kb": 512,
+        "mem_used_ratio": 0.06,
+        "sockets_tracked": 49
+      }
+    ]
+  },
+  "host_stats": {
+      "interface_stats": [
+          {
+              "interface_id": "iface-id-1",
+              "stats": {
+                  "bw_in_allowance_exceeded": 211,
+                  "bw_out_allowance_exceeded": 223,
+                  "conntrack_allowance_exceeded": 227,
+                  "linklocal_allowance_exceeded": 229,
+                  "pps_allowance_exceeded": 233,
+                  "conntrack_allowance_available": 239
+              }
+          }
+      ]
+  },
+  "env_metadata": [
+    [
+      "instance_id",
+      {
+        "String": "instance-id"
+      }
+    ]
+  ],
+  "service_metadata": {
+    "name": {
+      "String": "test-service"
+    },
+    "version": {
+      "String": "1.0"
+    },
+    "build_ts": {
+      "String": "build-time"
+    }
+  },
+  "failed_reports": 0,
+  "report_version": "1.1",
+  "k8s_metadata": {
+    "node_name": null,
+    "cluster_name": null
+  }
+}

--- a/test-data/report2.json
+++ b/test-data/report2.json
@@ -1,0 +1,135 @@
+{
+  "network_stats": [
+    {
+      "flow": {
+        "protocol": "TCP",
+        "local_address": "1.2.3.4",
+        "remote_address": "5.6.7.8",
+        "local_port": 0,
+        "remote_port": 28015
+      },
+      "stats": {
+        "sockets_connecting": 4,
+        "sockets_established": 3,
+        "sockets_closing": 2,
+        "sockets_closed": 1,
+        "sockets_completed": 44,
+        "severed_connect": 2,
+        "severed_establish": 1,
+        "connect_attempts": 14,
+        "bytes_received": 43,
+        "bytes_delivered": 47,
+        "segments_received": 53,
+        "segments_delivered": 59,
+        "retrans_syn": 20,
+        "retrans_est": 19,
+        "retrans_close": 18,
+        "rtos_syn": 17,
+        "rtos_est": 16,
+        "rtos_close": 15,
+        "connect_us": {
+            "count": 2,
+            "min": 12,
+            "max": 13,
+            "sum": 25
+        },
+        "rtt_us": {
+            "count": 3,
+            "min": 14,
+            "max": 15,
+            "sum": 44
+        },
+        "rtt_smoothed_us": {
+            "count": 4,
+            "min": 16,
+            "max": 17,
+            "sum": 66
+        }
+      }
+    }
+  ],
+  "process_stats": {
+    "counters": {
+      "event_related": {
+        "active_connect_events": 0,
+        "active_established_events": 0,
+        "passive_established_events": 0,
+        "state_change_events": 0,
+        "rtt_events": 0,
+        "retrans_events": 0,
+        "rto_events": 0,
+        "other_events": 0,
+        "socket_events": 0,
+        "sockets_invalid": 0,
+        "map_insertion_errors": 0,
+        "rtts_invalid": 0,
+        "set_flags_errors": 0,
+        "other_errors": 0
+      },
+      "process_related": {
+        "remote_nat_reversal_errors": 0,
+        "restarts": 0,
+        "sockets_added": 0,
+        "sockets_natd": 0,
+        "sockets_stale": 0,
+        "sockets_aggregated": 0,
+        "socket_deltas_completed": 0,
+        "socket_deltas_missing_props": 0,
+        "socket_deltas_above_limit": 0,
+        "socket_agg_completed": 0,
+        "socket_agg_missing_props": 0,
+        "socket_agg_above_limit": 0,
+        "socket_eviction_completed": 0,
+        "socket_eviction_failed": 0
+      }
+    },
+    "usage": [
+      {
+        "cpu_util": 0.04,
+        "mem_used_kb": 512,
+        "mem_used_ratio": 0.06,
+        "sockets_tracked": 49
+      }
+    ]
+  },
+  "host_stats": {
+      "interface_stats": [
+          {
+              "interface_id": "iface-id-1",
+              "stats": {
+                  "bw_in_allowance_exceeded": 211,
+                  "bw_out_allowance_exceeded": 223,
+                  "conntrack_allowance_exceeded": 227,
+                  "linklocal_allowance_exceeded": 229,
+                  "pps_allowance_exceeded": 233,
+                  "conntrack_allowance_available": 239
+              }
+          }
+      ]
+  },
+  "env_metadata": [
+    [
+      "instance_id",
+      {
+        "String": "instance-id"
+      }
+    ]
+  ],
+  "service_metadata": {
+    "name": {
+      "String": "test-service"
+    },
+    "version": {
+      "String": "1.0"
+    },
+    "build_ts": {
+      "String": "build-time"
+    }
+  },
+  "failed_reports": 0,
+  "report_version": "1.1",
+  "k8s_metadata": {
+    "node_name": null,
+    "cluster_name": null
+  }
+}


### PR DESCRIPTION
This is the initial release of the NFM agent.

Changes were tested by building then running the agent [a], which showed statistics printed to `stdout`.

[a]
```
cargo build --release
...
target/release/network-flow-monitor-agent --cgroup /mnt/cgroup-nfm --publish-reports off --log-reports on
```