### PR TITLE
IPv6 support

### DIFF
--- a/nfm-controller/src/open_metrics/server.rs
+++ b/nfm-controller/src/open_metrics/server.rs
@@ -7,8 +7,9 @@
 //! in Prometheus format on the /metrics endpoint.
 
 use std::io::{Error, ErrorKind, Result};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::rc::Rc;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Instant;
@@ -53,11 +54,10 @@ impl OpenMetricsServerConfig {
         port: u16,
         k8s_metadata: Option<Arc<KubernetesMetadataCollector>>,
     ) -> Self {
-        let socket_addr = format!("{}:{}", addr, port)
-            .parse()
-            .expect("Invalid server address");
+        let ip = IpAddr::from_str(&addr)
+            .expect(&format!("Invalid OpenMetrics server address: {}", addr));
         Self {
-            addr: socket_addr,
+            addr: SocketAddr::new(ip, port),
             k8s_metadata,
         }
     }


### PR DESCRIPTION
Fixes: #71 

*Description of changes:*
Adding support for IPv6 OpenMetrics server address.

*Tests*

Manually retrieved data from service:
```
 ./nfm-agent --cgroup /mnt/cgroup/ --publish-reports off -k on -n on --open-metrics on --open-metrics-address "::1" --open-metrics-port 9110

------
$ curl -g -6 "http://[::1]:9110/metrics"
# HELP bw_in_allowance_exceeded The number of packets queued or dropped because the inbound aggregate bandwidth exceeded the maximum for the instance.
# TYPE bw_in_allowance_exceeded gauge
bw_in_allowance_exceeded{eni="eni-064c984509db1e5b9",instance_id="test-node",node="test-node"} 0
bw_in_allowance_exceeded{eni="eni-079a45280cc2e1ee3",instance_id="test-node",node="test-node"} 0
bw_in_allowance_exceeded{eni="eni-07e65ecdc030dbaa5",instance_id="test-node",node="test-node"} 0
```

Also configured a Prometheus+Graphana to retrieve the data:
<img width="1049" height="465" alt="Screenshot 2025-11-27 at 14 29 37" src="https://github.com/user-attachments/assets/eb5ce2ab-f414-4dbd-9321-bd72651a110e" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
