### PR TITLE
Fix the README's tooltip to display as a graphical icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This application runs on Linux kernel version 5.8 and newer.
 
 ## Installation
 
-> [!TIP] [Instructions are
+> [!TIP]
+> [Instructions are
 > available](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents.html)
 > to deploy across a fleet of EC2 instances or EKS clusters and integrate with
 > Amazon CloudWatch Network Flow Monitor.


### PR DESCRIPTION
Wording after the `[!TIP]` has been moved to a newline for the icon to properly render.