### PR TITLE
Add packaging files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+out/
 target/
 **/Cargo.lock
 cobertura.xml

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,29 @@
+# Building Network Flow Monitor Agent Packages
+
+This directory contains the infrastructure to compile new Network Flow Monitor Agent release packages.
+
+## Building in Docker
+
+First, build the Docker image:
+```
+   docker build -t nfm-agent-builder -f packaging/linux/Dockerfile .
+```
+
+Now run the Docker container. It expects the root of this Git repository to be mounted at `/nfm` in the container, so fill in the `source` of the bind mount appropriately:
+```
+   docker run --rm --mount type=bind,source=/path/to/network-flow-monitor-agent-git-repo/,target=/nfm nfm-agent-builder x86_64
+```
+
+The container will create an `out` directory in the root of the Git repository containing the build artifacts.
+```
+$ ls out/*.rpm
+out/network-flow-monitor-agent.rpm
+```
+
+## Building locally
+
+Run the RPM build script:
+```
+    ./packaging/linux/create_rpm.sh x86_64
+```
+The script will create an `out` directory in the root of the Git repository containing the build artifacts.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -11,7 +11,7 @@ First, build the Docker image:
 
 Now run the Docker container. It expects the root of this Git repository to be mounted at `/nfm` in the container, so fill in the `source` of the bind mount appropriately:
 ```
-   docker run --rm --mount type=bind,source=/path/to/network-flow-monitor-agent-git-repo/,target=/nfm nfm-agent-builder x86_64
+   docker run --rm --mount type=bind,source=/path/to/network-flow-monitor-agent-git-repo/,target=/nfm nfm-agent-builder
 ```
 
 The container will create an `out` directory in the root of the Git repository containing the build artifacts.
@@ -24,6 +24,6 @@ out/network-flow-monitor-agent.rpm
 
 Run the RPM build script:
 ```
-    ./packaging/linux/create_rpm.sh x86_64
+    ./packaging/linux/create_rpm.sh
 ```
 The script will create an `out` directory in the root of the Git repository containing the build artifacts.

--- a/packaging/linux/Dockerfile
+++ b/packaging/linux/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+# Install development tools and gcc
+RUN dnf groupinstall -y "Development Tools" \
+    && dnf install -y gcc \
+    && dnf clean all
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="~/.cargo/bin:${PATH}"
+
+WORKDIR /nfm
+
+ENTRYPOINT ["/nfm/packaging/linux/create_rpm.sh"]

--- a/packaging/linux/amazon-nfm-agent.spec
+++ b/packaging/linux/amazon-nfm-agent.spec
@@ -1,0 +1,120 @@
+Name:       amazon-nfm-agent
+Summary:    Network Flow Monitor Agent
+Release:    %release
+Version:    0.1
+Requires:   bash
+
+Group:      Amazon/Tools
+License:    Apache License, Version 2.0
+URL:        https://github.com/aws/network-flow-monitor-agent
+
+Packager:   Amazon.com, Inc. <http://aws.amazon.com>
+Vendor:     Amazon.com
+
+# Define Macros
+%define _build_id_links none
+%define PKG_ROOT_DIR /opt/aws/network-flow-monitor
+%define NEFMO_CGROUP_DIR /mnt/cgroupnefmon
+%define PACKAGES_LEFT "$1"
+%define PACKAGE_COMMAND "$1"
+%define MIN_KERNEL_VERSION 5.8
+%define AGENT_LOG_DESCRIPTION "Network Flow Monitor Agent %{release}"
+
+%define NEFMON_USER networkflowmonitor
+%define NEFMON_GROUP networkflowmonitor-group
+
+%description
+Installs NetworkFlowMonitorAgent
+
+#### Pre-install scripts
+%pre
+set -o errexit # Exit if a command fails
+set -o nounset # Exit if an undefined variable is used
+set -o pipefail # Exit if a command in a pipeline fails
+
+HOST_KERNEL_VERSION=$(uname -r | cut -d. -f1,2)
+
+# Check kernel version
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+if [ $(version $HOST_KERNEL_VERSION) -lt $(version %MIN_KERNEL_VERSION) ]; then
+    echo "Error: This package requires Linux kernel" %MIN_KERNEL_VERSION "or later. Found $HOST_KERNEL_VERSION"
+    exit 1
+fi
+
+# Existing pre-install scripts...
+getent group %{NEFMON_GROUP} >/dev/null || groupadd -r %{NEFMON_GROUP}
+getent passwd %{NEFMON_USER} >/dev/null || useradd -r -g %{NEFMON_GROUP} -d %{PKG_ROOT_DIR} -s /sbin/nologin %{NEFMON_USER}
+
+getent group %{NEFMON_GROUP} >/dev/null || groupadd -r %{NEFMON_GROUP}
+getent passwd %{NEFMON_USER} >/dev/null || useradd -r -g %{NEFMON_GROUP} -d %{PKG_ROOT_DIR} -s /sbin/nologin %{NEFMON_USER}
+
+#### Install scripts
+%install
+mkdir -p %{buildroot}%{PKG_ROOT_DIR}
+mkdir -p %{_topdir}/RPMS
+mkdir -p %{_topdir}/BUILD
+mkdir -p %{buildroot}/usr/lib/systemd/system
+mkdir %{buildroot}%{PKG_ROOT_DIR}/etc
+cp %{_sourcedir}/packaging/linux/network-flow-monitor.ini %{buildroot}%{PKG_ROOT_DIR}/etc/
+cp %{_sourcedir}/packaging/linux/network-flow-monitor.service %{buildroot}/usr/lib/systemd/system/
+cp %{_sourcedir}/packaging/linux/network-flow-monitor-start %{buildroot}%{PKG_ROOT_DIR}/
+cp %{_sourcedir}/NOTICE %{buildroot}%{PKG_ROOT_DIR}/
+cp %{_sourcedir}/LICENSE %{buildroot}%{PKG_ROOT_DIR}/
+cp %{_sourcedir}/target/release/network-flow-monitor-agent %{buildroot}%{PKG_ROOT_DIR}/network-flow-monitor-agent
+
+
+#### Post-install scripts
+%post
+%systemd_post network-flow-monitor.service
+
+## Capabilities
+# Giving the agent capabilities so that we can perform e/BPF actions
+setcap cap_sys_admin,cap_bpf=eip %{PKG_ROOT_DIR}/network-flow-monitor-agent
+
+# Only create mount points on install or if the mountpoint doesn't exists
+if [ %PACKAGES_LEFT = 1 ] || ! mountpoint -q %{NEFMO_CGROUP_DIR}; then
+    echo "creating cgroupv2 mount point"
+    ## CGROUP
+    mkdir -p %{NEFMO_CGROUP_DIR}
+    chown %{NEFMON_USER}:%{NEFMON_GROUP} %{NEFMO_CGROUP_DIR}
+    mount -t cgroup2 networkflowmonitor-cgroup %{NEFMO_CGROUP_DIR}
+    echo "networkflowmonitor-cgroup %{NEFMO_CGROUP_DIR} cgroup2 defaults 0 0" >> /etc/fstab
+fi
+
+## Service start + enable on startup
+systemctl start network-flow-monitor.service
+systemctl enable network-flow-monitor.service
+
+echo "%{AGENT_LOG_DESCRIPTION} installed successfully."
+
+### Pre-Uninstall Scripts
+%preun
+%systemd_preun network-flow-monitor.service
+
+# Only remove mount points on uninstall
+if [ %PACKAGES_LEFT = 0 ] || [ %PACKAGE_COMMAND = "remove" ]; then
+    echo "removing cgroupv2 mount point"
+    ## CGROUP
+    if mountpoint -q %{NEFMO_CGROUP_DIR}; then
+        umount %{NEFMO_CGROUP_DIR}
+        sed -i.bak "\@^networkflowmonitor-cgroup@d" /etc/fstab
+    fi
+    rm -rf %{NEFMO_CGROUP_DIR}
+fi
+echo "%{AGENT_LOG_DESCRIPTION} uninstalled successfully."
+
+
+### Post-Uninstall Scripts
+%postun
+if [ %PACKAGES_LEFT = 0 ] || [ %PACKAGE_COMMAND = "remove" ]; then
+    userdel %{NEFMON_USER}
+    groupdel %{NEFMON_GROUP}
+fi
+
+%files
+%defattr(-,%{NEFMON_USER},%{NEFMON_GROUP})
+%{PKG_ROOT_DIR}/
+/usr/lib/systemd/system/network-flow-monitor.service
+
+%clean
+# rpmbuild deletes $buildroot after building, specifying clean section to make sure it is not deleted

--- a/packaging/linux/create_rpm.sh
+++ b/packaging/linux/create_rpm.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+
+FOLDER=$1
+
+if [ -z "$FOLDER" ]
+ then
+   echo "Folder name must be provided"
+   exit 1
+fi
+
+if [[ "$FOLDER" == *amd64 ]]; then
+ TARGET=x86_64
+elif [[ "$FOLDER" == *arm64 ]]; then
+ TARGET=aarch64
+else
+ echo "Unsupported architecture"
+ exit 1
+fi
+
+cargo build --release
+
+echo "************************************************************"
+echo "Creating $FOLDER rpm file for Amazon Linux $TARGET"
+echo "************************************************************"
+
+OUT_DIR=$(pwd)/out
+rm -rf "${OUT_DIR}/bin/$FOLDER/linux"
+
+echo "Creating the rpm package $FOLDER"
+
+SPEC_FILE="packaging/linux/amazon-nfm-agent.spec"
+BUILD_ROOT="${OUT_DIR}/bin/$FOLDER/linux"
+
+# Ensure build root exists
+mkdir -p "${BUILD_ROOT}"
+
+rpmbuild -bb \
+         --target $TARGET \
+         --define "release 3" \
+         --define "_topdir ${OUT_DIR}/bin/$FOLDER/linux/rpmbuild" \
+         --define "_sourcedir $(pwd)" \
+         --buildroot "${BUILD_ROOT}" \
+         "${SPEC_FILE}"
+cp ${OUT_DIR}/bin/$FOLDER/linux/rpmbuild/RPMS/$TARGET/*.rpm ${OUT_DIR}/bin/$FOLDER/amazon-nfm-agent.rpm
+rm -rf ${OUT_DIR}/bin/$FOLDER/linux/rpmbuild/RPMS/$TARGET/*

--- a/packaging/linux/create_rpm.sh
+++ b/packaging/linux/create_rpm.sh
@@ -6,7 +6,7 @@ set -o pipefail
 set -o xtrace
 
 
-TARGET_ARCH=$1
+TARGET_ARCH=`uname -p`
 
 if [ -z "$TARGET_ARCH" ]
  then

--- a/packaging/linux/create_rpm.sh
+++ b/packaging/linux/create_rpm.sh
@@ -29,7 +29,7 @@ rm -rf "${OUT_DIR}/bin/$FOLDER/linux"
 
 echo "Creating the rpm package $FOLDER"
 
-SPEC_FILE="packaging/linux/amazon-nfm-agent.spec"
+SPEC_FILE="packaging/linux/network-flow-monitor-agent.spec"
 BUILD_ROOT="${OUT_DIR}/bin/$FOLDER/linux"
 
 # Ensure build root exists
@@ -42,5 +42,5 @@ rpmbuild -bb \
          --define "_sourcedir $(pwd)" \
          --buildroot "${BUILD_ROOT}" \
          "${SPEC_FILE}"
-cp ${OUT_DIR}/bin/$FOLDER/linux/rpmbuild/RPMS/$TARGET/*.rpm ${OUT_DIR}/bin/$FOLDER/amazon-nfm-agent.rpm
+cp ${OUT_DIR}/bin/$FOLDER/linux/rpmbuild/RPMS/$TARGET/*.rpm ${OUT_DIR}/bin/$FOLDER/network-flow-monitor-agent.rpm
 rm -rf ${OUT_DIR}/bin/$FOLDER/linux/rpmbuild/RPMS/$TARGET/*

--- a/packaging/linux/create_rpm.sh
+++ b/packaging/linux/create_rpm.sh
@@ -1,46 +1,47 @@
 #!/usr/bin/env bash
-set -e
 
-FOLDER=$1
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
 
-if [ -z "$FOLDER" ]
+
+TARGET_ARCH=$1
+
+if [ -z "$TARGET_ARCH" ]
  then
-   echo "Folder name must be provided"
+   echo "Architecture name must be provided"
    exit 1
 fi
 
-if [[ "$FOLDER" == *amd64 ]]; then
- TARGET=x86_64
-elif [[ "$FOLDER" == *arm64 ]]; then
- TARGET=aarch64
-else
- echo "Unsupported architecture"
- exit 1
+if [[ "$TARGET_ARCH" != "x86_64" && "$TARGET_ARCH" != "aarch64" ]]; then
+    echo "Unsupported architecture: $TARGET_ARCH"
+    exit 1
 fi
 
 cargo build --release
 
-echo "************************************************************"
-echo "Creating $FOLDER rpm file for Amazon Linux $TARGET"
-echo "************************************************************"
+echo "***********************************************"
+echo "Creating $TARGET_ARCH rpm file for Amazon Linux"
+echo "***********************************************"
 
 OUT_DIR=$(pwd)/out
-rm -rf "${OUT_DIR}/bin/$FOLDER/linux"
+rm -rf "${OUT_DIR}/bin/linux"
 
-echo "Creating the rpm package $FOLDER"
+echo "Creating the rpm package $TARGET_ARCH"
 
 SPEC_FILE="packaging/linux/network-flow-monitor-agent.spec"
-BUILD_ROOT="${OUT_DIR}/bin/$FOLDER/linux"
+BUILD_ROOT="${OUT_DIR}/bin/linux"
 
 # Ensure build root exists
 mkdir -p "${BUILD_ROOT}"
 
 rpmbuild -bb \
-         --target $TARGET \
-         --define "release 3" \
-         --define "_topdir ${OUT_DIR}/bin/$FOLDER/linux/rpmbuild" \
+         --target $TARGET_ARCH \
+         --define "AGENT_VERSION 0.1.3" \
+         --define "_topdir ${OUT_DIR}/bin/linux/rpmbuild" \
          --define "_sourcedir $(pwd)" \
          --buildroot "${BUILD_ROOT}" \
          "${SPEC_FILE}"
-cp ${OUT_DIR}/bin/$FOLDER/linux/rpmbuild/RPMS/$TARGET/*.rpm ${OUT_DIR}/bin/$FOLDER/network-flow-monitor-agent.rpm
-rm -rf ${OUT_DIR}/bin/$FOLDER/linux/rpmbuild/RPMS/$TARGET/*
+cp ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*.rpm ${OUT_DIR}/network-flow-monitor-agent.rpm
+rm -rf ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*

--- a/packaging/linux/network-flow-monitor-agent.spec
+++ b/packaging/linux/network-flow-monitor-agent.spec
@@ -1,36 +1,37 @@
 Name:       network-flow-monitor-agent
 Summary:    Network Flow Monitor Agent
-Release:    %release
-Version:    0.1
+Release:    1
+Version:    %AGENT_VERSION
 Requires:   bash
 
 Group:      Amazon/Tools
 License:    Apache License, Version 2.0
 URL:        https://github.com/aws/network-flow-monitor-agent
 
-Packager:   Amazon.com, Inc. <http://aws.amazon.com>
-Vendor:     Amazon.com
+Packager:   Amazon Web Services, Inc. <http://aws.amazon.com>
+Vendor:     Amazon Web Services, Inc
 
 # Define Macros
 %define _build_id_links none
 %define PKG_ROOT_DIR /opt/aws/network-flow-monitor
-%define NEFMO_CGROUP_DIR /mnt/cgroupnefmon
+%define NFM_CGROUP_DIR /mnt/cgroup-nfm
 %define PACKAGES_LEFT "$1"
 %define PACKAGE_COMMAND "$1"
 %define MIN_KERNEL_VERSION 5.8
-%define AGENT_LOG_DESCRIPTION "Network Flow Monitor Agent %{release}"
+%define AGENT_LOG_DESCRIPTION "Network Flow Monitor Agent %{AGENT_VERSION}"
 
-%define NEFMON_USER networkflowmonitor
-%define NEFMON_GROUP networkflowmonitor-group
+%define NFM_USER networkflowmonitor
+%define NFM_GROUP networkflowmonitor-group
 
 %description
-Installs NetworkFlowMonitorAgent
+Installs Network Flow Monitor Agent
 
 #### Pre-install scripts
 %pre
-set -o errexit # Exit if a command fails
-set -o nounset # Exit if an undefined variable is used
-set -o pipefail # Exit if a command in a pipeline fails
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
 
 HOST_KERNEL_VERSION=$(uname -r | cut -d. -f1,2)
 
@@ -42,11 +43,11 @@ if [ $(version $HOST_KERNEL_VERSION) -lt $(version %MIN_KERNEL_VERSION) ]; then
 fi
 
 # Existing pre-install scripts...
-getent group %{NEFMON_GROUP} >/dev/null || groupadd -r %{NEFMON_GROUP}
-getent passwd %{NEFMON_USER} >/dev/null || useradd -r -g %{NEFMON_GROUP} -d %{PKG_ROOT_DIR} -s /sbin/nologin %{NEFMON_USER}
+getent group %{NFM_GROUP} >/dev/null || groupadd -r %{NFM_GROUP}
+getent passwd %{NFM_USER} >/dev/null || useradd -r -g %{NFM_GROUP} -d %{PKG_ROOT_DIR} -s /sbin/nologin %{NFM_USER}
 
-getent group %{NEFMON_GROUP} >/dev/null || groupadd -r %{NEFMON_GROUP}
-getent passwd %{NEFMON_USER} >/dev/null || useradd -r -g %{NEFMON_GROUP} -d %{PKG_ROOT_DIR} -s /sbin/nologin %{NEFMON_USER}
+getent group %{NFM_GROUP} >/dev/null || groupadd -r %{NFM_GROUP}
+getent passwd %{NFM_USER} >/dev/null || useradd -r -g %{NFM_GROUP} -d %{PKG_ROOT_DIR} -s /sbin/nologin %{NFM_USER}
 
 #### Install scripts
 %install
@@ -72,13 +73,13 @@ cp %{_sourcedir}/target/release/network-flow-monitor-agent %{buildroot}%{PKG_ROO
 setcap cap_sys_admin,cap_bpf=eip %{PKG_ROOT_DIR}/network-flow-monitor-agent
 
 # Only create mount points on install or if the mountpoint doesn't exists
-if [ %PACKAGES_LEFT = 1 ] || ! mountpoint -q %{NEFMO_CGROUP_DIR}; then
+if [ %PACKAGES_LEFT = 1 ] || ! mountpoint -q %{NFM_CGROUP_DIR}; then
     echo "creating cgroupv2 mount point"
     ## CGROUP
-    mkdir -p %{NEFMO_CGROUP_DIR}
-    chown %{NEFMON_USER}:%{NEFMON_GROUP} %{NEFMO_CGROUP_DIR}
-    mount -t cgroup2 networkflowmonitor-cgroup %{NEFMO_CGROUP_DIR}
-    echo "networkflowmonitor-cgroup %{NEFMO_CGROUP_DIR} cgroup2 defaults 0 0" >> /etc/fstab
+    mkdir -p %{NFM_CGROUP_DIR}
+    chown %{NFM_USER}:%{NFM_GROUP} %{NFM_CGROUP_DIR}
+    mount -t cgroup2 networkflowmonitor-cgroup %{NFM_CGROUP_DIR}
+    echo "networkflowmonitor-cgroup %{NFM_CGROUP_DIR} cgroup2 defaults 0 0" >> /etc/fstab
 fi
 
 ## Service start + enable on startup
@@ -95,11 +96,11 @@ echo "%{AGENT_LOG_DESCRIPTION} installed successfully."
 if [ %PACKAGES_LEFT = 0 ] || [ %PACKAGE_COMMAND = "remove" ]; then
     echo "removing cgroupv2 mount point"
     ## CGROUP
-    if mountpoint -q %{NEFMO_CGROUP_DIR}; then
-        umount %{NEFMO_CGROUP_DIR}
+    if mountpoint -q %{NFM_CGROUP_DIR}; then
+        umount %{NFM_CGROUP_DIR}
         sed -i.bak "\@^networkflowmonitor-cgroup@d" /etc/fstab
     fi
-    rm -rf %{NEFMO_CGROUP_DIR}
+    rm -rf %{NFM_CGROUP_DIR}
 fi
 echo "%{AGENT_LOG_DESCRIPTION} uninstalled successfully."
 
@@ -107,12 +108,12 @@ echo "%{AGENT_LOG_DESCRIPTION} uninstalled successfully."
 ### Post-Uninstall Scripts
 %postun
 if [ %PACKAGES_LEFT = 0 ] || [ %PACKAGE_COMMAND = "remove" ]; then
-    userdel %{NEFMON_USER}
-    groupdel %{NEFMON_GROUP}
+    userdel %{NFM_USER}
+    groupdel %{NFM_GROUP}
 fi
 
 %files
-%defattr(-,%{NEFMON_USER},%{NEFMON_GROUP})
+%defattr(-,%{NFM_USER},%{NFM_GROUP})
 %{PKG_ROOT_DIR}/
 /usr/lib/systemd/system/network-flow-monitor.service
 

--- a/packaging/linux/network-flow-monitor-agent.spec
+++ b/packaging/linux/network-flow-monitor-agent.spec
@@ -1,4 +1,4 @@
-Name:       amazon-nfm-agent
+Name:       network-flow-monitor-agent
 Summary:    Network Flow Monitor Agent
 Release:    %release
 Version:    0.1

--- a/packaging/linux/network-flow-monitor-start
+++ b/packaging/linux/network-flow-monitor-start
@@ -13,10 +13,10 @@ function load_ini_section() {
     local ini_file=$1
     local section=$2
 
-    # Declare variables with defaults
-    cgroup="default"
-    endpoint="default"
-    region="default"
+    # Initialize with defaults
+    declare -g cgroup="default"
+    declare -g region="default"
+    declare -g endpoint="default"
 
     while IFS='=' read -r key value; do
         # Skip empty lines, comments, and section headers
@@ -29,8 +29,7 @@ function load_ini_section() {
         # Validate key name (only allow alphanumeric and underscore)
         [[ ! "$key" =~ ^[a-zA-Z0-9_]+$ ]] && continue
 
-        # Export the variable so it's available in the script scope
-        export "$key=$value"
+        declare -g "$key=$value"
     done < <(sed -n "/^\[$section\]/,/^\[/p" "$ini_file")
 }
 

--- a/packaging/linux/network-flow-monitor-start
+++ b/packaging/linux/network-flow-monitor-start
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace
+
+INI_FILE="/opt/aws/network-flow-monitor/etc/network-flow-monitor.ini"
+DEFAULT_CGROUP="/mnt/cgroupnefmon"
+
+# Function to read an ini file and print out key/value pairs
+function parse_ini_file() {
+    local ini_file=$1
+    local section=$2
+    eval "$(awk -F= -v section="$section" '
+        /^\[/{section=0}
+        /^\['"$section"'\]/{section=1; next}
+        section==1 && $1 !~ /^($|#|;)/ {
+            gsub(/^[ \t]+|[ \t]+$/, "", $1);
+            gsub(/^[ \t]+|[ \t]+$/, "", $2);
+            print $1"=\""$2"\""
+        }' "$ini_file")"
+}
+
+# Function to validate the cgroup. If default is provided, will check if cgroup for Network Flow Monitor is
+# available and mounted. If not will emit message and exit 1
+function parse_cgroup() {
+    local cgroup_dir="${1:-default}"
+
+    if [ "$cgroup_dir" = "default" ]; then
+        # Create and mount the default directory if needed.
+        cgroup_dir=$DEFAULT_CGROUP
+        if [ ! -d "$cgroup_dir" ]; then
+            echo "Directory: [$cgroup_dir] missing. Cannot start agent without it. Exiting"
+            exit 1
+        fi
+        if ! mountpoint -q "$cgroup_dir"; then
+            echo "cgroup isn't mounted. Mount it by running as root/sudo: [# mount -t cgroup2 networkflowmonitor-cgroup $cgroup_dir]"
+        fi
+    fi
+    echo $cgroup_dir
+}
+
+# Function to validate the region. If default is provided, the region is retrieved from IMDSv2.
+function parse_region() {
+    local region_input="${1:-default}"
+
+    if [ "$region_input" = "default" ]; then
+        # Retrieve region from IMDSv2
+        token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 300" "http://169.254.169.254/latest/api/token" 2> /dev/null)
+        region=$(curl -H "X-aws-ec2-metadata-token: $token" "http://169.254.169.254/latest/dynamic/instance-identity/document" 2> /dev/null | grep -oP '(?<="region" : ")[^"]*')
+        echo "$region"
+    else
+        echo "$region_input"
+    fi
+}
+
+# Function to generate the endpoint where the agent is going to publish. If the
+# endpoint configured is "default", this function will generate the appropriate
+# endpoint.
+function parse_endpoint() {
+    local endpoint_input="${1:-default}"
+    local region_input="$2"
+
+    if [ "$endpoint_input" = "default" ]; then
+        # Generate the endpoint using the region
+        endpoint="https://networkflowmonitorreports.$region_input.api.aws/publish"
+        echo "$endpoint"
+    else
+        echo "$endpoint_input"
+    fi
+}
+
+
+parse_ini_file "$INI_FILE" "config"
+CGROUP=$(parse_cgroup $cgroup)
+REGION=$(parse_region $region)
+ENDPOINT=$(parse_endpoint $endpoint $REGION)
+
+echo "Starting Network Flow Monitor Agent"
+echo "cgroup: ${CGROUP}"
+echo "endpoint: ${ENDPOINT}"
+echo "endpoint-region: ${REGION}"
+
+/opt/aws/network-flow-monitor/network-flow-monitor-agent --cgroup ${CGROUP} --endpoint ${ENDPOINT} --endpoint-region ${REGION}

--- a/packaging/linux/network-flow-monitor-start
+++ b/packaging/linux/network-flow-monitor-start
@@ -1,25 +1,37 @@
 #!/bin/bash
 
 set -o errexit
-set -o pipefail
 set -o nounset
+set -o pipefail
 set -o xtrace
 
 INI_FILE="/opt/aws/network-flow-monitor/etc/network-flow-monitor.ini"
-DEFAULT_CGROUP="/mnt/cgroupnefmon"
+DEFAULT_CGROUP="/mnt/cgroup-nfm"
 
-# Function to read an ini file and print out key/value pairs
-function parse_ini_file() {
+# Function to load variables from an INI file section into the current shell scope
+function load_ini_section() {
     local ini_file=$1
     local section=$2
-    eval "$(awk -F= -v section="$section" '
-        /^\[/{section=0}
-        /^\['"$section"'\]/{section=1; next}
-        section==1 && $1 !~ /^($|#|;)/ {
-            gsub(/^[ \t]+|[ \t]+$/, "", $1);
-            gsub(/^[ \t]+|[ \t]+$/, "", $2);
-            print $1"=\""$2"\""
-        }' "$ini_file")"
+
+    # Declare variables with defaults
+    cgroup="default"
+    endpoint="default"
+    region="default"
+
+    while IFS='=' read -r key value; do
+        # Skip empty lines, comments, and section headers
+        [[ -z "$key" || "$key" =~ ^[[:space:]]*[#\;] || "$key" =~ ^\[ ]] && continue
+
+        # Trim whitespace
+        key=$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        value=$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+        # Validate key name (only allow alphanumeric and underscore)
+        [[ ! "$key" =~ ^[a-zA-Z0-9_]+$ ]] && continue
+
+        # Export the variable so it's available in the script scope
+        export "$key=$value"
+    done < <(sed -n "/^\[$section\]/,/^\[/p" "$ini_file")
 }
 
 # Function to validate the cgroup. If default is provided, will check if cgroup for Network Flow Monitor is
@@ -72,7 +84,8 @@ function parse_endpoint() {
 }
 
 
-parse_ini_file "$INI_FILE" "config"
+load_ini_section "$INI_FILE" "config"
+
 CGROUP=$(parse_cgroup $cgroup)
 REGION=$(parse_region $region)
 ENDPOINT=$(parse_endpoint $endpoint $REGION)

--- a/packaging/linux/network-flow-monitor.ini
+++ b/packaging/linux/network-flow-monitor.ini
@@ -1,7 +1,7 @@
 [config]
-# default or the cgroup used to monitor the nework events.
+# cgroup used to monitor network events.
 cgroup=default
-# default or the URL of the endpoint. Default will use Network Flow Monitor's VPC Endpoint.
+# provide the endpoint URL, or default to use the endpoint of the Network Flow Monitor service.
 endpoint=default
-# default or the region of the endpoint.
+# provide the region of the endpoint, or default to use the region retrieved from the local instance metadata service (IMSv2).
 region=default

--- a/packaging/linux/network-flow-monitor.ini
+++ b/packaging/linux/network-flow-monitor.ini
@@ -1,0 +1,7 @@
+[config]
+# default or the cgroup used to monitor the nework events.
+cgroup=default
+# default or the URL of the endpoint. Default will use Network Flow Monitor's VPC Endpoint.
+endpoint=default
+# default or the region of the endpoint.
+region=default

--- a/packaging/linux/network-flow-monitor.service
+++ b/packaging/linux/network-flow-monitor.service
@@ -8,7 +8,7 @@ Restart=always
 RestartSec=5
 User=networkflowmonitor
 
-LimitAS=100M
+MemoryMax=100M
 LimitNICE=+10
 CPUQuota=5%
 

--- a/packaging/linux/network-flow-monitor.service
+++ b/packaging/linux/network-flow-monitor.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Network Flow Monitor Agent
+
+[Service]
+Type=simple
+ExecStart=/opt/aws/network-flow-monitor/network-flow-monitor-start
+Restart=always
+RestartSec=5
+User=networkflowmonitor
+
+LimitAS=100M
+LimitNICE=+10
+CPUQuota=5%
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Added spec file for RPM packaging along with startup script. Included RPM build script (create_rpm.sh) for testing and systemd service with default configuration files.

This commit sets up the basic infrastructure for building and packaging the Network Flow Monitor Agent.

* Testing
```
$ ./packaging/linux/create_rpm.sh x86_64
...
************************************************************
Creating x86_64 rpm file for Amazon Linux
************************************************************
Building target platforms: x86_64
Building for target x86_64
...

$ rpm -ql out/network-flow-monitor-agent.rpm
/opt/aws/network-flow-monitor
/opt/aws/network-flow-monitor/LICENSE
/opt/aws/network-flow-monitor/NOTICE
/opt/aws/network-flow-monitor/etc
/opt/aws/network-flow-monitor/etc/network-flow-monitor.ini
/opt/aws/network-flow-monitor/network-flow-monitor-agent
/opt/aws/network-flow-monitor/network-flow-monitor-start
/usr/lib/systemd/system/network-flow-monitor.service
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
