### PR TITLE
increase nat resolution precision

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,11 +29,13 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
+      - name: Install conntrack
+        run: sudo apt-get update && sudo apt-get install -y conntrack
       - name: Check code coverage
         run: |
           BPF_OBJECT_PATH="${{ github.workspace }}/target/ebpf/bpfel-unknown-none/release/nfm-bpf" \
-          cargo tarpaulin \
-          --features open-metrics \
+          sudo -E env "PATH=$PATH" cargo tarpaulin \
+          --features open-metrics,requires-conntrack \
           --ignore-tests \
           --workspace \
           --exclude nfm-bpf \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,11 @@ default-members = ["nfm-controller", "nfm-common"]
 
 [workspace.metadata]
 bpf_target = "bpfel-unknown-none"
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+panic = "abort"
+strip = false
+overflow-checks = true

--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -20,6 +20,7 @@ crate-type = ["lib"]
 [features]
 default = []
 privileged = [] # To identify test that need privileges to run.
+requires-conntrack = [] # To identify tests that requires conntrack CLI to be present
 dhat = ["dep:dhat"] # enable dhat only when requested
 open-metrics = [
     "default",
@@ -32,10 +33,6 @@ open-metrics = [
 ]
 
 [profile.dev]
-panic = "abort"
-overflow-checks = true
-
-[profile.release]
 panic = "abort"
 overflow-checks = true
 

--- a/nfm-controller/src/events/event_provider.rs
+++ b/nfm-controller/src/events/event_provider.rs
@@ -9,7 +9,7 @@ use std::vec::Vec;
 
 pub trait EventProvider {
     #[allow(clippy::borrowed_box)]
-    fn perform_aggregation_cycle(&mut self, nat_resolver: &Box<dyn NatResolver>);
+    fn perform_aggregation_cycle(&mut self, nat_resolver: &mut Box<dyn NatResolver>);
     fn network_stats(&mut self) -> Vec<AggregateResults>;
     fn counters(&mut self) -> CountersOverall;
     fn socket_count(&self) -> u64;


### PR DESCRIPTION
*Issue #, if available:*
Due to out of sync nature of listening to bpf vs netlink, we are occasionally missing to 'un-nat' connections acquired from bpf side, and insert them as is to our cache and report it that way to backend.

*Description of changes:*
1. Because we are first receiving netlink socket events, then processing bpf ones, there can be new entries in bpf part that do not have corresponding nat entry received yet. Inverting the order here to prevent that.
2. Right now configuration targets 10k tps, however this is not enough for large hosts. Making it target 100k so that there are no unresolved natted entries present in the agent report. At least for great majority of cases.
3. Enabling optimized builds. no idea why we didnt have this before. For the current use case alone there is 10% cpu reduction and also around the same memory reduction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Testing
For correctness, i have created a cluster, installed a load balancer service, and ran the agent as a daemonset. Then ran a long running ~70k new tcp connections per second load test towards the cluster-ip of the load balancer service and observed that there is no leaked cluster-ip references.

Env:
```
[16:48] /local/home/eerdem/work/potat/src/PersonalFarmForPotatoCultivation % kubectl get services
NAME                         TYPE           CLUSTER-IP       EXTERNAL-IP                                                                    PORT(S)          AGE
kubernetes                   ClusterIP      10.100.0.1       <none>                                                                         443/TCP          328d
nginx-basic-service          NodePort       10.100.132.212   <none>                                                                         80:30003/TCP     125d
nginx-hostns-zervice         NodePort       10.100.75.151    <none>                                                                         8102:30002/TCP   125d
nginx-loadbalancer-service   LoadBalancer   10.100.139.110   k8s-default-nginxloa-522cdfb86a-526565fa7f78b77d.elb.eu-west-1.amazonaws.com   5555:32611/TCP   18d
```

Agent [leak detection](https://github.com/aws/network-flow-monitor-agent/blob/nat_slips_debug/nfm-controller/src/events/event_provider_ebpf.rs#L182) logs:
```
bash-5.2# grep "flow_leaks" log.txt | tail -n 5
leaks:0 flow_leaks:0 rtt_zero_leaks:0 leaked_entries:[]
leaks:0 flow_leaks:0 rtt_zero_leaks:0 leaked_entries:[]
leaks:0 flow_leaks:0 rtt_zero_leaks:0 leaked_entries:[]
leaks:0 flow_leaks:0 rtt_zero_leaks:0 leaked_entries:[]
leaks:0 flow_leaks:0 rtt_zero_leaks:0 leaked_entries:[]
```

For performance validation i have added [adhoc measurement code](https://github.com/aws/network-flow-monitor-agent/blob/nat_slips_debug/nfm-controller/src/events/nat_resolver.rs#L123) to measure call count and performance impact. It is consistent with expectation. Netlink socket reading performance:
```
bash-5.2# grep perform_aggregation_cycle log.txt | tail -n 5
perform_aggregation_cycle: 9288 entries in 26283 µs (3085 ns/entry avg) | 71839 events/sec. Events so far: 282539248
perform_aggregation_cycle: 12073 entries in 33674 µs (3085 ns/entry avg) | 71677 events/sec. Events so far: 282551321
perform_aggregation_cycle: 14458 entries in 43964 µs (3085 ns/entry avg) | 72644 events/sec. Events so far: 282565779
perform_aggregation_cycle: 389 entries in 1035 µs (3085 ns/entry avg) | 72596 events/sec. Events so far: 282566168
perform_aggregation_cycle: 8498 entries in 23806 µs (3085 ns/entry avg) | 71590 events/sec. Events so far: 282574666
```

Agent top:
```
bash-5.2# while true; do top -b -n 1 | grep networkflow | sed "s/^/$(date) /"; sleep 1; done
Mon Nov 10 16:57:30 UTC 2025  402482 root      20   0  231596  90056  12284 R  20.0   0.1  19:58.35 networkflowmoni
Mon Nov 10 16:57:32 UTC 2025  402482 root      20   0  231596  90056  12284 R  21.1   0.1  19:58.70 networkflowmoni
Mon Nov 10 16:57:33 UTC 2025  402482 root      20   0  231596  90056  12284 R  20.7   0.1  19:59.08 networkflowmoni
Mon Nov 10 16:57:34 UTC 2025  402482 root      20   0  231596  90056  12284 R  10.5   0.1  19:59.40 networkflowmoni
Mon Nov 10 16:57:36 UTC 2025  402482 root      20   0  231596  90056  12284 R  29.2   0.1  19:59.72 networkflowmoni
Mon Nov 10 16:57:37 UTC 2025  402482 root      20   0  231596  90056  12284 R  11.1   0.1  20:00.02 networkflowmoni
Mon Nov 10 16:57:38 UTC 2025  402482 root      20   0  231596  90056  12284 R  20.0   0.1  20:00.38 networkflowmoni
```

