### PR TITLE
Add %systemd_postun_with_restart macro to ensure the NFM service rest…

### DIFF
--- a/packaging/linux/network-flow-monitor-agent.spec
+++ b/packaging/linux/network-flow-monitor-agent.spec
@@ -107,6 +107,8 @@ echo "%{AGENT_LOG_DESCRIPTION} uninstalled successfully."
 
 ### Post-Uninstall Scripts
 %postun
+# The agent needs to be restarted upon upgrade to pick up the new binary
+%systemd_postun_with_restart network-flow-monitor.service
 if [ %PACKAGES_LEFT = 0 ] || [ %PACKAGE_COMMAND = "remove" ]; then
     userdel %{NFM_USER}
     groupdel %{NFM_GROUP}


### PR DESCRIPTION
Add %systemd_postun_with_restart macro to ensure the NFM service restarts after package upgrades to pick up the new binary


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
