### PR TITLE
Add an integration test suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   validate:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -41,3 +41,13 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Check environment
+        run: |
+          cat /etc/os-release
+          ldd --version
+      - name: Build release binary
+        run: cargo build --release
+      - name: Run integration tests
+        run: |
+          docker build -t integration-test -f test-data/Dockerfile.test .
+          docker run --privileged -t integration-test

--- a/README.md
+++ b/README.md
@@ -45,13 +45,23 @@ To run the application with statistics printed to stdout, use the following
 command.  Run this as root or with the `CAP_BPF` capability.
 
 ```bash
-target/release/network-flow-monitor-agent --cgroup /mnt/cgroup-nfm --publish-reports off --log-reports on
+target/release/network-flow-monitor-agent --cgroup /mnt/cgroup-nfm \
+   --publish-reports off --log-reports on
 ```
 
-To see the available command-line options, run:
+### Testing
+
+Run GitHub actions locally using the [act](https://nektosact.com/) CLI:
 
 ```bash
-target/release/network-flow-monitor-agent --help
+act workflow_dispatch --privileged
+```
+
+Run only integration tests by building and running the test suite's docker container:
+
+```bash
+docker build -t integration-tests -f test-data/Dockerfile.test .
+docker run --privileged -t integration-tests
 ```
 
 ## License

--- a/test-data/Dockerfile.test
+++ b/test-data/Dockerfile.test
@@ -1,0 +1,18 @@
+FROM ubuntu:24.04
+
+# Print env details to aid in diagnostics.
+RUN cat /etc/os-release && ldd --version
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY target/release/network-flow-monitor-agent /usr/local/bin/
+COPY test-data/integration-* /test-context/
+
+RUN chmod +x /test-context/integration-*
+
+# Set the entrypoint with unbuffered output.
+ENV PYTHONUNBUFFERED=1
+ENTRYPOINT ["/test-context/integration-entrypoint"]

--- a/test-data/integration-entrypoint
+++ b/test-data/integration-entrypoint
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+clean_up() {
+    kill $MONITOR_PID
+}
+trap clean_up EXIT
+
+# Set up the cgroup.
+mkdir -p /mnt/cgroup-nfm
+if ! grep -qs '/mnt/cgroup-nfm cgroup2' /proc/mounts; then
+    mount -t cgroup2 none /mnt/cgroup-nfm
+fi
+
+# Start the agent in the background.
+rm -f /test-context/agent.log
+network-flow-monitor-agent --cgroup /mnt/cgroup-nfm --publish-reports off \
+    --log-reports on --publish-secs 5 > /test-context/agent.log &
+MONITOR_PID=$!
+
+# Run all tests in the test suite.
+for test_script in `ls /test-context/integration-test*`; do
+    $test_script
+done

--- a/test-data/integration-test-01
+++ b/test-data/integration-test-01
@@ -1,0 +1,146 @@
+#!/usr/bin/python3
+
+import http.client
+import http.server
+import json
+from queue import Queue, Empty
+import socketserver
+import threading
+import time
+
+def start_http_server():
+    # Define a simple 200-OK HTTP server.
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'Hello from test server!')
+            
+        def log_message(self, format, *args):
+            # Suppress logging.
+            pass
+
+    # Run in a thread.
+    server = socketserver.TCPServer(('localhost', 8080), Handler)
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.daemon = True
+    server_thread.start()
+    return server
+
+def send_http_request():
+    print('Sending test HTTP request...', end='')
+
+    try:
+        # Use a new TCP connection for each HTTP request.
+        conn = http.client.HTTPConnection('localhost', 8080)
+        conn.request('GET', '/')
+        response = conn.getresponse()
+        if response.status == 200:
+            print('succeeded')
+            return True
+        else:
+            print(f'failed: {response.status}')
+            return False
+    except Exception as e:
+        print(f'failed: {e}')
+        return False
+    finally:
+        conn.close()
+
+class LogReader:
+    def __init__(self, file_path):
+        self.queue = Queue()
+        self.reader_thread = threading.Thread(
+            target=self._read_log,
+            args=(file_path, self.queue)
+        )
+        self.reader_thread.daemon = True
+        self.reader_thread.start()
+
+    def _read_log(self, file_path, queue):
+        with open(file_path, 'r') as f:
+            while True:
+                line = f.readline()
+                if line:
+                    queue.put(line)
+                else:
+                    time.sleep(0.1)
+
+    # Reads log lines until validator_fn returns True or the timeout has elapsed.
+    def read_until(self, validator_fn, timeout_secs):
+        start_time = time.time()
+        while True:
+            try:
+                line = self.queue.get(timeout=0.1)
+                try:
+                    data = json.loads(line)
+                    if validator_fn(data):
+                        print('succeeded')
+                        return True
+                except json.JSONDecodeError as e:
+                    print('failed')
+                    print(f'Invalid JSON in log: {line.strip()}')
+                    return False
+            except Empty:
+                pass
+
+            if time.time() - start_time > timeout_secs:
+                print('failed')
+                print(f'Timed out after {timeout_secs} sec')
+                return False
+
+def await_agent_readiness(file_path, timeout_secs):
+    def validator(data):
+        if data['message'] == 'Aggregating across sockets':
+            return True
+        return False
+
+    print('Awaiting agent readiness....', end='')
+    reader = LogReader(file_path)
+    return reader.read_until(validator, timeout_secs)
+
+def count_logged_connections(file_path, expected_count, timeout_secs):
+    counts = {'client': 0, 'server': 0}
+
+    def validator(data):
+        if data['message'] != 'Publishing report':
+            return False
+
+        for net_stat in data['report']['network_stats']:
+            if net_stat['flow']['local_address'] == '127.0.0.1':
+                new_count = net_stat['stats']['sockets_completed']
+                if net_stat['flow']['remote_port'] == 8080:
+                    counts['client'] += new_count
+                elif net_stat['flow']['local_port'] == 8080:
+                    counts['server'] += new_count
+
+        if counts['client'] == expected_count and counts['server'] == expected_count:
+            return True 
+        return False
+
+    print('Awaiting agent results......', end='')
+    reader = LogReader(file_path)
+    success = reader.read_until(validator, timeout_secs)
+    if success:
+        print('[SUCCESS] The agent reported all TCP connections from both client and server')
+
+    return success
+
+def main():
+    if not await_agent_readiness(file_path='/test-context/agent.log', timeout_secs=5):
+        exit(1)
+
+    # Start an HTTP server and send a few requests.
+    server = start_http_server()
+    for _ in range(3):
+        if not send_http_request():
+            exit(1)
+    server.shutdown()
+    
+    # Validate the results.
+    success = count_logged_connections(file_path='/test-context/agent.log', expected_count=3, timeout_secs=15)
+    exit(0 if success else 1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Add an integration test suite

This changes adds the first set of integration tests for the NFM agent.  A Dockerfile is introduced to define an integ test container image.  Within that container all scripts are invoked that match the path `test-data/integration-test*`.  The first of those tests included in this change performs a few HTTP requests between client and server within the local host, and validates the NFM agent reports the appropriate stats.

### Testing

1. Built and ran the test suite in a docker container via:
```bash
docker run --privileged -t integration-test
docker run --privileged -it --entrypoint /bin/bash integration-test
```

2. Ran the full set of GitHub actions locally via `act workflow_dispatch --privileged` and saw success.  The relevant output is:

```text
[CI/Validate] ⭐ Run Main Run integration tests
[CI/Validate]   �  docker exec cmd=[bash -e /var/run/act/workflow/9] user= workdir=
[+] Building 1.6s (10/10) FINISHED                               docker:default
...
| Awaiting agent readiness....succeeded
| Sending test HTTP request...succeeded
| Sending test HTTP request...succeeded
| Sending test HTTP request...succeeded
| Awaiting agent results......succeeded
| [SUCCESS] The agent reported all TCP connections from both client and server
[CI/Validate]   ✅  Success - Main Run integration tests
```