### PR TITLE
More aggresive decrease sampling interval

### DIFF
--- a/nfm-controller/src/events/event_provider_ebpf.rs
+++ b/nfm-controller/src/events/event_provider_ebpf.rs
@@ -279,7 +279,8 @@ impl<C: Clock> EventProviderEbpf<C> {
 
     fn decrease_sampling_interval(&mut self) {
         if self.ebpf_control_data.sampling_interval > 1 {
-            self.ebpf_control_data.sampling_interval -= 1;
+            self.ebpf_control_data.sampling_interval -=
+                self.ebpf_control_data.sampling_interval.div_ceil(7);
             self.send_control_data();
         }
     }

--- a/nfm-controller/src/events/event_provider_ebpf.rs
+++ b/nfm-controller/src/events/event_provider_ebpf.rs
@@ -28,6 +28,7 @@ use aya_obj::generated::BPF_ANY;
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
 use log::info;
 use procfs::{Current, Meminfo};
+use std::cmp::min;
 use std::fs::File;
 use std::mem;
 
@@ -267,9 +268,16 @@ impl<C: Clock> EventProviderEbpf<C> {
     }
 
     fn increase_sampling_interval(&mut self) {
-        if self.ebpf_control_data.sampling_interval > 1 {
-            self.ebpf_control_data.sampling_interval =
-                self.ebpf_control_data.sampling_interval.saturating_mul(3) / 2;
+        // With 1000 sampling rate, the probability of picking up a new connection
+        // is 1/1000.
+        let max_sampling_interval = 1000;
+        if self.ebpf_control_data.sampling_interval > max_sampling_interval {
+            return;
+        } else if self.ebpf_control_data.sampling_interval > 1 {
+            self.ebpf_control_data.sampling_interval = min(
+                max_sampling_interval,
+                self.ebpf_control_data.sampling_interval.saturating_mul(3) / 2,
+            );
         } else {
             self.ebpf_control_data.sampling_interval = 2;
         }


### PR DESCRIPTION
When the agent reaches its tracked socket limit, it enables a sampling mechanism that processes fewer events. The sampling interval increases each time we hit the limit. Once the limit errors stop occurring, the system gradually increases the number of processed events.

However, the current algorithm increases the sampling interval more aggressively than it decreases it. This imbalance causes the agent to stop collecting metrics for extended periods, sometimes lasting several hours.

The calculation to increase the sampling interval is aggressive compared with calculation to decrease the interval. Due to this, sometimes the agent stops collecting metrics for hours:
![Screenshot 2025-04-25 at 12 27 06](https://github.com/user-attachments/assets/56ffb959-d995-4afe-ab11-5a105d1ed6e9)

We modified the sampling interval decrease calculation to recover event processing more quickly after limit errors resolve. The new algorithm reduces the sampling interval more aggressively, allowing faster recovery of normal event processing.. Tested in 2 different instances:
![Screenshot 2025-04-29 at 14 49 13](https://github.com/user-attachments/assets/6ec2a3c2-0726-412a-9a1a-dd06641a4d2f)
![Screenshot 2025-04-29 at 14 47 01](https://github.com/user-attachments/assets/016c87dd-e055-4a89-9634-2c10fe2dcd86)



-------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
