### PR TITLE
Add SUSE RPM build and extract version from Cargo.toml

### DIFF
--- a/packaging/linux/create_rpm.sh
+++ b/packaging/linux/create_rpm.sh
@@ -19,6 +19,9 @@ if [[ "$TARGET_ARCH" != "x86_64" && "$TARGET_ARCH" != "aarch64" ]]; then
     exit 1
 fi
 
+AGENT_VERSION=$(grep '^version' nfm-controller/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+echo "Detected agent version: $AGENT_VERSION"
+
 cargo build --release
 
 echo "***********************************************"
@@ -38,10 +41,27 @@ mkdir -p "${BUILD_ROOT}"
 
 rpmbuild -bb \
          --target $TARGET_ARCH \
-         --define "AGENT_VERSION 0.2.1" \
+         --define "AGENT_VERSION ${AGENT_VERSION}" \
          --define "_topdir ${OUT_DIR}/bin/linux/rpmbuild" \
          --define "_sourcedir $(pwd)" \
          --buildroot "${BUILD_ROOT}" \
          "${SPEC_FILE}"
 cp ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*.rpm ${OUT_DIR}/network-flow-monitor-agent.rpm
+rm -rf ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*
+
+echo "***********************************************"
+echo "Creating $TARGET_ARCH rpm file for SUSE"
+echo "***********************************************"
+
+# SUSE RPM
+rpmbuild -bb \
+         --target $TARGET_ARCH \
+         --define "AGENT_VERSION ${AGENT_VERSION}" \
+         --define "_topdir ${OUT_DIR}/bin/linux/rpmbuild" \
+         --define "_sourcedir $(pwd)" \
+         --define "suse_version 1" \
+         --buildroot "${BUILD_ROOT}" \
+         "${SPEC_FILE}"
+
+cp ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*.rpm ${OUT_DIR}/network-flow-monitor-agent.suse.rpm
 rm -rf ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*


### PR DESCRIPTION
### Description

Update the RPM packaging script (packaging/linux/create_rpm.sh) with two 
improvements:

1. SUSE-compatible RPM build — Adds a second rpmbuild step with suse_version defined, 
generating a separate .suse.rpm artifact. SUSE requires libcap-progs instead of the 
standard libcap dependency, so a dedicated build ensures compatibility.

2. Dynamic version extraction — Replaces the hardcoded AGENT_VERSION 0.2.1 with a value 
extracted at build time from nfm-controller/Cargo.toml, keeping the version in a single 
source of truth.

### Changes

- Extract AGENT_VERSION from nfm-controller/Cargo.toml using grep/sed
- Replace hardcoded version 0.2.1 with ${AGENT_VERSION} in the existing rpmbuild call
- Add a new rpmbuild invocation with --define "suse_version 1" for SUSE
- Output the SUSE RPM as network-flow-monitor-agent.suse.rpm

### Testing

- Verified RPM builds successfully for both standard and SUSE targets
- Confirmed the version is correctly extracted from Cargo.toml
