### PR TITLE
Unify RPM packaging to produce a single distro-agnostic package

### DIFF
--- a/packaging/linux/create_rpm.sh
+++ b/packaging/linux/create_rpm.sh
@@ -48,20 +48,3 @@ rpmbuild -bb \
          "${SPEC_FILE}"
 cp ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*.rpm ${OUT_DIR}/network-flow-monitor-agent.rpm
 rm -rf ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*
-
-echo "***********************************************"
-echo "Creating $TARGET_ARCH rpm file for SUSE"
-echo "***********************************************"
-
-# SUSE RPM
-rpmbuild -bb \
-         --target $TARGET_ARCH \
-         --define "AGENT_VERSION ${AGENT_VERSION}" \
-         --define "_topdir ${OUT_DIR}/bin/linux/rpmbuild" \
-         --define "_sourcedir $(pwd)" \
-         --define "suse_version 1" \
-         --buildroot "${BUILD_ROOT}" \
-         "${SPEC_FILE}"
-
-cp ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*.rpm ${OUT_DIR}/network-flow-monitor-agent.suse.rpm
-rm -rf ${OUT_DIR}/bin/linux/rpmbuild/RPMS/$TARGET_ARCH/*

--- a/packaging/linux/network-flow-monitor-agent.spec
+++ b/packaging/linux/network-flow-monitor-agent.spec
@@ -2,11 +2,7 @@ Name:       network-flow-monitor-agent
 Summary:    Network Flow Monitor Agent
 Release:    1
 Version:    %AGENT_VERSION
-%if 0%{?suse_version}
-Requires: libcap-progs, bash
-%else
-Requires: libcap, bash
-%endif
+Requires:   /usr/sbin/setcap, bash
 
 Group:      Amazon/Tools
 License:    Apache License, Version 2.0


### PR DESCRIPTION
## Problem
                                                                                 
The RPM spec used a build-time conditional (`%if 0%{?suse_version}`) to select between `libcap` (RHEL/Amazon Linux) and `libcap-progs` (SUSE) as a runtime dependency. This required building two separate RPMs (`network-flow-monitor-agent.rpm` and `network-flow-monitor-agent.suse.rpm`) from the same source, even though the compiled binary is identical.                                                     
                                                                                 
## Solution                                                                      
                                                                                 
Replace the distro-specific conditional with a file-based dependency on `/usr/sbin/setcap`. RPM's dependency resolver automatically maps this path to the correct package on each distribution:                                                    
- Amazon Linux / RHEL / Fedora → `libcap`                                        
- openSUSE / SLES → `libcap-progs`                                               
                                                                                 
This eliminates the need for a separate SUSE build step in `create_rpm.sh`.      
                                                                                 
## Changes                                                                       
                                                                                 
- `network-flow-monitor-agent.spec`: Replace `%if/%else/%endif` block with `Requires: /usr/sbin/setcap, bash`                                                     
- `create_rpm.sh`: Remove the second `rpmbuild` invocation for SUSE 

## Testing                                                                       

### Full installation on EC2 instances                                           
                                                                                 
Tested RPM installation on the following AMIs:                                   
                                                                                 
| Distro | Install command | Result |                                      
|--------|-----------------|--------|                                      
| Amazon Linux 2023 | `sudo dnf -y install /tmp/network-flow-monitor-agent.rpm` | ✅ Installed |                    
| Red Hat | `sudo dnf -y install /tmp/network-flow-monitor-agent.rpm` | ✅ Installed |                                
| SUSE Linux | `sudo zypper -n --no-gpg-checks install /tmp/network-flow-monitor-agent.rpm` | ✅ Installed |                                                  
                                                                                 
On all instances, verified:                                                      
- `rpm -qi network-flow-monitor-agent` — package metadata correct  

> **Note:** On SUSE, `libcap-progs` (which provides `/usr/sbin/setcap`) is not installed by default. During installation, `zypper` automatically detected that `libcap-progs` is the provider of `/usr/sbin/setcap` and installed it as a dependency, confirming that the file-based `Requires` resolves correctly without needing distro-specific conditionals.   

#### Installation logs on AL2

```
Amazon Linux 2023 Kernel Livepatch repository                                                                                                                                                                       199 kB/s |  31 kB     00:00    
Dependencies resolved.
====================================================================================================================================================================================================================================================
 Package                                                                 Architecture                                        Version                                                Repository                                                 Size
====================================================================================================================================================================================================================================================
Installing:
 network-flow-monitor-agent                                              x86_64                                              0.2.3-1                                                @commandline                                              4.8 M

Transaction Summary
====================================================================================================================================================================================================================================================
Install  1 Package

Total size: 4.8 M
Installed size: 19 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                                            1/1 
  Running scriptlet: network-flow-monitor-agent-0.2.3-1.x86_64                                                                                                                                                                                  1/1 
++ cut -d. -f1,2
++ uname -r
+ HOST_KERNEL_VERSION=6.1
++ version 6.1
++ awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
++ echo 6.1
++ version 5.8
++ awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
++ echo 5.8
+ '[' 6001000000 -lt 5008000000 ']'
+ getent group networkflowmonitor-group
+ groupadd -r networkflowmonitor-group
+ getent passwd networkflowmonitor
+ useradd -r -g networkflowmonitor-group -d /opt/aws/network-flow-monitor -s /sbin/nologin networkflowmonitor
+ getent group networkflowmonitor-group
+ getent passwd networkflowmonitor

  Installing       : network-flow-monitor-agent-0.2.3-1.x86_64                                                                                                                                                                                  1/1 
  Running scriptlet: network-flow-monitor-agent-0.2.3-1.x86_64                                                                                                                                                                                  1/1 
creating cgroupv2 mount point
Created symlink /etc/systemd/system/multi-user.target.wants/network-flow-monitor.service → /usr/lib/systemd/system/network-flow-monitor.service.
Network Flow Monitor Agent 0.2.3 installed successfully.

  Verifying        : network-flow-monitor-agent-0.2.3-1.x86_64                                                                                                                                                                                  1/1 

Installed:
  network-flow-monitor-agent-0.2.3-1.x86_64                                                                                                                                                                                                         

Complete!
```

#### Installation logs on Red Hat

```
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use "rhc" or "subscription-manager" to register.

Red Hat Enterprise Linux 10 for x86_64 - AppStream from RHUI (RPMs)                                                                                                                                                  29 MB/s | 4.5 MB     00:00    
Red Hat Enterprise Linux 10 for x86_64 - BaseOS from RHUI (RPMs)                                                                                                                                                     90 MB/s |  52 MB     00:00    
Red Hat Enterprise Linux 10 Client Configuration                                                                                                                                                                     32 kB/s | 2.5 kB     00:00    
Dependencies resolved.
====================================================================================================================================================================================================================================================
 Package                                                                 Architecture                                        Version                                                Repository                                                 Size
====================================================================================================================================================================================================================================================
Installing:
 network-flow-monitor-agent                                              x86_64                                              0.2.3-1                                                @commandline                                              4.8 M

Transaction Summary
====================================================================================================================================================================================================================================================
Install  1 Package

Total size: 4.8 M
Installed size: 19 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                                            1/1 
  Running scriptlet: network-flow-monitor-agent-0.2.3-1.x86_64                                                                                                                                                                                  1/1 
++ uname -r
++ cut -d. -f1,2
+ HOST_KERNEL_VERSION=6.12
++ version 6.12
++ echo 6.12
++ awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
++ version 5.8
++ echo 5.8
++ awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
+ '[' 6012000000 -lt 5008000000 ']'
+ getent group networkflowmonitor-group
+ groupadd -r networkflowmonitor-group
+ getent passwd networkflowmonitor
+ useradd -r -g networkflowmonitor-group -d /opt/aws/network-flow-monitor -s /sbin/nologin networkflowmonitor
+ getent group networkflowmonitor-group
+ getent passwd networkflowmonitor

  Installing       : network-flow-monitor-agent-0.2.3-1.x86_64                                                                                                                                                                                  1/1 
  Running scriptlet: network-flow-monitor-agent-0.2.3-1.x86_64                                                                                                                                                                                  1/1 
creating cgroupv2 mount point
Created symlink '/etc/systemd/system/multi-user.target.wants/network-flow-monitor.service' → '/usr/lib/systemd/system/network-flow-monitor.service'.
Network Flow Monitor Agent 0.2.3 installed successfully.

Installed products updated.

Installed:
  network-flow-monitor-agent-0.2.3-1.x86_64                                                                                                                                                                                                         

Complete!
[ec2-user@ip-172-31-2-143 ~]$ rpm -qi network-flow-monitor-agent
Name        : network-flow-monitor-agent
Version     : 0.2.3
Release     : 1
Architecture: x86_64
Install Date: Mon Mar 30 14:22:03 2026
Group       : Amazon/Tools
Size        : 19605099
License     : Apache License, Version 2.0
Signature   : (none)
Source RPM  : network-flow-monitor-agent-0.2.3-1.src.rpm
Build Date  : Mon Mar 30 14:08:20 2026
Build Host  : ea53bacffb4a
Packager    : Amazon Web Services, Inc. <http://aws.amazon.com>
Vendor      : Amazon Web Services, Inc
URL         : https://github.com/aws/network-flow-monitor-agent
Summary     : Network Flow Monitor Agent
Description :
Installs Network Flow Monitor Agent
```

#### Installation logs on SUSE

```
Refreshing service 'SUSE_Linux_Enterprise_Server_x86_64'.
Retrieving repository 'SLE-Product-SLES-16.0' metadata .......................................................................................................................................................................................[done]
Building repository 'SLE-Product-SLES-16.0' cache ............................................................................................................................................................................................[done]
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 2 NEW packages are going to be installed:
  libcap-progs network-flow-monitor-agent

The following package has no support information from its vendor:
  network-flow-monitor-agent

2 new packages to install.

Package download size:     4.9 MiB

Package install size change:
              |      18.8 MiB  required by packages that will be installed
    18.8 MiB  |  -      0 B    released by packages that will be removed

Backend:  classic_rpmtrans
Continue? [y/n/v/...? shows all options] (y): y
Preloading: libcap-progs-2.73-160000.2.2.x86_64.rpm [done]
Preload finished. [success (15.7 KiB/s) ] ....................................................................................................................................................................................................[done]
Retrieving: libcap-progs-2.73-160000.2.2.x86_64 (SLE-Product-SLES-16.0)                                                                                                                                                         (1/2),  67.6 KiB    
Retrieving: network-flow-monitor-agent-0.2.3-1.x86_64 (Plain RPM files cache)                                                                                                                                                   (2/2),   4.8 MiB    
network-flow-monitor-agent.rpm:
    Package header is not signed!
network-flow-monitor-agent-0.2.3-1.x86_64 (Plain RPM files cache): Signature verification failed [6-File is unsigned]
Accepting package despite the error. (--no-gpg-checks)


Checking for file conflicts: .................................................................................................................................................................................................................[done]
(1/2) Installing: libcap-progs-2.73-160000.2.2.x86_64 ........................................................................................................................................................................................[done]
++ uname -r
++ cut -d. -f1,2
+ HOST_KERNEL_VERSION=6.12
++ version 6.12
++ echo 6.12
++ awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
++ version 5.8
++ echo 5.8
++ awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
+ '[' 6012000000 -lt 5008000000 ']'
+ getent group networkflowmonitor-group
+ groupadd -r networkflowmonitor-group
+ getent passwd networkflowmonitor
+ useradd -r -g networkflowmonitor-group -d /opt/aws/network-flow-monitor -s /sbin/nologin networkflowmonitor
+ getent group networkflowmonitor-group
+ getent passwd networkflowmonitor
creating cgroupv2 mount point
Created symlink '/etc/systemd/system/multi-user.target.wants/network-flow-monitor.service' -> '/usr/lib/systemd/system/network-flow-monitor.service'.
Network Flow Monitor Agent 0.2.3 installed successfully.
(2/2) Installing: network-flow-monitor-agent-0.2.3-1.x86_64 ..................................................................................................................................................................................[done]
Running post-transaction scripts .............................................................................................................................................................................................................[done]
```