### PR TITLE
Updated shadow-rs version

### DIFF
--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -74,7 +74,7 @@ reqwest = { version = "0.12", features = [
 ], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shadow-rs = "0.36"
+shadow-rs = "1.1.0"
 signal-hook = "0.3"
 structured-logger = "1.0"
 sys-info = "0.9"
@@ -90,6 +90,6 @@ url = "2.5"
 
 [build-dependencies]
 cargo_metadata = "0.19"
-shadow-rs = "0.36"
+shadow-rs = "1.1.0"
 which = { version = "6.0.0", default-features = false }
 

--- a/nfm-controller/build.rs
+++ b/nfm-controller/build.rs
@@ -5,8 +5,9 @@ use cargo_metadata::MetadataCommand;
 use std::path::Path;
 use std::process::Command;
 use which::which;
+use shadow_rs::ShadowBuilder;
 
-fn main() -> shadow_rs::SdResult<()> {
+fn main() {
     // We skip the eBPF build if running under tarpaulin, which measures code test coverage.
     // tarpaulin is incompatible with `no_std` and BPF's different target architecture.
     let should_build_ebpf = std::env::var("CARGO_CFG_TARPAULIN").is_err();
@@ -17,7 +18,7 @@ fn main() -> shadow_rs::SdResult<()> {
         build_ebpf(release);
     }
 
-    shadow_rs::new()
+    ShadowBuilder::builder().build().unwrap();
 }
 
 fn set_up_toolchain() {


### PR DESCRIPTION
Updated _shadow-rs_ dependency.



Built and tested using a value populated by the package:
```
$ ./target/release/network-flow-monitor-agent --version
network-flow-monitor-agent 0.1.4
```

----------


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
