### PR TITLE
Main

### DIFF
--- a/packaging/linux/network-flow-monitor-agent.spec
+++ b/packaging/linux/network-flow-monitor-agent.spec
@@ -71,7 +71,10 @@ cp %{_sourcedir}/target/release/network-flow-monitor-agent %{buildroot}%{PKG_ROO
 
 ## Capabilities
 # Giving the agent capabilities so that we can perform e/BPF actions
-setcap cap_sys_admin,cap_bpf=eip %{PKG_ROOT_DIR}/network-flow-monitor-agent
+# Try with cap_bpf name first, fallback to numeric to support older setcap versions
+if ! setcap cap_sys_admin,cap_bpf=eip %{PKG_ROOT_DIR}/network-flow-monitor-agent 2>/dev/null; then
+    setcap cap_sys_admin,39=eip %{PKG_ROOT_DIR}/network-flow-monitor-agent
+fi
 
 # Only create mount points on install or if the mountpoint doesn't exists
 if [ %PACKAGES_LEFT = 1 ] || ! mountpoint -q %{NFM_CGROUP_DIR}; then


### PR DESCRIPTION
*Description of changes:*
Support for older versions of `setcap`. Testing this in Ubuntu 20.04, installation fails because the eBPF capability is not present, so using the numerical value instead.

*Test:*

Installed this in 2 Ubuntu version, 20.04 and 24.04:
```
$ sudo dpkg -i networkflowmonitoragent_0.2.0-2_amd64.deb
Selecting previously unselected package networkflowmonitoragent.
(Reading database ... 69448 files and directories currently installed.)
Preparing to unpack networkflowmonitoragent_0.2.0-2_amd64.deb ...
Unpacking networkflowmonitoragent (0.2.0-2) ...
Setting up networkflowmonitoragent (0.2.0-2) ...
creating cgroupv2 mount point
Network Flow Monitor Agent 0.2.0 installed successfully.
$ cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.6 LTS (Focal Fossa)"
```

and
```
$ sudo dpkg --install nfm-test.deb
Selecting previously unselected package networkflowmonitoragent.
(Reading database ... 79559 files and directories currently installed.)
Preparing to unpack nfm-test.deb ...
Unpacking networkflowmonitoragent (0.2.0-2) ...
Setting up networkflowmonitoragent (0.2.0-2) ...
creating cgroupv2 mount point
Network Flow Monitor Agent 0.2.0 installed successfully.

$ cat /etc/os-release
PRETTY_NAME="Ubuntu 24.04.3 LTS"
```

 ----------


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
