### PR TITLE
Release 0.1.4

### DIFF
--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nfm-controller"
 description = "network-flow-monitor-agent collects networking performance statistics from the local machine"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 build = "build.rs"
 license = "Apache-2.0"

--- a/packaging/linux/create_rpm.sh
+++ b/packaging/linux/create_rpm.sh
@@ -38,7 +38,7 @@ mkdir -p "${BUILD_ROOT}"
 
 rpmbuild -bb \
          --target $TARGET_ARCH \
-         --define "AGENT_VERSION 0.1.3" \
+         --define "AGENT_VERSION 0.1.4" \
          --define "_topdir ${OUT_DIR}/bin/linux/rpmbuild" \
          --define "_sourcedir $(pwd)" \
          --buildroot "${BUILD_ROOT}" \


### PR DESCRIPTION
Updating the release version from 0.1.3 to 0.1.4.

#### Main version changes
* Proxy support for reports - [commit](https://github.com/aws/network-flow-monitor-agent/commit/ed04ef45bf4d8e8b17009069e16f9d5066c26c20)
* Fix sampling bug where the agent sample value don't recovers after a high load - [PR](https://github.com/aws/network-flow-monitor-agent/pull/27)

-------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
