### PR TITLE
Add HTTPS proxy configuration support.

### DIFF
--- a/nfm-controller/src/lib.rs
+++ b/nfm-controller/src/lib.rs
@@ -100,7 +100,7 @@ pub struct Options {
     #[clap(short = 'r', long, default_value = "")]
     endpoint_region: String,
 
-    /// Proxy endpoint for all HTTPS traffic
+    /// Proxy endpoint for published reports
     #[clap(short = 'x', long, default_value = "")]
     proxy: String,
 

--- a/nfm-controller/src/lib.rs
+++ b/nfm-controller/src/lib.rs
@@ -100,9 +100,9 @@ pub struct Options {
     #[clap(short = 'r', long, default_value = "")]
     endpoint_region: String,
 
-    /// HTTPS proxy endpoint
+    /// Proxy endpoint for all HTTPS traffic
     #[clap(short = 'x', long, default_value = "")]
-    https_proxy: String,
+    proxy: String,
 
     /// Enable log reports
     #[clap(short = 'l', long, default_value_t = OnOff::Off)]
@@ -441,7 +441,7 @@ mod test {
                     endpoint: "a".to_string(),
                     endpoint_region: "b".to_string(),
                     cgroup: "c".to_string(),
-                    https_proxy: "d".to_string(),
+                    proxy: "d".to_string(),
                     top_k: 100,
                     notrack_secs: 0,
                     usage_data: OnOff::On,

--- a/nfm-controller/src/lib.rs
+++ b/nfm-controller/src/lib.rs
@@ -100,6 +100,10 @@ pub struct Options {
     #[clap(short = 'r', long, default_value = "")]
     endpoint_region: String,
 
+    /// HTTPS proxy endpoint
+    #[clap(short = 'x', long, default_value = "")]
+    https_proxy: String,
+
     /// Enable log reports
     #[clap(short = 'l', long, default_value_t = OnOff::Off)]
     log_reports: OnOff,
@@ -437,6 +441,7 @@ mod test {
                     endpoint: "a".to_string(),
                     endpoint_region: "b".to_string(),
                     cgroup: "c".to_string(),
+                    https_proxy: "d".to_string(),
                     top_k: 100,
                     notrack_secs: 0,
                     usage_data: OnOff::On,

--- a/nfm-controller/src/reports/publisher.rs
+++ b/nfm-controller/src/reports/publisher.rs
@@ -67,7 +67,7 @@ impl MultiPublisher {
                 get_credentials_provider(),
                 RealTimeClock {},
                 opt.report_compression,
-                opt.https_proxy.clone(),
+                opt.proxy.clone(),
             )));
         };
         publisher_builder.build()
@@ -197,7 +197,7 @@ mod tests {
             endpoint: "a".to_string(),
             endpoint_region: "b".to_string(),
             cgroup: "c".to_string(),
-            https_proxy: "d".to_string(),
+            proxy: "d".to_string(),
             top_k: 100,
             notrack_secs: 0,
             usage_data: OnOff::Off,

--- a/nfm-controller/src/reports/publisher.rs
+++ b/nfm-controller/src/reports/publisher.rs
@@ -67,6 +67,7 @@ impl MultiPublisher {
                 get_credentials_provider(),
                 RealTimeClock {},
                 opt.report_compression,
+                opt.https_proxy.clone(),
             )));
         };
         publisher_builder.build()
@@ -196,6 +197,7 @@ mod tests {
             endpoint: "a".to_string(),
             endpoint_region: "b".to_string(),
             cgroup: "c".to_string(),
+            https_proxy: "d".to_string(),
             top_k: 100,
             notrack_secs: 0,
             usage_data: OnOff::Off,

--- a/nfm-controller/src/reports/publisher_endpoint.rs
+++ b/nfm-controller/src/reports/publisher_endpoint.rs
@@ -408,13 +408,12 @@ mod tests {
 
         // Test empty proxy string
         assert!(matches!(
-            ReportPublisherOTLP::new(
+            ReportPublisherOTLP::new_without_proxy(
                 "http://localhost".to_string(),
                 "us-west-1".to_string(),
                 provider.clone(),
                 mock_clock.clone(),
                 ReportCompression::None,
-                "".to_string(),
             ),
             ReportPublisherOTLP { .. }
         ));

--- a/nfm-controller/src/reports/publisher_endpoint.rs
+++ b/nfm-controller/src/reports/publisher_endpoint.rs
@@ -65,7 +65,7 @@ where
         let mut builder = Client::builder().use_rustls_tls();
 
         if !proxy.is_empty() {
-            let proxy_instance = Proxy::https(&proxy).expect("Invalid proxy URL provided");
+            let proxy_instance = Proxy::all(&proxy).expect("Invalid proxy URL provided");
             builder = builder.proxy(proxy_instance);
         }
 


### PR DESCRIPTION
Add HTTPS proxy configuration support.

*Issue #, if available:*

*Description of changes:*

Adds ability to configure HTTPS proxy for telemetry data submission via new -x/--https-proxy CLI option. The proxy setting is applied to the OTLP report publisher's HTTP client if a valid proxy URL is provided.

**Testing**
Tested agent telemetry submission through local HTTP proxy (port 9000) to mock OTLP endpoint (127.0.0.1:8000/publish). Confirmed successful data flow using

```
$ sudo ./target/release/network-flow-monitor-agent --cgroup /mnt/cgroup2 --endpoint-region us-west-2 --endpoint https://localhost:8000/publish --proxy  http://127.0.0.1:9000

...
{"level":"INFO","message":"Proxy configured: http://127.0.0.1:9000","target":"nfm_agent::reports::publisher_endpoint","timestamp":1740527595690}

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
