### PR TITLE
AWS Network Flow Monitor Kubernetes Helm Charts 'v1.0.2-eksbuild.2' Release

### DIFF
--- a/charts/amazon-network-flow-monitor-agent/Chart.yaml
+++ b/charts/amazon-network-flow-monitor-agent/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This version needs to increase every time the chart and its templates
 # change. This should follow SemVer.
-version: 1.0.1
+version: 1.0.2
 
 # Keep this in sync with Amazon CloudWatch Network Flow Monitor Agent package version
 # used when building the its Docker image

--- a/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
+++ b/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
@@ -16,7 +16,7 @@ VALUES_FILENAME=values.yaml
 PROD_CONTAINER_REGISTRY="602401143452.dkr.ecr.us-west-2.amazonaws.com"
 export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-$PROD_CONTAINER_REGISTRY}
 
-export LATEST_KNOWN_IMAGE_TAG="v1.0.2-eksbuild.1"
+export LATEST_KNOWN_IMAGE_TAG="v1.0.2-eksbuild.2"
 export IMAGE_TAG=${IMAGE_TAG:-$LATEST_KNOWN_IMAGE_TAG}
 
 # Will install 'Amazon CloudWatch Network Flow Monitor Agent' Manifest Files to an existing K8s Cluster

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -1,6 +1,6 @@
 image:
   override: '' # if defined, this value is used as the canonical image name ("{image_repo}{image_name}:{tag}")
-  tag: v1.0.2-eksbuild.1  # this is the default image tag. It might be overwritten at runtime
+  tag: v1.0.2-eksbuild.2  # this is the default image tag. It might be overwritten at runtime
   containerRegistry: '' # this gets overriden at runtime with the correct Docker Image Registry
   name: aws-network-sonar-agent  # DO NOT try to override this
 

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -54,5 +54,6 @@ affinity:
           operator: In
           values:
             - amd64
+            - arm64
 
 priorityClassName: ""


### PR DESCRIPTION
**DO NOT MERGE YET!**: Docker Images hasn't yet been replicated to prod ECR repositories. Only merged after replication is confirmed;

*Description of changes:*
- HelmCharts and Docker Images available for ARM64 based Kubernetes nodes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
