### PR TITLE
remove duplicate btf objects

### DIFF
--- a/nfm-common/src/sock_ops_handler.rs
+++ b/nfm-common/src/sock_ops_handler.rs
@@ -59,7 +59,7 @@ impl BpfControlConveyor {
         let control_option = bpf_array_get!(self, NFM_CONTROL, 0);
         if let Some(control_data) = control_option {
             let sampling_interval = control_data.sampling_interval;
-            sampling_interval <= 1 || bpf_get_rand_u32!(self) % sampling_interval == 0
+            sampling_interval <= 1 || bpf_get_rand_u32!(self).is_multiple_of(sampling_interval)
         } else {
             true
         }

--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -20,6 +20,7 @@ crate-type = ["lib"]
 [features]
 default = []
 privileged = [] # To identify test that need privileges to run.
+dhat = ["dep:dhat"] # enable dhat only when requested
 
 [profile.dev]
 panic = "abort"
@@ -35,6 +36,9 @@ rustls = { version = "0.23.29", default-features = false }
 aws-credential-types = "1.2"
 aws-sign-v4 = "0.3"
 nfm-common = { version = "0.1.0", path = "../nfm-common", features = ["user"] }
+
+# Memory profiling
+dhat = { version = "0.3", optional = true}
 
 anyhow = "1"
 assert_approx_eq = "1"

--- a/nfm-controller/src/events/event_provider_ebpf.rs
+++ b/nfm-controller/src/events/event_provider_ebpf.rs
@@ -21,7 +21,7 @@ use aya::{
     include_bytes_aligned,
     maps::{Array as SharedArray, HashMap as SharedHashMap, MapData, MapError, PerCpuArray},
     programs::{CgroupAttachMode, SockOps},
-    Btf, Ebpf, EbpfLoader, VerifierLogLevel,
+    Ebpf, EbpfLoader, VerifierLogLevel,
 };
 use aya_obj::generated::BPF_ANY;
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
@@ -60,7 +60,6 @@ fn instantiate_ebpf_object(
     info!(sock_props_max_entries, sock_stats_max_entries; "Loading eBPF program");
     EbpfLoader::new()
         .verifier_log_level(VerifierLogLevel::VERBOSE | VerifierLogLevel::STATS)
-        .btf(Btf::from_sys_fs().ok().as_ref())
         .set_max_entries(
             NFM_SK_PROPS_MAP_NAME,
             sock_props_max_entries.try_into().unwrap(),

--- a/nfm-controller/src/main.rs
+++ b/nfm-controller/src/main.rs
@@ -8,7 +8,6 @@ use nfm_agent::{on_load, Options};
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
-
 fn main() -> Result<(), anyhow::Error> {
     #[cfg(feature = "dhat")]
     let _profiler = dhat::Profiler::new_heap();

--- a/nfm-controller/src/main.rs
+++ b/nfm-controller/src/main.rs
@@ -4,6 +4,13 @@
 use clap::Parser;
 use nfm_agent::{on_load, Options};
 
+#[cfg(feature = "dhat")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+
 fn main() -> Result<(), anyhow::Error> {
+    #[cfg(feature = "dhat")]
+    let _profiler = dhat::Profiler::new_heap();
     on_load(Options::parse())
 }

--- a/nfm-controller/src/utils/cpu.rs
+++ b/nfm-controller/src/utils/cpu.rs
@@ -111,8 +111,8 @@ mod test {
             high_usage_ratio
         );
         assert!(
-            high_usage_ratio <= 5.0,
-            "expected <= 5.0, got {}",
+            high_usage_ratio <= 15.0,
+            "expected <= 15.0, got {}",
             high_usage_ratio
         );
     }


### PR DESCRIPTION
*Issue #, if available:*

While fiddling around with inspection tools for upcoming testing improvements i have realised that there are multiple calls to btf loader from aya side / loading same object twice. It turns out that the object to manage btf on user space is not dropped properly post ebpf load, and having duplicate calls [call#1](https://github.com/aya-rs/aya/blob/ade2e2a739dbe0b1c44b02c19fed8343121dd00a/aya/src/bpf.rs#L157) [call#2](https://github.com/aws/network-flow-monitor-agent/blob/main/nfm-controller/src/events/event_provider_ebpf.rs#L63) causes both objects to persist, resulting in unnecessary  memory consumption.
This change alleviates that by removing redundant call (call#2), resulting in 9.5MBytes of lesser memory usage.

There was also a relevant [issue](https://github.com/aya-rs/aya/issues/1172) on aya side.

The ideal scenario would be that the other btf loader object that is created (the one is call#1) should also go out of scope and get dropped after relocation but it is not the case, and have not investigated the reason for that

*Testing*:
<img width="1655" height="846" alt="Screenshot 2025-09-25 at 03 59 43" src="https://github.com/user-attachments/assets/3ddd80c0-01ff-48fb-8690-6260edd2c5c3" />

Without change [DHAT Output](https://github.com/user-attachments/files/22526968/dhat-heap.json) (load the downloaded file here https://nnethercote.github.io/dh_view/dh_view.html to view)

```
[2:41] ~/work/network-flow-monitor-agent % sudo -E env "PATH=$PATH" cargo run --features dhat --release -- --cgroup /mnt/cgroupnetworkflowmonitoragent --log-reports on --publish-reports off
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /local/home/eerdem/work/network-flow-monitor-agent/nfm-controller/Cargo.toml
workspace: /local/home/eerdem/work/network-flow-monitor-agent/Cargo.toml
   Compiling nfm-controller v0.2.1 (/local/home/eerdem/work/network-flow-monitor-agent/nfm-controller)
    Finished `release` profile [optimized] target(s) in 10.90s
     Running `target/release/network-flow-monitor-agent --cgroup /mnt/cgroupnetworkflowmonitoragent --log-reports on --publish-reports off`
{"args":{"cgroup":"/mnt/cgroupnetworkflowmonitoragent","top_k":500,"notrack_secs":65,"usage_data":"on","aggregate_msecs":500,"publish_secs":30,"jitter_secs":5,"endpoint":"","endpoint_region":"","proxy":"","log_reports":"on","publish_reports":"off","report_compression":"gzip","kubernetes_metadata":"off","resolve_nat":"off"},"level":"INFO","message":"Starting up","target":"nfm_agent","timestamp":1758768128346}
{"level":"INFO","message":"Loading eBPF
 program","sock_props_max_entries":3250,"sock_stats_max_entries":9750,"target":"nfm_agent::events::event_provider_ebpf","timestamp":1758768128346}
{"ebpf_allocated_mem_kb":1313,"level":"INFO","message":"Calculated BPF maps approximate memory usage","target":"nfm_agent::events::event_provider_ebpf","timestamp":1758768129160}
{"level":"INFO","message":"Dropping CAP_SYS_ADMIN and CAP_BPF capabilities","target":"nfm_agent","timestamp":1758768129160}
{"level":"INFO","message":"Successfully dropped CAP_SYS_ADMIN and CAP_BPF capabilities","target":"nfm_agent","timestamp":1758768129160}
{"level":"INFO","message":"Retrieved total system memory","target":"nfm_agent::utils::memory_inspector","timestamp":1758768129186,"total_kb":64424936}
{"level":"INFO","message":"Acquired processor CPU core count from sys_info","num_logical_cores":16,"target":"nfm_agent::utils::cpu","timestamp":1758768129186}
{"level":"INFO","message":"Aggregating across sockets","target":"nfm_agent::events::event_provider_ebpf","timestamp":1758768129686}
{"control_data":{"sampling_interval":1},"cpus_per_sock_avg":3.5,"cpus_per_sock_max":4,"cpus_per_sock_min":3,"flow_aggregation_result":{"completed":2,"partial":0,"failed":0},"flows_after":1,"flows_before":0,"level":"INFO","message":"Aggregation complete","sock_add_result":{"completed":2,"partial":0,"failed":0},"sock_cache_len":0,"sock_delta_result":{"completed":2,"partial":0,"failed":0},"sock_eviction_result":{"completed":2,"partial":0,"failed":0},"sock_nat_result":{"completed":0,"partial":0,"failed":0},"target":"nfm_agent::events::event_provider_ebpf","timestamp":1758768129686}
^C{"level":"INFO","message":"Exiting","target":"nfm_agent","timestamp":1758768130186}
dhat: Total:     45,064,946 bytes in 281,505 blocks
dhat: At t-gmax: 23,037,722 bytes in 70,918 blocks
dhat: At t-end:  278,917 bytes in 325 blocks
dhat: The data has been saved to dhat-heap.json, and is viewable with dhat/dh_view.html
```

With change [DHAT Output](https://github.com/user-attachments/files/22526966/dhat-heap-deduped.json):
<img width="1611" height="370" alt="Screenshot 2025-09-25 at 04 01 10" src="https://github.com/user-attachments/assets/55fbfd21-8c55-4615-b4fd-f87b2b947946" />

```
[2:40] ~/work/network-flow-monitor-agent % sudo -E env "PATH=$PATH" cargo run --features dhat --release -- --cgroup /mnt/cgroupnetworkflowmonitoragent --log-reports on --publish-reports off
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /local/home/eerdem/work/network-flow-monitor-agent/nfm-controller/Cargo.toml
workspace: /local/home/eerdem/work/network-flow-monitor-agent/Cargo.toml
   Compiling nfm-controller v0.2.1 (/local/home/eerdem/work/network-flow-monitor-agent/nfm-controller)
    Finished `release` profile [optimized] target(s) in 10.99s
     Running `target/release/network-flow-monitor-agent --cgroup /mnt/cgroupnetworkflowmonitoragent --log-reports on --publish-reports off`
{"args":{"cgroup":"/mnt/cgroupnetworkflowmonitoragent","top_k":500,"notrack_secs":65,"usage_data":"on","aggregate_msecs":500,"publish_secs":30,"jitter_secs":5,"endpoint":"","endpoint_region":"","proxy":"","log_reports":"on","publish_reports":"off","report_compression":"gzip","kubernetes_metadata":"off","resolve_nat":"off"},"level":"INFO","message":"Starting up","target":"nfm_agent","timestamp":1758768027062}
{"level":"INFO","message":"Loading eBPF program","sock_props_max_entries":3250,"sock_stats_max_entries":9750,"target":"nfm_agent::events::event_provider_ebpf","timestamp":1758768027062}
{"ebpf_allocated_mem_kb":1313,"level":"INFO","message":"Calculated BPF maps approximate memory usage","target":"nfm_agent::events::event_provider_ebpf","timestamp":1758768027471}
{"level":"INFO","message":"Dropping CAP_SYS_ADMIN and CAP_BPF capabilities","target":"nfm_agent","timestamp":1758768027471}
{"level":"INFO","message":"Successfully dropped CAP_SYS_ADMIN and CAP_BPF capabilities","target":"nfm_agent","timestamp":1758768027471}
{"level":"INFO","message":"Retrieved total system memory","target":"nfm_agent::utils::memory_inspector","timestamp":1758768027495,"total_kb":64424936}
{"level":"INFO","message":"Acquired processor CPU core count from sys_info","num_logical_cores":16,"target":"nfm_agent::utils::cpu","timestamp":1758768027495}
^C{"level":"INFO","message":"Exiting","target":"nfm_agent","timestamp":1758768027995}
dhat: Total:     23,855,522 bytes in 144,242 blocks
dhat: At t-gmax: 13,680,746 bytes in 35,468 blocks
dhat: At t-end:  278,917 bytes in 325 blocks
dhat: The data has been saved to dhat-heap.json, and is viewable with dhat/dh_view.html
```

Inter operability is also tested by building the code in linux 5.10 and running in 6.1 to ascertain that this change is not actually removing BTF support in exchange for some measly memory gains.

