### PR TITLE
Drop privileges after attach eBPF program

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ docker build -t integration-tests -f test-data/Dockerfile.test .
 docker run --privileged -t integration-tests
 ```
 
+Some unit tests need privileges to run:
+```
+sudo -E cargo test --features privileged
+```
 ### Distributions
 You can download the official release from our permanent URLs. For more information, refer to [link](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents-download-agent-commandline.html)
 

--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -17,6 +17,10 @@ name = "nfm_agent"
 path = "src/lib.rs"
 crate-type = ["lib"]
 
+[features]
+default = []
+privileged = [] # To identify test that need privileges to run.
+
 [profile.dev]
 panic = "abort"
 overflow-checks = true
@@ -26,7 +30,7 @@ panic = "abort"
 overflow-checks = true
 
 [dependencies]
-aws-config = { version = "1.5", features = [ "rustls" ] }
+aws-config = { version = "1.5", features = ["rustls"] }
 aws-credential-types = "1.2"
 aws-sign-v4 = "0.3"
 nfm-common = { version = "0.1.0", path = "../nfm-common", features = ["user"] }
@@ -44,7 +48,11 @@ flate2 = "1.0"
 futures = "0.3"
 hashbrown = "0.15"
 k8s-openapi = { version = "0.24", features = ["latest"] }
-kube = { version = "0.99", features = ["runtime", "derive", "rustls-tls"], default-features = false }
+kube = { version = "0.99", features = [
+    "runtime",
+    "derive",
+    "rustls-tls",
+], default-features = false }
 libc = "0.2"
 log = "0.4"
 netlink-packet-core = { version = "0.7" }
@@ -60,7 +68,10 @@ opentelemetry-proto = { version = "0.27", features = [
 procfs = "0.16"
 prost = "0.13"
 rand = "0.8"
-reqwest = { version = "0.12", features = ["blocking", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = [
+    "blocking",
+    "rustls-tls",
+], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shadow-rs = "0.36"


### PR DESCRIPTION
*Description of changes:*

Dropping *cap_sys_admin* privileges after the eBPF program is attached. This will improve the security posture of the service by being able to run as a non-privileged user.

*Test*:

Checked the runtime caps of the process before and after the change:
```
$ getpcaps 16729
16729: cap_sys_admin,cap_bpf=ep

$ getpcaps 24668                                                                                                                                              
24668: cap_bpf=ep
```

The telemetry is being collected:
```
{"level":"INFO","message":"Publishing report","report":{"network_stats":[{"flow":{"protocol":"TCP","local_address":"REDACTED","remote_address":"REDACTED","local_port":0,"remote_port":443},"stats":{"sockets_connecting":0,"sockets_established":0,"sockets_closing":0,"sockets_closed":0,"sockets_completed":1,"severed_connect":0,"severed_establish":1,"connect_attempts":1,"bytes_received":4384,"bytes_delivered":6589,"segments_received":11,"segments_delivered":7,"retrans_syn":0,"retrans_est":0,"retrans_close":0,"rtos_syn":0,"rtos_est":0,"rtos_close":0,"connect_us":{"count":1,"min":1105,"max":1105,"sum":1105},"rtt_us":{"count":1,"min":1045,"max":1045,"sum":1045},"rtt_smoothed_us":{"count":1,"min":1045,"max":1045,"sum":1045}}},{"flow":{"protocol":"TCP","local_address":"REDACTED","remote_address":"REDACTED","local_port":0,"remote_port":443},"stats":{"sockets_connecting":0,"sockets_established":0,"sockets_closing":0,"sockets_closed":0,"sockets_completed":6,"severed_connect":0,"severed_establish":0,"connect_attempts":6,"bytes_received":32516,"bytes_delivered":15859,"segments_received":63,"segments_delivered":48,"retrans_syn":0,"retrans_est":0,"retrans_close":0,"rtos_syn":0,"rtos_est":0,"rtos_close":0,"connect_us":{"count":6,"min":67802,"max":69135,"sum":410492},"rtt_us":{"count":11,"min":67790,"max":75966,"sum":788588},"rtt_smoothed_us":{"count":11,"min":67790,"max":75966,"sum":788588}}},{"flow":{"protocol":"TCP","local_address":"172.19.88.122","remote_address":"34.199.181.51","local_port":0,"remote_port":443},"stats":{"sockets_connecting":0,"sockets_established":0,"sockets_closing":0,"sockets_closed":0,"sockets_completed":5,"severed_connect":0,"severed_establish":0,"connect_attempts":5,"bytes_received":27141,"bytes_delivered":13210,"segments_received":55,"segments_delivered":40,"retrans_syn":0,"retrans_est":0,"retrans_close":0,"rtos_syn":0,"rtos_est":0,"rtos_close":0,"connect_us":{"count":5,"min":67832,"max":68721,"sum":341177},"rtt_us":{"count":10,"min":67352,"max":75577,"sum":698265},"rtt_smoothed_us":{"count":10,"min":67352,"max":75577,"sum":698265}}},{"flow":

....

"service_metadata":{"name":{"String":"network-flow-monitor"},"version":{"String":"0.1.4"},"build_ts":{"String":"2025-05-28T11:24:48Z"}},"failed_reports":0,"report_version":"1.1","k8s_metadata":{"node_name":null,"cluster_name":null}},"target":"nfm_agent::reports::publisher","timestamp":1748431646531}
```
-----


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
