### PR TITLE
AWS Network Flow Monitor Kubernetes Helm Charts 'v1.0.2-eksbuild.1' Release

### DIFF
--- a/charts/amazon-network-flow-monitor-agent/Makefile
+++ b/charts/amazon-network-flow-monitor-agent/Makefile
@@ -7,3 +7,24 @@ helm/install/customer:
 .PHONY: helm/uninstall/customer
 helm/uninstall/customer:
 	UNINSTALL=true ./bin/agent-k8s-install.sh
+
+# Eksclt configures IRSA (IAM Role for Service Account) so that 'Amazon CloudWatch Network Flow Monitor Agent' can finally authenticate to Ingestion APIs
+# - Ensure to add CLUSTER_NAME to have IRSA configured when calling this make target. Ex: make eksctl/irsa/customer CLUSTER_NAME=my-cluster
+# - Ensure to add REGION to have IRSA configured when calling this make target. Ex: make eksctl/irsa/customer REGION=us-west-2
+# - Similarly, a custom IAM Role name can be defined when calling this make target: Ex: make eksctl/irsa/customer CLUSTER_NAME=my-cluster NFM_AGENT_PUBLISH_ROLE=MyNFMAgentPublishRole
+# - Similarly, a custom Kubernetes namespace can be defined when calling this make target: Ex: make eksctl/irsa/customer CLUSTER_NAME=my-cluster NAMESPACE=MyNamespace
+.PHONY: eksctl/install/irsa
+eksctl/install/irsa:
+	./bin/irsa-setup.sh
+
+# Eksclt deletes previously configured IRSA (IAM Role for Service Account)
+# - Deleting IRSA is required prior to re-installing 'Amazon CloudWatch Network Flow Monitor Agent'
+.PHONY: eksctl/uninstall/irsa
+eksctl/uninstall/irsa:
+	UNINSTALL=true ./bin/irsa-setup.sh
+
+# Kubectl forces a new DaemonSet rollout
+# - This assumes 'Amazon CloudWatch Network Flow Monitor Agent' DaemonSet has been already installed via 'helm/install/customer'
+.PHONY: kubectl/daemonset/restart
+kubectl/daemonset/restart:
+	./bin/daemonset-rollout.sh

--- a/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
+++ b/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
@@ -13,7 +13,8 @@ HELM_CHARTS_DIR="$(dirname "$(realpath "$0")")/../"
 VALUES_FILENAME=values.yaml
 
 # Publicly Accessible Docker Image Repository for 'Amazon CloudWatch Network Flow Monitor'
-CONTAINER_REGISTRY="602401143452.dkr.ecr.us-west-2.amazonaws.com"
+PROD_CONTAINER_REGISTRY="602401143452.dkr.ecr.us-west-2.amazonaws.com"
+export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-$PROD_CONTAINER_REGISTRY}
 
 export LATEST_KNOWN_IMAGE_TAG="v1.0.1-eksbuild.2"
 export IMAGE_TAG=${IMAGE_TAG:-$LATEST_KNOWN_IMAGE_TAG}

--- a/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
+++ b/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
@@ -16,7 +16,7 @@ VALUES_FILENAME=values.yaml
 PROD_CONTAINER_REGISTRY="602401143452.dkr.ecr.us-west-2.amazonaws.com"
 export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-$PROD_CONTAINER_REGISTRY}
 
-export LATEST_KNOWN_IMAGE_TAG="v1.0.1-eksbuild.2"
+export LATEST_KNOWN_IMAGE_TAG="v1.0.2-eksbuild.1"
 export IMAGE_TAG=${IMAGE_TAG:-$LATEST_KNOWN_IMAGE_TAG}
 
 # Will install 'Amazon CloudWatch Network Flow Monitor Agent' Manifest Files to an existing K8s Cluster

--- a/charts/amazon-network-flow-monitor-agent/bin/daemonset-rollout.sh
+++ b/charts/amazon-network-flow-monitor-agent/bin/daemonset-rollout.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script is used for forcing a new 'Amazon CloudWatch Network Flow Monitor Agent' DaemonSet rollout
+# - A new deployment is triggered and PODs replaced with new ones
+# - Used to enable PODs to acquire permissions from IRSA for the first time
+# 
+# RECOMMENDED to call this script via available make targets
+
+NFM_DAEMON_SET_NAME=aws-network-flow-monitor-agent
+DEFAULT_NAMESPACE=amazon-network-flow-monitor
+
+NAMESPACE=${NAMESPACE:-$DEFAULT_NAMESPACE}
+
+kubectl rollout restart daemonset -n ${NAMESPACE} ${NFM_DAEMON_SET_NAME}

--- a/charts/amazon-network-flow-monitor-agent/bin/irsa-setup.sh
+++ b/charts/amazon-network-flow-monitor-agent/bin/irsa-setup.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This script is used for configuring IRSA for 'Amazon CloudWatch Network Flow Monitor Agent' authentication with Ingestion APIs
+# - IAM Role for IRSA will be created automatically by eksctl, if it doesn't exist already;
+# 
+# RECOMMENDED to call this script via available make targets
+
+NFM_SERVICE_ACCOUNT=aws-network-flow-monitor-agent-service-account
+NFM_AGENT_PUBLISH_MANAGED_POLICY=arn:aws:iam::aws:policy/CloudWatchNetworkFlowMonitorAgentPublishPolicy
+DEFAULT_NAMESPACE=amazon-network-flow-monitor
+SUGGESTED_NFM_AGENT_PUBLISH_ROLE=CloudWatchNetworkFlowMonitorAgentPublishRole
+
+NAMESPACE=${NAMESPACE:-$DEFAULT_NAMESPACE}
+NFM_AGENT_PUBLISH_ROLE=${NFM_AGENT_PUBLISH_ROLE:-$SUGGESTED_NFM_AGENT_PUBLISH_ROLE}
+
+if [ -z $CLUSTER_NAME ]; then
+    echo "CLUSTER_NAME not defined. Aborting."
+    exit 1
+fi
+
+if [ -z $REGION ]; then
+    echo "REGION not defined. Aborting."
+    exit 1
+fi
+
+function install-irsa() {
+    echo "Installing IRSA with ${NFM_AGENT_PUBLISH_ROLE} IAM Role."
+    eksctl create iamserviceaccount --cluster $CLUSTER_NAME --name $NFM_SERVICE_ACCOUNT --region $REGION \
+        --namespace $NAMESPACE --role-name $NFM_AGENT_PUBLISH_ROLE --attach-policy-arn $NFM_AGENT_PUBLISH_MANAGED_POLICY \
+        --override-existing-serviceaccounts --approve
+}
+
+function uninstall-irsa() {
+    echo "Uninstalling IRSA with ${NFM_AGENT_PUBLISH_ROLE} IAM Role."
+    eksctl delete iamserviceaccount --cluster $CLUSTER_NAME --name $NFM_SERVICE_ACCOUNT --region $REGION \
+        --namespace $NAMESPACE 
+}
+
+
+if [ $UNINSTALL ]; then
+  uninstall-irsa
+else
+  install-irsa
+fi

--- a/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
+++ b/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
@@ -55,6 +55,9 @@ spec:
         kubernetes.io/os: linux
       terminationGracePeriodSeconds: 5
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -1,6 +1,6 @@
 image:
   override: '' # if defined, this value is used as the canonical image name ("{image_repo}{image_name}:{tag}")
-  tag: v1.0.1-eksbuild.2  # this is the default image tag. It might be overwritten at runtime
+  tag: v1.0.2-eksbuild.1  # this is the default image tag. It might be overwritten at runtime
   containerRegistry: '' # this gets overriden at runtime with the correct Docker Image Registry
   name: aws-network-sonar-agent  # DO NOT try to override this
 
@@ -19,10 +19,13 @@ daemonSet:
 # Common labels to add to all network-flow-monitor-agent resources. Evaluated as a template.
 additionalLabels: {}
 
-# Useful parameters that provide additional flexibility
+# Useful parameters that provide flexibility to customers
 podLabels: {}
 podAnnotations: {}
 tolerations: []
+
+# allow user to change the internal addon name labels
+nameOverride: ""
 
 env:
   NFM_AGENT_LOG_LEVEL: INFO
@@ -51,3 +54,5 @@ affinity:
           operator: In
           values:
             - amd64
+
+priorityClassName: ""


### PR DESCRIPTION
*Description of changes:*
- This code change updates Helm Charts to consume 'v1.0.2-eksbuild.1' Docker image tag hosted in NFM Prod ECR (602401143452.dkr.ecr.us-west-2.amazonaws.com)
- Add new make targets present in ./charts/amazon-network-flow-monitor-agent/Makefile:
   - eksctl/install/irsa: Configures IRSA automatically;
   - eksctl/uninstall/irsa: Removes already configured IRSA;
   - kubectl/daemonset/restart: Forces a new DaemonSet deployment for Pods to acquire permissions created by configured IRSA;

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
