### PR TITLE
Add Codecov coverage status badge to provide visibility into test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Network Flow Monitor Agent
 
 [![CI](https://github.com/aws/network-flow-monitor-agent/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aws/network-flow-monitor-agent/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/github/aws/network-flow-monitor-agent/graph/badge.svg?token=T4XUR6NZRM)](https://codecov.io/github/aws/network-flow-monitor-agent)
 
 This is an on-host agent that passively collects performance statistics related
 to various communication protocols of interest, beginning with TCP.  The

--- a/nfm-common/Cargo.toml
+++ b/nfm-common/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nfm-common"
+description = "network-flow-monitor-agent collects networking performance statistics from the local machine"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added Codecov coverage status badge to provide visibility into test coverage
- Add required description field to Cargo.toml to resolve crates.io publishing error
```
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error (status 400 Bad Request): missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
