### PR TITLE
fix pod info resolution

### DIFF
--- a/Dockerfile.k8s
+++ b/Dockerfile.k8s
@@ -4,7 +4,7 @@ FROM amazonlinux:2023
 RUN yum install -y util-linux
 
 # Agent dependencies
-RUN yum install -y iproute ethtool
+RUN yum install -y iproute ethtool procps
 
 # Copy local executable to image
 COPY ./target/release/network-flow-monitor-agent /usr/local/bin/nfm-agent

--- a/charts/amazon-network-flow-monitor-agent/Chart.yaml
+++ b/charts/amazon-network-flow-monitor-agent/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This version needs to increase every time the chart and its templates
 # change. This should follow SemVer.
-version: 1.1.1
+version: 1.1.2
 
 # Keep this in sync with Amazon CloudWatch Network Flow Monitor Agent package version
 # used when building the its Docker image

--- a/charts/amazon-network-flow-monitor-agent/README.md
+++ b/charts/amazon-network-flow-monitor-agent/README.md
@@ -1,0 +1,31 @@
+## Directions for self managed Kubernetes
+The directions below will deploy the agent to your current cluster (`kubectl config current-context` to see your current cluster) under "nfm-addon" namespace.
+If you want to use default namespace simply remove --namespace and --create-namespace lines.
+
+Make sure that you have an image ready under "ECR_REPO_CONTAINING_NFM_IMAGE".
+You can use the publicly available images, or build the agent and upload to your repo using following:
+```
+docker build -f Dockerfile.k8s -t aws-network-sonar-agent:v1.1.2-eksbuild.1 .
+docker tag aws-network-sonar-agent:v1.1.2-eksbuild.1 $ECR_REPO_CONTAINING_NFM_IMAGE/aws-network-sonar-agent:v1.1.2-eksbuild.1
+docker push $ECR_REPO_CONTAINING_NFM_IMAGE/aws-network-sonar-agent:v1.1.2-eksbuild.1
+```
+
+#### Build helm package
+helm package charts/amazon-network-flow-monitor-agent/
+
+#### Set ECR repo (EKS Prod ECR by default, or your own custom)
+ECR_REPO_CONTAINING_NFM_IMAGE="602401143452.dkr.ecr.us-west-2.amazonaws.com"
+
+#### Install the built template
+helm install nfm-addon-release charts/amazon-network-flow-monitor-agent/ \
+  --namespace nfm-addon \
+  --create-namespace \
+  --set image.containerRegistry=$ECR_REPO_CONTAINING_NFM_IMAGE \
+  --set image.tag=v1.1.2-eksbuild.1
+
+##### Or upgrade the built template
+helm upgrade nfm-addon-release charts/amazon-network-flow-monitor-agent/ \
+  --namespace nfm-addon \
+  --create-namespace \
+  --set image.containerRegistry=$ECR_REPO_CONTAINING_NFM_IMAGE \
+  --set image.tag=v1.1.2-eksbuild.1

--- a/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
+++ b/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
@@ -16,7 +16,7 @@ VALUES_FILENAME=values.yaml
 PROD_CONTAINER_REGISTRY="602401143452.dkr.ecr.us-west-2.amazonaws.com"
 export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-$PROD_CONTAINER_REGISTRY}
 
-export LATEST_KNOWN_IMAGE_TAG="v1.1.1-eksbuild.1-rev1"
+export LATEST_KNOWN_IMAGE_TAG="v1.1.2-eksbuild.1"
 export IMAGE_TAG=${IMAGE_TAG:-$LATEST_KNOWN_IMAGE_TAG}
 
 # Will install 'Amazon CloudWatch Network Flow Monitor Agent' Manifest Files to an existing K8s Cluster

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -1,6 +1,6 @@
 image:
   override: '' # if defined, this value is used as the canonical image name ("{image_repo}{image_name}:{tag}")
-  tag: v1.1.1-eksbuild.1-rev1  # this is the default image tag. It might be overwritten at runtime
+  tag: v1.1.2-eksbuild.1  # this is the default image tag. It might be overwritten at runtime
   containerRegistry: '' # this gets overriden at runtime with the correct Docker Image Registry
   name: aws-network-sonar-agent # this determines the ecr folder to look for in the target ecr registry
 
@@ -22,7 +22,9 @@ additionalLabels: {}
 # Useful parameters that provide flexibility to customers
 podLabels: {}
 podAnnotations: {}
-tolerations: []
+tolerations:
+- operator: Exists # by default install everywhere, tolerate every taint
+
 
 # allow user to change the internal addon name labels
 nameOverride: ""

--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nfm-controller"
 description = "network-flow-monitor-agent collects networking performance statistics from the local machine"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 build = "build.rs"
 license = "Apache-2.0"


### PR DESCRIPTION
*Issue #, if available:*
Fixing a bug where resolution of client side pod info would fail when a client pod has multiple ports exposed.

Also making ingestion endpoint customisable.

This release will also fix:
* https://github.com/aws/network-flow-monitor-agent/issues/52
* https://github.com/aws/network-flow-monitor-agent/issues/71

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Testing:
 * unit tests for pod_info
 * installed the helm template using README.md to local cluster for custom endpoint:
 *
```
[15:05] ~/work/network-flow-monitor-agent % helm upgrade nfm-addon charts/amazon-network-flow-monitor-agent/ \ 
--namespace nfm-addon \
--set image.containerRegistry=XXXXXX.dkr.ecr.eu-west-1.amazonaws.com \
--set image.tag=latest \
--set env.CUSTOM_INGESTION_ENDPOINT="https://my-custom-endpoint.example.com/publish"

[15:06] ~/work/network-flow-monitor-agent % kubectl logs aws-network-flow-monitor-agent-54hmd -n nfm-addon
+ mkdir -p /mnt/cgroup-nfm-agent
+ mount -t cgroup2 none /mnt/cgroup-nfm-agent
+ sysctl -w net.core.rmem_max=12800000
net.core.rmem_max = 12800000
+ cd /usr/local/bin
++ curl -s -X PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds: 600'
+ echo 'Successfully retrieved IMDS Token'
Successfully retrieved IMDS Token
http://169.254.169.254/latest/meta-data/placement/region
+ region=eu-west-1
+ [[ -z eu-west-1 ]]
+ [[ -n https://my-custom-endpoint.example.com/publish ]]
+ endpoint=https://my-custom-endpoint.example.com/publish
+ OPEN_METRICS_ARGS=()
+ [[ '' == \o\n ]]
+ echo -e 'Starting NetworkFlowMonitorAgent with:\n\tendpoint:https://my-custom-endpoint.example.com/publish\n\topen metrics config: '
Starting NetworkFlowMonitorAgent with:
      endpoint:https://my-custom-endpoint.example.com/publish
      open metrics config: 
+ ./nfm-agent --cgroup /mnt/cgroup-nfm-agent --endpoint-region eu-west-1 --endpoint https://my-custom-endpoint.example.com/publish -k on -n on
{"args":{"cgroup":"/mnt/cgroup-nfm-agent","top_k":500,"notrack_secs":65,"usage_data":"on","aggregate_msecs":500,"publish_secs":30,"jitter_secs":5,"endpoint":"https://my-custom-endpoint.example.com/publish","endpoint_region":"eu-west-1","proxy":"","log_reports":"off","publish_reports":"on","report_compression":"gzip","kubernetes_metadata":"on","resolve_nat":"on","open_metrics":"off","open_metrics_port":80,"open_metrics_address":"127.0.0.1"},"level":"INFO","message":"Starting up","target":"nfm_agent","timestamp":1765983938615}
  ```
