### PR TITLE
change rpm release number to reflect suse change

### DIFF
--- a/packaging/linux/network-flow-monitor-agent.spec
+++ b/packaging/linux/network-flow-monitor-agent.spec
@@ -1,6 +1,6 @@
 Name:       network-flow-monitor-agent
 Summary:    Network Flow Monitor Agent
-Release:    1
+Release:    2
 Version:    %AGENT_VERSION
 Requires:   bash
 Requires:   (libcap2-bin or libcap-progs or libcap)


### PR DESCRIPTION
Incrementing release number so that the suse support change is auto-detected on internal distributions
