### PR TITLE
Fix clippy warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
+  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
   validate:

--- a/nfm-controller/build.rs
+++ b/nfm-controller/build.rs
@@ -17,7 +17,7 @@ fn main() -> shadow_rs::SdResult<()> {
 
 fn set_up_toolchain() {
     Command::new("rustup")
-        .args(&["component", "add", "rust-src"])
+        .args(["component", "add", "rust-src"])
         .status()
         .expect("Failed to add rust-src");
 
@@ -27,7 +27,7 @@ fn set_up_toolchain() {
         .is_err()
     {
         Command::new("cargo")
-            .args(&["install", "bpf-linker"])
+            .args(["install", "bpf-linker"])
             .status()
             .expect("Failed to install bpf-linker");
     }
@@ -48,7 +48,7 @@ fn build_ebpf(release: bool) {
         .expect("Failed to get BPF target triple");
 
     let bpf_obj_path = target_dir
-        .join(&target_triple)
+        .join(target_triple)
         .join(if release { "release" } else { "debug" })
         .join("nfm-bpf");
     println!(


### PR DESCRIPTION
*Description of changes:*
Fixed `clippy` warnings that are blocking the `CI` Github action configured.
Also added a new github action to trigger the CI workflow manually.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
