### PR TITLE
make rmem_max configurable and fix pod deletions

### DIFF
--- a/charts/amazon-network-flow-monitor-agent/README.md
+++ b/charts/amazon-network-flow-monitor-agent/README.md
@@ -9,7 +9,7 @@ You can use the publicly available images, or build the agent and upload to your
 ECR_REPO_CONTAINING_NFM_IMAGE="602401143452.dkr.ecr.eu-west-1.amazonaws.com"
 
 #### Set an image tag
-IMAGE_TAG_SUFFIX="v1.1.3-eksbuild.3"
+IMAGE_TAG_SUFFIX="v1.1.3-eksbuild.4"
 IMAGE_TAG="aws-network-sonar-agent:$IMAGE_TAG_SUFFIX"
 
 #### Build Docker image and publish it to your repo (SKIP if using 602401143452 (public ECR))

--- a/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
+++ b/charts/amazon-network-flow-monitor-agent/bin/agent-k8s-install.sh
@@ -16,7 +16,7 @@ VALUES_FILENAME=values.yaml
 PROD_CONTAINER_REGISTRY="602401143452.dkr.ecr.us-west-2.amazonaws.com"
 export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-$PROD_CONTAINER_REGISTRY}
 
-export LATEST_KNOWN_IMAGE_TAG="v1.1.3-eksbuild.3"
+export LATEST_KNOWN_IMAGE_TAG="v1.1.3-eksbuild.4"
 export IMAGE_TAG=${IMAGE_TAG:-$LATEST_KNOWN_IMAGE_TAG}
 
 # Will install 'Amazon CloudWatch Network Flow Monitor Agent' Manifest Files to an existing K8s Cluster

--- a/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
+++ b/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
@@ -43,10 +43,12 @@ spec:
             - -c
             - |
               set -e
-              # Set rmem_max to 12.8MB to hold 10k Netfilter Conntrack Messages
+              # Configure rmem_max and aim to hold more Netfilter Conntrack Messages
               CURRENT=$(sysctl -n net.core.rmem_max)
-              REQUIRED=12800000
+              REQUIRED={{ int .Values.rmemMax }}
               echo "Current rmem_max: $CURRENT"
+              # Save original value for restoration on pod exit
+              echo $CURRENT > /config/rmem_max_original
               if [ "$CURRENT" -lt "$REQUIRED" ]; then
                 sysctl -w net.core.rmem_max=$REQUIRED
                 echo "Updated rmem_max to: $REQUIRED"
@@ -86,7 +88,51 @@ spec:
             - name: cgroup-mount
               mountPath: /cgroup-mount
               mountPropagation: Bidirectional
+            - name: config
+              mountPath: /config
       containers:
+        - name: cleanup
+          # This privileged sidecar exists solely to restore host state on pod termination.
+          # The main container cannot do this because:
+          # 1. sysctl requires SYS_ADMIN or privileged
+          # 2. umount with Bidirectional propagation requires privileged
+          # On SIGTERM it restores rmem_max to its original value and unmounts the cgroup2 filesystem.
+          image: {{ include "aws-network-flow-monitor-agent.image" . }}
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+          command:
+            - sh
+            - -c
+            - |
+              trap '
+                if [ -f /config/rmem_max_original ]; then
+                  ORIGINAL=$(cat /config/rmem_max_original)
+                  echo "Restoring rmem_max to: $ORIGINAL"
+                  sysctl -w net.core.rmem_max=$ORIGINAL && echo "Restored rmem_max" || echo "Failed to restore rmem_max"
+                fi
+                if umount /cgroup-mount/cgroup-nfm-agent; then
+                  echo "Unmounted cgroup"
+                else
+                  echo "Failed to unmount cgroup (may not have been mounted)"
+                fi
+              ' TERM
+              sleep infinity &
+              wait
+          resources:
+            limits:
+              cpu: 10m
+              memory: 16Mi
+            requests:
+              cpu: 1m
+              memory: 8Mi
+          volumeMounts:
+            - name: cgroup-mount
+              mountPath: /cgroup-mount
+              mountPropagation: Bidirectional
+            - name: config
+              mountPath: /config
+              readOnly: true
         - name: {{ .Values.daemonSet.name }}
           image: {{ include "aws-network-flow-monitor-agent.image" . }}
           securityContext:
@@ -139,6 +185,8 @@ spec:
           {{- end }}
       volumes:
         - name: cgroup-mount
+          emptyDir: {}
+        - name: config
           emptyDir: {}
       {{- if .Values.caCerts.enabled }}
         - name: ca-bundle

--- a/charts/amazon-network-flow-monitor-agent/values.yaml
+++ b/charts/amazon-network-flow-monitor-agent/values.yaml
@@ -1,6 +1,6 @@
 image:
   override: '' # if defined, this value is used as the canonical image name ("{image_repo}{image_name}:{tag}")
-  tag: v1.1.3-eksbuild.3  # this is the default image tag. It might be overwritten at runtime
+  tag: v1.1.3-eksbuild.4  # this is the default image tag. It might be overwritten at runtime
   containerRegistry: '' # this gets overriden at runtime with the correct Docker Image Registry
   name: aws-network-sonar-agent # this determines the ecr folder to look for in the target ecr registry
 
@@ -52,6 +52,12 @@ caCerts:
   mountPath: "/etc/ssl/certs"
   # File name in the container for the CA certificate bundle
   fileName: "ca-bundle.crt"
+
+# Used to set maximum possible receive buffer allowed for all networking protocols.
+# Value of 12800000 will provide room for 10k NetFilter Conntrack event messages
+# Lesser values are also acceptable but might reduce NFM Agent NAT resolution precision, especially on very high throughput (>50k new tcp conn persec) hosts.
+# Which might result in Kubernetes internal IPs (such as cluster-ip of services) to appear in flow reports (because of them not being un-NATed).
+rmemMax: 12800000
 
 resources:
   limits:


### PR DESCRIPTION
*Issue #, if available:*
Internally reported issue about EKS NFM pods are not deleting on addon deletion.

after inspection i realized that after our change to move cgroup creation to init container, the main container is not privileged anymore to umount this created cgroup. which prevents pod deletion and makes them stuck indefinitely in error state.

theres two ways to approach this:
1. grant privileged permissions to main container to handle deletion with preStop hook [absolute no-go, defeats the purpose of init container in the first place]
2. create a privileged sidecar that automatically umounts the cgroup on pod deletion. [selected]


*Description of changes:*
1. allowing rmem_max value to be configured
2. storing current rmem_max of the host in init container.
3. creating a sidecar container that will sleep indefinitely until container deletion, and at that time it will umount the cgroup and restore the rmem_max to original value.


testing:
following https://github.com/aws/network-flow-monitor-agent/blob/main/charts/amazon-network-flow-monitor-agent/README.md
1. installed helm chart. observed nfm cgroup presence, and rmem_max change
2. removed the cart, observed nfm cgroup disappearing, and rmem_max returning to default:
```
[root@ip-192-168-91-113 bin]# sysctl -w net.core.rmem_max=2000000
net.core.rmem_max = 2000000
[root@ip-192-168-91-113 bin]# mount | grep cgroup-nfm
... helm installed here
[root@ip-192-168-91-113 bin]# mount | grep cgroup-nfm
none on /var/lib/kubelet/pods/a652f518-f1be-405b-9ad7-bd028266abae/volumes/kubernetes.io~empty-dir/cgroup-mount/cgroup-nfm-agent type cgroup2 (rw,relatime,seclabel)
[root@ip-192-168-91-113 bin]# sysctl -n net.core.rmem_max
12800000
... helm removed here
[root@ip-192-168-91-113 bin]# sysctl -n net.core.rmem_max
2000000
[root@ip-192-168-91-113 bin]# mount | grep cgroup-nfm
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
