### PR TITLE
fix crashes due to subtract with overflow

### DIFF
--- a/nfm-controller/src/events/event_provider_ebpf.rs
+++ b/nfm-controller/src/events/event_provider_ebpf.rs
@@ -110,7 +110,7 @@ impl<C: Clock> EventProvider for EventProviderEbpf<C> {
         // Retrieve properties of newly initiated sockets.
         let mut new_cpu_sock_keys = HashSet::<CpuSockKey>::new();
         let now_us = self.clock.now_us();
-        let context_timestamp = now_us - self.notrack_us / 2;
+        let context_timestamp = now_us.saturating_sub(self.notrack_us / 2);
         let mut sock_add_result = SockOperationResult::default();
         for (cpu_sock_key, sock_context) in self.ebpf_sock_props.iter().flatten() {
             let result =
@@ -137,7 +137,7 @@ impl<C: Clock> EventProvider for EventProviderEbpf<C> {
             &self.sock_cache,
             &mut self.sock_stream,
         );
-        let staleness_timestamp = now_us - self.notrack_us;
+        let staleness_timestamp = now_us.saturating_sub(self.notrack_us);
         let sock_delta_result = self
             .sock_cache
             .update_stats_and_get_deltas(&mut self.sock_stream, staleness_timestamp);


### PR DESCRIPTION
*Issue #, if available:*
Started after optimizations are enabled. If the host is just started and clock_boottime is < 65 seconds, then some of our subs can panic. fixing that.

i.e.:
```
{"level":"INFO","message":"Retrieved total system memory","target":"nfm_agent::utils::memory_inspector","timestamp":1763776838244,"total_kb":16049896}
{"level":"INFO","message":"Acquired processor CPU core count from sys_info","num_logical_cores":8,"target":"nfm_agent::utils::cpu","timestamp":1763776838244}
{"backtrace":"   0: std::backtrace_rs::backtrace::libunwind::trace\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9\n   1: std::backtrace_rs::backtrace::trace_unsynchronized\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14\n   2: std::backtrace::Backtrace::create\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/backtrace.rs:331:13\n   3: structured_logger::log_panic\n   4: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/alloc/src/boxed.rs:1985:9\n   5: std::panicking::rust_panic_with_hook\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:841:13\n   6: std::panicking::begin_panic_handler::{{closure}}\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:699:13\n   7: std::sys::backtrace::__rust_end_short_backtrace\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/backtrace.rs:174:18\n   8: __rustc::rust_begin_unwind\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:697:5\n   9: core::panicking::panic_fmt\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:75:14\n  10: core::panicking::panic_const::panic_const_sub_overflow\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:175:17\n  11: nfm_agent::do_work\n  12: nfm_agent::on_load\n  13: network_flow_monitor_agent::main\n  14: std::sys::backtrace::__rust_begin_short_backtrace\n  15: std::rt::lang_start::{{closure}}\n  16: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/ops/function.rs:290:21\n  17: std::panicking::catch_unwind::do_call\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:589:40\n  18: std::panicking::catch_unwind\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:552:19\n  19: std::panic::catch_unwind\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panic.rs:359:14\n  20: std::rt::lang_start_internal::{{closure}}\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/rt.rs:175:24\n  21: std::panicking::catch_unwind::do_call\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:589:40\n  22: std::panicking::catch_unwind\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:552:19\n  23: std::panic::catch_unwind\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panic.rs:359:14\n  24: std::rt::lang_start_internal\n             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/rt.rs:171:5\n  25: main\n  26: __libc_start_call_main\n  27: __libc_start_main_alias_2\n  28: <unknown>\n","file":"nfm-controller/src/events/event_provider_ebpf.rs","level":"ERROR","line":140,"message":"thread 'main' panicked at nfm-controller/src/events/event_provider_ebpf.rs:140:35:\nattempt to subtract with overflow","target":"panic","thread_name":"main","timestamp":1763776838744}
/usr/local/bin/sonar-agent-start.sh: line 42:  4034 Aborted                 (core dumped) ./networkflowmonitor-agent --cgroup /mnt/cgroupnetworkflowmonitoragent --endpoint-region ${region} --endpoint ${endpoint} -k on -n on "${OPEN_METRICS_ARGS[@]}"
```

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
