### PR TITLE
Adding bpf memory usage to the report

### DIFF
--- a/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
+++ b/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
@@ -51,8 +51,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: RUST_LOG
-              value: "{{.Values.env.RUST_LOG}}"
       nodeSelector:
         kubernetes.io/os: linux
       terminationGracePeriodSeconds: 5

--- a/nfm-common/src/ebpf_actuals.rs
+++ b/nfm-common/src/ebpf_actuals.rs
@@ -58,20 +58,20 @@ pub type SharedHashMap<K, V> = aya_ebpf::maps::HashMap<K, V>;
 pub static NFM_CONTROL: SharedHashMap<SingletonKey, ControlData> =
     SharedHashMap::with_max_entries(1, BPF_F_NO_PREALLOC);
 
-// NFM_COUNTERS communicates events from BPF to user-space.  It is per-CPU and contents are never
+// NFM_COUNTERS communicates events from BPF to user-space. It is per-CPU and contents are never
 // deleted.
 #[map]
 pub static NFM_COUNTERS: PerCpuHashMap<SingletonKey, EventCounters> =
     PerCpuHashMap::with_max_entries(1, 0);
 
-// SK_PROPS communicates the properties of a newly established socket to user-space.  It is used as
+// SK_PROPS communicates the properties of a newly established socket to user-space. It is used as
 // a signaling channel; entries are deleted by user-space once read.
 #[map]
 pub static NFM_SK_PROPS: SharedHashMap<CpuSockKey, SockContext> =
     SharedHashMap::with_max_entries(MAX_ENTRIES_SK_PROPS_LO as u32, BPF_F_NO_PREALLOC);
 
 // SK_STATS is where the BPF program writes socket statistics in response to sock_ops events for
-// tracked sockets.  Entries are deleted by user-space upon socket closure.
+// tracked sockets. Entries are deleted by user-space upon socket closure.
 #[map]
 pub static NFM_SK_STATS: SharedHashMap<CpuSockKey, SockStats> =
     SharedHashMap::with_max_entries(MAX_ENTRIES_SK_STATS_LO as u32, BPF_F_NO_PREALLOC);

--- a/nfm-controller/src/events/event_provider.rs
+++ b/nfm-controller/src/events/event_provider.rs
@@ -13,4 +13,5 @@ pub trait EventProvider {
     fn network_stats(&mut self) -> Vec<AggregateResults>;
     fn counters(&mut self) -> CountersOverall;
     fn socket_count(&self) -> u64;
+    fn ebpf_allocated_mem_kb(&self) -> u32;
 }

--- a/nfm-controller/src/lib.rs
+++ b/nfm-controller/src/lib.rs
@@ -310,6 +310,7 @@ fn do_work(
             usage_stats.mem_used_kb = usage_stats.mem_used_kb.max(mem_used_kb);
             usage_stats.mem_used_ratio = usage_stats.mem_used_ratio.max(mem_used_ratio);
             usage_stats.sockets_tracked = usage_stats.sockets_tracked.max(provider.socket_count());
+            usage_stats.ebpf_allocated_mem_kb = provider.ebpf_allocated_mem_kb();
         }
     }
 }
@@ -368,6 +369,9 @@ mod test {
             CountersOverall::default()
         }
         fn socket_count(&self) -> u64 {
+            0
+        }
+        fn ebpf_allocated_mem_kb(&self) -> u32 {
             0
         }
     }

--- a/nfm-controller/src/reports/publisher_endpoint.rs
+++ b/nfm-controller/src/reports/publisher_endpoint.rs
@@ -695,6 +695,7 @@ mod tests {
             mem_used_kb: 512,
             mem_used_ratio: 0.06,
             sockets_tracked: 100,
+            ebpf_allocated_mem_kb: 12801,
         });
 
         process_stats

--- a/nfm-controller/src/reports/report.rs
+++ b/nfm-controller/src/reports/report.rs
@@ -147,6 +147,7 @@ pub struct UsageStats {
     pub mem_used_kb: u64,
     pub mem_used_ratio: f64,
     pub sockets_tracked: u64,
+    pub ebpf_allocated_mem_kb: u32,
 }
 
 impl ProcessStats {
@@ -242,6 +243,7 @@ mod tests {
             mem_used_kb: 512,
             mem_used_ratio: 0.06,
             sockets_tracked: 49,
+            ebpf_allocated_mem_kb: 12800,
         });
         let grouped_iface_stats = GroupedInterfaceStats {
             interface_id: "iface-id-1".to_string(),

--- a/nfm-controller/src/reports/report_otlp.rs
+++ b/nfm-controller/src/reports/report_otlp.rs
@@ -473,6 +473,7 @@ mod tests {
             mem_used_kb: 512,
             mem_used_ratio: 0.06,
             sockets_tracked: 100,
+            ebpf_allocated_mem_kb: 12802,
         });
 
         let iface1_stats = GroupedInterfaceStats {

--- a/test-data/report-ec2-otel.json
+++ b/test-data/report-ec2-otel.json
@@ -674,6 +674,24 @@
                   }
                 ]
               }
+            },
+            {
+              "name": "ebpf_allocated_mem_kb",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 12802
+                  }
+                ]
+              }
             }
           ],
           "schemaUrl": ""

--- a/test-data/report-k8s-eks-otel.json
+++ b/test-data/report-k8s-eks-otel.json
@@ -722,6 +722,24 @@
                   }
                 ]
               }
+            },
+            {
+              "name": "ebpf_allocated_mem_kb",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 12802
+                  }
+                ]
+              }
             }
           ],
           "schemaUrl": ""

--- a/test-data/report-k8s-vanilla-otel.json
+++ b/test-data/report-k8s-vanilla-otel.json
@@ -716,6 +716,24 @@
                   }
                 ]
               }
+            },
+            {
+              "name": "ebpf_allocated_mem_kb",
+              "description": "",
+              "unit": "",
+              "metadata": [],
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [],
+                    "startTimeUnixNano": "1718716821050000",
+                    "timeUnixNano": "1718716821050000",
+                    "exemplars": [],
+                    "flags": 0,
+                    "asInt": 12802
+                  }
+                ]
+              }
             }
           ],
           "schemaUrl": ""

--- a/test-data/report1.json
+++ b/test-data/report1.json
@@ -88,7 +88,8 @@
         "cpu_util": 0.04,
         "mem_used_kb": 512,
         "mem_used_ratio": 0.06,
-        "sockets_tracked": 49
+        "sockets_tracked": 49,
+        "ebpf_allocated_mem_kb": 12800
       }
     ]
   },

--- a/test-data/report2.json
+++ b/test-data/report2.json
@@ -88,7 +88,8 @@
         "cpu_util": 0.04,
         "mem_used_kb": 512,
         "mem_used_ratio": 0.06,
-        "sockets_tracked": 49
+        "sockets_tracked": 49,
+        "ebpf_allocated_mem_kb": 12800
       }
     ]
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding eBPF memory usage to the agent report. This will be a static value calculated once at load time, and re-read & sent every time. eBPF usage is relatively mild for small hosts (less than 1 MByte) but it can go up to 10s for large hosts which is considerable for idle-time memory usage

*Testing*
Ran in two hosts with 64 and 4 GBytes of memory:
```
{"level":"INFO","message":"Loading eBPF program","sock_props_max_entries":3250,"sock_stats_max_entries":9750,"target":"amzn_nfm::events::event_provider_ebpf","timestamp":1749239609127}
{"ebpf_allocated_memory_kb":1313,"level":"INFO","message":"Calculated BPF maps approximate memory usage","target":"amzn_nfm::events::event_provider_ebpf","timestamp":1749239609161}
```

```
{"level":"INFO","message":"Loading eBPF program","sock_props_max_entries":250,"sock_stats_max_entries":750,"target":"amzn_nfm::events::event_provider_ebpf","timestamp":1749239806969}
{"ebpf_allocated_memory_kb":101,"level":"INFO","message":"Calculated BPF maps approximate memory usage","target":"amzn_nfm::events::event_provider_ebpf","timestamp":1749239807007}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
