### PR TITLE
make agent log level configurable for k8s through RUST_LOG env var

### DIFF
--- a/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
+++ b/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
@@ -51,6 +51,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: RUST_LOG
+              value: "{{.Values.env.RUST_LOG}}"
       nodeSelector:
         kubernetes.io/os: linux
       terminationGracePeriodSeconds: 5

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -28,7 +28,7 @@ tolerations: []
 nameOverride: ""
 
 env:
-  NFM_AGENT_LOG_LEVEL: INFO
+  RUST_LOG: info
 
 resources:
   limits:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/network-flow-monitor-agent/issues/30

*Description of changes:*
Feeding RUST_LOG env var to the kubernetes application. A matching change for EKS add-on will be made in internal repo post merge.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
