### PR TITLE
Unify RPM packaging to produce a single distro-agnostic package

### DIFF
--- a/packaging/linux/create_rpm.sh
+++ b/packaging/linux/create_rpm.sh
@@ -19,6 +19,9 @@ if [[ "$TARGET_ARCH" != "x86_64" && "$TARGET_ARCH" != "aarch64" ]]; then
     exit 1
 fi
 
+AGENT_VERSION=$(grep '^version' nfm-controller/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+echo "Detected agent version: $AGENT_VERSION"
+
 cargo build --release
 
 echo "***********************************************"
@@ -38,10 +41,27 @@ mkdir -p "${BUILD_ROOT}"
 
 rpmbuild -bb \
          --target $TARGET_ARCH \
-         --define "AGENT_VERSION 0.2.1" \
+         --define "AGENT_VERSION ${AGENT_VERSION}" \
          --define "_topdir ${OUT_DIR}/bin/linux/rpmbuild" \
          --define "_sourcedir $(pwd)" \
          --buildroot "${BUILD_ROOT}" \
          "${SPEC_FILE}"
 cp ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*.rpm ${OUT_DIR}/network-flow-monitor-agent.rpm
+rm -rf ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*
+
+echo "***********************************************"
+echo "Creating $TARGET_ARCH rpm file for SUSE"
+echo "***********************************************"
+
+# SUSE RPM
+rpmbuild -bb \
+         --target $TARGET_ARCH \
+         --define "AGENT_VERSION ${AGENT_VERSION}" \
+         --define "_topdir ${OUT_DIR}/bin/linux/rpmbuild" \
+         --define "_sourcedir $(pwd)" \
+         --define "suse_version 1" \
+         --buildroot "${BUILD_ROOT}" \
+         "${SPEC_FILE}"
+
+cp ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*.rpm ${OUT_DIR}/network-flow-monitor-agent.suse.rpm
 rm -rf ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*

--- a/packaging/linux/create_rpm.sh
+++ b/packaging/linux/create_rpm.sh
@@ -48,20 +48,3 @@ rpmbuild -bb \
          "${SPEC_FILE}"
 cp ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*.rpm ${OUT_DIR}/network-flow-monitor-agent.rpm
 rm -rf ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*
-
-echo "***********************************************"
-echo "Creating $TARGET_ARCH rpm file for SUSE"
-echo "***********************************************"
-
-# SUSE RPM
-rpmbuild -bb \
-         --target $TARGET_ARCH \
-         --define "AGENT_VERSION ${AGENT_VERSION}" \
-         --define "_topdir ${OUT_DIR}/bin/linux/rpmbuild" \
-         --define "_sourcedir $(pwd)" \
-         --define "suse_version 1" \
-         --buildroot "${BUILD_ROOT}" \
-         "${SPEC_FILE}"
-
-cp ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*.rpm ${OUT_DIR}/network-flow-monitor-agent.suse.rpm
-rm -rf ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*

--- a/packaging/linux/network-flow-monitor-agent.spec
+++ b/packaging/linux/network-flow-monitor-agent.spec
@@ -2,11 +2,7 @@ Name:       network-flow-monitor-agent
 Summary:    Network Flow Monitor Agent
 Release:    1
 Version:    %AGENT_VERSION
-%if 0%{?suse_version}
-Requires: libcap-progs, bash
-%else
-Requires: libcap, bash
-%endif
+Requires:   /usr/sbin/setcap, bash
 
 Group:      Amazon/Tools
 License:    Apache License, Version 2.0


### PR DESCRIPTION
## Problem
                                                                                 
The RPM spec used a build-time conditional (`%if 0%{?suse_version}`) to select between `libcap` (RHEL/Amazon Linux) and `libcap-progs` (SUSE) as a runtime dependency. This required building two separate RPMs (`network-flow-monitor-agent.rpm` and `network-flow-monitor-agent.suse.rpm`) from the same source, even though the compiled binary is identical.                                                     
                                                                                 
## Solution                                                                      
                                                                                 
Replace the distro-specific conditional with a file-based dependency on `/usr/sbin/setcap`. RPM's dependency resolver automatically maps this path to the correct package on each distribution:                                                    
- Amazon Linux / RHEL / Fedora → `libcap`                                        
- openSUSE / SLES → `libcap-progs`                                               
                                                                                 
This eliminates the need for a separate SUSE build step in `create_rpm.sh`.      
                                                                                 
## Changes                                                                       
                                                                                 
- `network-flow-monitor-agent.spec`: Replace `%if/%else/%endif` block with `Requires: /usr/sbin/setcap, bash`                                                     
- `create_rpm.sh`: Remove the second `rpmbuild` invocation for SUSE 