### PR TITLE
Remove `publish = false` from Cargo.toml files to allow publishing to…

### DIFF
--- a/nfm-common/Cargo.toml
+++ b/nfm-common/Cargo.toml
@@ -2,7 +2,6 @@
 name = "nfm-common"
 version = "0.1.0"
 edition = "2021"
-publish = false
 
 [dependencies]
 aya = { version = "0.13", optional = true }

--- a/nfm-common/Cargo.toml
+++ b/nfm-common/Cargo.toml
@@ -2,6 +2,8 @@
 name = "nfm-common"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/aws/network-flow-monitor-agent"
 
 [dependencies]
 aya = { version = "0.13", optional = true }

--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -4,6 +4,8 @@ description = "network-flow-monitor-agent collects networking performance statis
 version = "0.1.3"
 edition = "2021"
 build = "build.rs"
+license = "Apache-2.0"
+repository = "https://github.com/aws/network-flow-monitor-agent"
 
 [[bin]]
 # The controller and BPF packages join forces into a single 'network-flow-monitor-agent' executable.
@@ -27,7 +29,7 @@ overflow-checks = true
 aws-config = { version = "1.5", features = [ "rustls" ] }
 aws-credential-types = "1.2"
 aws-sign-v4 = "0.3"
-nfm-common = { path = "../nfm-common", features = ["user"] }
+nfm-common = { version = "0.1.0", path = "../nfm-common", features = ["user"] }
 
 anyhow = "1"
 assert_approx_eq = "1"

--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -3,7 +3,6 @@ name = "nfm-controller"
 description = "network-flow-monitor-agent collects networking performance statistics from the local machine"
 version = "0.1.3"
 edition = "2021"
-publish = false
 build = "build.rs"
 
 [[bin]]
@@ -79,4 +78,4 @@ url = "2.5"
 [build-dependencies]
 cargo_metadata = "0.19"
 shadow-rs = "0.36"
-which = { version = "6.0.0", default-features = false } 
+which = { version = "6.0.0", default-features = false }


### PR DESCRIPTION
Remove `publish = false` from Cargo.toml files to allow publishing to to crates.io



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
