### PR TITLE
Add artifact upload for nfm agent binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,3 +51,10 @@ jobs:
         run: |
           docker build -t integration-test -f test-data/Dockerfile.test .
           docker run --privileged -t integration-test
+      - name: Upload release binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-flow-monitor-agent
+          path:  ./target/release/network-flow-monitor-agent
+          retention-days: 3
+          if-no-files-found: error


### PR DESCRIPTION
Add a step to upload network-flow-monitor-agent binary as workflow artifact

Agent binary download URL: https://github.com/aws/network-flow-monitor-agent/actions/runs/16962033737/artifacts/3763737909

### Testing
Tested gitub action locally using the [act](https://nektosact.com/) CLI


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
