### PR TITLE
feat: Add versioning infrastructure and bump to v1.1.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,35 @@
+name: Tag Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - nfm-controller/Cargo.toml
+      - charts/amazon-network-flow-monitor-agent/values.yaml
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create version tags
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+      - name: Create tags
+        run: |
+          VERSION=$(grep '^version' nfm-controller/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          EKSBUILD_TAG=$(grep 'tag:' charts/amazon-network-flow-monitor-agent/values.yaml | head -1 | sed 's/.*tag: *\(v[^ ]*\).*/\1/')
+
+          for TAG in "v${VERSION}" "$EKSBUILD_TAG"; do
+            if git rev-parse "$TAG" >/dev/null 2>&1; then
+              echo "Tag $TAG already exists, skipping"
+            else
+              git tag "$TAG"
+              git push origin "$TAG"
+              echo "Created tag $TAG"
+            fi
+          done

--- a/.github/workflows/version-sync.yaml
+++ b/.github/workflows/version-sync.yaml
@@ -1,0 +1,113 @@
+name: Version Sync
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - nfm-controller/Cargo.toml
+      - charts/amazon-network-flow-monitor-agent/values.yaml
+      - charts/amazon-network-flow-monitor-agent/Chart.yaml
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync eksbuild tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Read versions
+        id: versions
+        run: |
+          CURRENT_CARGO=$(git show origin/main:nfm-controller/Cargo.toml | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/')
+          NEW_CARGO=$(grep '^version' nfm-controller/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+
+          CURRENT_EKS_TAG=$(git show origin/main:charts/amazon-network-flow-monitor-agent/values.yaml | grep 'tag:' | head -1 | sed 's/.*tag: *\(v[^ ]*\).*/\1/')
+          NEW_EKS_TAG=$(grep 'tag:' charts/amazon-network-flow-monitor-agent/values.yaml | head -1 | sed 's/.*tag: *\(v[^ ]*\).*/\1/')
+
+          CURRENT_EKS_BUILD=$(echo "$CURRENT_EKS_TAG" | sed 's/.*-eksbuild\.\(.*\)/\1/')
+          NEW_EKS_BUILD=$(echo "$NEW_EKS_TAG" | sed 's/.*-eksbuild\.\(.*\)/\1/')
+          NEW_EKS_VERSION=$(echo "$NEW_EKS_TAG" | sed 's/^v\(.*\)-eksbuild\..*/\1/')
+
+          CHART_VERSION=$(grep '^version:' charts/amazon-network-flow-monitor-agent/Chart.yaml | head -1 | sed 's/version: *//')
+
+          echo "current-cargo=$CURRENT_CARGO" >> "$GITHUB_OUTPUT"
+          echo "new-cargo=$NEW_CARGO" >> "$GITHUB_OUTPUT"
+          echo "current-eks-tag=$CURRENT_EKS_TAG" >> "$GITHUB_OUTPUT"
+          echo "new-eks-tag=$NEW_EKS_TAG" >> "$GITHUB_OUTPUT"
+          echo "chart-version=$CHART_VERSION" >> "$GITHUB_OUTPUT"
+          echo "current-eks-build=$CURRENT_EKS_BUILD" >> "$GITHUB_OUTPUT"
+          echo "new-eks-build=$NEW_EKS_BUILD" >> "$GITHUB_OUTPUT"
+          echo "new-eks-version=$NEW_EKS_VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$NEW_CARGO" != "$CURRENT_CARGO" ]; then
+            echo "cargo-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "cargo-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Cargo: $NEW_CARGO (main: $CURRENT_CARGO)"
+          echo "EKS tag: $NEW_EKS_TAG (main: $CURRENT_EKS_TAG)"
+          echo "Chart version: $CHART_VERSION"
+
+      - name: Auto-sync on Cargo version change
+        if: steps.versions.outputs.cargo-changed == 'true'
+        run: |
+          CURRENT="${{ steps.versions.outputs.current-cargo }}"
+          NEW="${{ steps.versions.outputs.new-cargo }}"
+
+          if [ "$(printf '%s\n' "$CURRENT" "$NEW" | sort -V | tail -1)" != "$NEW" ]; then
+            echo "ERROR: New version ($NEW) is not greater than current ($CURRENT)"
+            exit 1
+          fi
+
+          NEW_TAG="v${NEW}-eksbuild.1"
+          echo "Updating values.yaml tag to $NEW_TAG and Chart.yaml version to $NEW"
+          sed -i "s|tag: *v[^ ]*|tag: ${NEW_TAG}|" charts/amazon-network-flow-monitor-agent/values.yaml
+          sed -i "s|^version: .*|version: ${NEW}|" charts/amazon-network-flow-monitor-agent/Chart.yaml
+
+          if git diff --quiet; then
+            echo "Already up to date"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add charts/amazon-network-flow-monitor-agent/values.yaml charts/amazon-network-flow-monitor-agent/Chart.yaml
+            git commit -m "chore: Update eksbuild tag to ${NEW_TAG} and chart version to ${NEW}"
+            git push
+          fi
+
+      - name: Validate manual changes
+        if: steps.versions.outputs.cargo-changed == 'false'
+        run: |
+          CARGO="${{ steps.versions.outputs.new-cargo }}"
+          CHART="${{ steps.versions.outputs.chart-version }}"
+          EKS_VERSION="${{ steps.versions.outputs.new-eks-version }}"
+          CURRENT_BUILD="${{ steps.versions.outputs.current-eks-build }}"
+          NEW_BUILD="${{ steps.versions.outputs.new-eks-build }}"
+
+          if [ "$CHART" != "$CARGO" ]; then
+            echo "ERROR: Chart.yaml version ($CHART) != Cargo.toml version ($CARGO)"
+            exit 1
+          fi
+
+          if [ "$EKS_VERSION" != "$CARGO" ]; then
+            echo "ERROR: EKS tag base version ($EKS_VERSION) != Cargo.toml version ($CARGO)"
+            exit 1
+          fi
+
+          if [ "$NEW_BUILD" = "$CURRENT_BUILD" ]; then
+            echo "No eksbuild change, OK"
+            exit 0
+          fi
+
+          EXPECTED=$((CURRENT_BUILD + 1))
+          if [ "$NEW_BUILD" != "$EXPECTED" ]; then
+            echo "ERROR: eksbuild should be $EXPECTED (was $CURRENT_BUILD), got $NEW_BUILD"
+            exit 1
+          fi
+
+          echo "Validation passed"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,46 @@ sudo -E cargo test --features privileged
 ### Distributions
 You can download the official release from our permanent URLs. For more information, refer to [link](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents-download-agent-commandline.html)
 
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/) with tags in the format `vX.Y.Z`:
+
+- `X` (major): Incompatible changes (e.g., breaking config format, removed features)
+- `Y` (minor): New functionality in a backward-compatible manner (e.g., new metrics, new CLI flags)
+- `Z` (patch): Backward-compatible bug fixes and minor improvements
+
+The agent version is defined in `nfm-controller/Cargo.toml` and used by the Rust binary at runtime.
+
+### Release Tags
+
+When the version in `Cargo.toml` is updated on `main`, a GitHub Action automatically creates a `vX.Y.Z` tag.
+EKS releases use separate `vX.Y.Z-eksbuild.N` tags that may point to different commits
+(e.g., helm chart changes without agent code changes).
+
+### Bumping the Version
+
+1. Update the version in `nfm-controller/Cargo.toml`
+2. Merge to `main`
+3. The `tag-release` workflow creates the tag automatically
+
+### Version Sync
+
+The following files are kept in sync automatically via the `version-sync` workflow:
+
+| File | Field | Updated by |
+|---|---|---|
+| `nfm-controller/Cargo.toml` | `version` | Developer (source of truth) |
+| `charts/.../Chart.yaml` | `version` | Auto-synced from Cargo.toml |
+| `charts/.../values.yaml` | `image.tag` | Auto-synced or manual bump |
+
+When `Cargo.toml` version changes in a PR:
+- `Chart.yaml` version is updated automatically
+- `values.yaml` tag is reset to `vX.Y.Z-eksbuild.1`
+
+When only `values.yaml` tag changes (e.g., helm chart fix):
+- The `eksbuild` number must increment by exactly 1
+- The base version must match `Cargo.toml`
+
 ## License
 
 This project is licensed under the Apache 2.0 License.

--- a/charts/amazon-network-flow-monitor-agent/Chart.yaml
+++ b/charts/amazon-network-flow-monitor-agent/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This version needs to increase every time the chart and its templates
 # change. This should follow SemVer.
-version: 1.1.3
+version: 1.1.4
 
 # Keep this in sync with Amazon CloudWatch Network Flow Monitor Agent package version
 # used when building the Docker image

--- a/charts/amazon-network-flow-monitor-agent/Chart.yaml
+++ b/charts/amazon-network-flow-monitor-agent/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 version: 1.1.3
 
 # Keep this in sync with Amazon CloudWatch Network Flow Monitor Agent package version
-# used when building the its Docker image
+# used when building the Docker image
 appVersion: "0.2"
 
 kubeVersion: ">=1.28.0-0"

--- a/charts/amazon-network-flow-monitor-agent/Chart.yaml
+++ b/charts/amazon-network-flow-monitor-agent/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This version needs to increase every time the chart and its templates
 # change. This should follow SemVer.
-version: 1.1.4
+version: 1.1.3
 
 # Keep this in sync with Amazon CloudWatch Network Flow Monitor Agent package version
 # used when building the Docker image

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -1,6 +1,6 @@
 image:
   override: '' # if defined, this value is used as the canonical image name ("{image_repo}{image_name}:{tag}")
-  tag: v1.1.3-eksbuild.3  # this is the default image tag. It might be overwritten at runtime
+  tag: v1.1.3-eksbuild.1  # this is the default image tag. It might be overwritten at runtime
   containerRegistry: '' # this gets overriden at runtime with the correct Docker Image Registry
   name: aws-network-sonar-agent # this determines the ecr folder to look for in the target ecr registry
 

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -1,6 +1,6 @@
 image:
   override: '' # if defined, this value is used as the canonical image name ("{image_repo}{image_name}:{tag}")
-  tag: v1.1.3-eksbuild.1  # this is the default image tag. It might be overwritten at runtime
+  tag: v1.1.4-eksbuild.1  # this is the default image tag. It might be overwritten at runtime
   containerRegistry: '' # this gets overriden at runtime with the correct Docker Image Registry
   name: aws-network-sonar-agent # this determines the ecr folder to look for in the target ecr registry
 

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -1,6 +1,6 @@
 image:
   override: '' # if defined, this value is used as the canonical image name ("{image_repo}{image_name}:{tag}")
-  tag: v1.1.4-eksbuild.1  # this is the default image tag. It might be overwritten at runtime
+  tag: v1.1.3-eksbuild.3  # this is the default image tag. It might be overwritten at runtime
   containerRegistry: '' # this gets overriden at runtime with the correct Docker Image Registry
   name: aws-network-sonar-agent # this determines the ecr folder to look for in the target ecr registry
 

--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nfm-controller"
 description = "network-flow-monitor-agent collects networking performance statistics from the local machine"
-version = "0.2.3"
+version = "1.1.4"
 edition = "2021"
 build = "build.rs"
 license = "Apache-2.0"

--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nfm-controller"
 description = "network-flow-monitor-agent collects networking performance statistics from the local machine"
-version = "1.1.4"
+version = "1.1.3"
 edition = "2021"
 build = "build.rs"
 license = "Apache-2.0"


### PR DESCRIPTION
## Add versioning infrastructure and bump to v1.1.4

### Motivation

The agent version was scattered across multiple files with no automated sync or validation. `Cargo.toml` had `0.2.3`, the CDK pipeline had `0.2.1` hardcoded, and EKS tags were at `v1.1.3`. There was no mechanism to prevent drift or automate tag creation.

### Changes

**Version alignment**
- Bumped `nfm-controller/Cargo.toml` from `0.2.3` to `1.1.3`
- `Chart.yaml` and `values.yaml` will be auto-synced by the `version-sync` workflow

**`tag-release.yaml`** (new workflow)
- Triggers on push to `main` when `Cargo.toml` or `values.yaml` changes
- Creates `vX.Y.Z` and `vX.Y.Z-eksbuild.B` tags automatically
- Skips if tags already exist

**`version-sync.yaml`** (new workflow)
- Triggers on PRs that modify `Cargo.toml`, `values.yaml`, or `Chart.yaml`
- When `Cargo.toml` version changes:
  - Validates new version is greater than current
  - Auto-updates `values.yaml` tag to `vNEW-eksbuild.1`
  - Auto-updates `Chart.yaml` version to match
- When only `values.yaml` changes manually:
  - Validates base version matches `Cargo.toml`
  - Validates `eksbuild` number increments by exactly 1
  - Validates `Chart.yaml` version matches `Cargo.toml`

**`ci.yaml`**
- Added explicit `permissions: contents: read`

**`README.md`**
- Added Versioning section documenting semver conventions, release tags, version bump process, and version sync

### Version Sync Summary

| File | Field | Updated by |
|---|---|---|
| `nfm-controller/Cargo.toml` | `version` | Developer (source of truth) |
| `charts/.../Chart.yaml` | `version` | Auto-synced from Cargo.toml |
| `charts/.../values.yaml` | `image.tag` | Auto-synced or manual bump |