### PR TITLE
remove cgroupv2 creation requirement from k8s

### DIFF
--- a/charts/amazon-network-flow-monitor-agent/bin/entrypoint.sh
+++ b/charts/amazon-network-flow-monitor-agent/bin/entrypoint.sh
@@ -5,11 +5,14 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
-# Get cgroupv2 mount created by the init container
-CGROUP_PATH="/cgroup-mount/cgroup-nfm-agent"
-
-if [[ -z "$CGROUP_PATH" ]]; then
-    echo "ERROR: No cgroupv2 mount found. The cgroupv2 must have been mounted from init container by now on $CGROUP_PATH."
+# Auto-detect cgroupv2 path from host mount. Cgroupv2 is default since kubernetes 1.25 (covers all NFM supported versions)
+# So it must be readily available on the host.
+if [[ $(stat -fc %T /host-cgroup 2>/dev/null) == "cgroup2fs" ]]; then
+    CGROUP_PATH="/host-cgroup"
+elif [[ $(stat -fc %T /host-cgroup/unified 2>/dev/null) == "cgroup2fs" ]]; then
+    CGROUP_PATH="/host-cgroup/unified"
+else
+    echo "ERROR: No cgroupv2 filesystem found at /sys/fs/cgroup or /sys/fs/cgroup/unified."
     exit 1
 fi
 

--- a/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
+++ b/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
@@ -55,87 +55,15 @@ spec:
               else
                 echo "rmem_max "$CURRENT" is already sufficient, keeping current value"
               fi
-
-              check_cgroupv2() {
-                local path="$1"
-                if ! mountpoint -q "$path" 2>/dev/null; then
-                  return 1
-                fi
-                local fs_type=$(stat -fc %T "$path" 2>/dev/null || echo "unknown")
-                if [ "$fs_type" = "cgroup2fs" ]; then
-                  return 0
-                fi
-                return 1
-              }
-
-              # Mount /cgroup-mount/cgroup-nfm-agent
-              CGROUP_PATH="/cgroup-mount/cgroup-nfm-agent"
-              mkdir -p "$CGROUP_PATH"
-
-              if check_cgroupv2 "$CGROUP_PATH"; then
-                echo "Found cgroupv2 at: $CGROUP_PATH. Will use that"
-                exit 0
-              fi
-
-              # Mount cgroupv2 on /cgroup-mount/cgroup-nfm-agent
-              if ! mount -t cgroup2 none "$CGROUP_PATH"; then
-                echo "ERROR: Failed to mount cgroupv2 at $CGROUP_PATH. NFM agent requires cgroupv2 support."
-                exit 1
-              fi
-
-              echo "Mounted cgroupv2 at: $CGROUP_PATH"
           volumeMounts:
-            - name: cgroup-mount
-              mountPath: /cgroup-mount
-              mountPropagation: Bidirectional
             - name: config
               mountPath: /config
       containers:
-        - name: cleanup
-          # This privileged sidecar exists solely to restore host state on pod termination.
-          # The main container cannot do this because:
-          # 1. sysctl requires SYS_ADMIN or privileged
-          # 2. umount with Bidirectional propagation requires privileged
-          # On SIGTERM it restores rmem_max to its original value and unmounts the cgroup2 filesystem.
-          image: {{ include "aws-network-flow-monitor-agent.image" . }}
-          securityContext:
-            privileged: true
-            readOnlyRootFilesystem: true
-          command:
-            - sh
-            - -c
-            - |
-              trap '
-                if [ -f /config/rmem_max_original ]; then
-                  ORIGINAL=$(cat /config/rmem_max_original)
-                  echo "Restoring rmem_max to: $ORIGINAL"
-                  sysctl -w net.core.rmem_max=$ORIGINAL && echo "Restored rmem_max" || echo "Failed to restore rmem_max"
-                fi
-                if umount /cgroup-mount/cgroup-nfm-agent; then
-                  echo "Unmounted cgroup"
-                else
-                  echo "Failed to unmount cgroup (may not have been mounted)"
-                fi
-              ' TERM
-              sleep infinity &
-              wait
-          resources:
-            limits:
-              cpu: 10m
-              memory: 16Mi
-            requests:
-              cpu: 1m
-              memory: 8Mi
-          volumeMounts:
-            - name: cgroup-mount
-              mountPath: /cgroup-mount
-              mountPropagation: Bidirectional
-            - name: config
-              mountPath: /config
-              readOnly: true
         - name: {{ .Values.daemonSet.name }}
           image: {{ include "aws-network-flow-monitor-agent.image" . }}
           securityContext:
+            seLinuxOptions:
+              type: control_t
             capabilities:
               add:
                 - BPF
@@ -178,18 +106,50 @@ spec:
               value: {{ .Values.caCerts.mountPath }}/{{ .Values.caCerts.fileName }}
             {{- end }}
           volumeMounts:
-            - name: cgroup-mount
-              mountPath: /cgroup-mount
-              mountPropagation: HostToContainer
+            - name: host-cgroup
+              mountPath: /host-cgroup
+              readOnly: true
           {{- if .Values.caCerts.enabled }}
             - name: ca-bundle
               mountPath: {{ .Values.caCerts.mountPath }}/{{ .Values.caCerts.fileName }}
               subPath: {{ .Values.caCerts.fileName }}
               readOnly: true
           {{- end }}
+        - name: cleanup
+          # Restores net.core.rmem_max on pod termination.
+          image: {{ include "aws-network-flow-monitor-agent.image" . }}
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+          command:
+            - sh
+            - -c
+            - |
+              trap '
+                if [ -f /config/rmem_max_original ]; then
+                  ORIGINAL=$(cat /config/rmem_max_original)
+                  echo "Restoring rmem_max to: $ORIGINAL"
+                  sysctl -w net.core.rmem_max=$ORIGINAL && echo "Restored rmem_max" || echo "Failed to restore rmem_max"
+                fi
+              ' TERM
+              sleep infinity &
+              wait
+          resources:
+            limits:
+              cpu: 10m
+              memory: 16Mi
+            requests:
+              cpu: 1m
+              memory: 8Mi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
       volumes:
-        - name: cgroup-mount
-          emptyDir: {}
+        - name: host-cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
         - name: config
           emptyDir: {}
       {{- if .Values.caCerts.enabled }}
@@ -204,7 +164,7 @@ spec:
       {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 30
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}


### PR DESCRIPTION
*Issue #, if available:*
Creating a separate cgroupv2 for bottlerocket kubernetes nodes are tampering with how containerd propagates root cgroup '/sys/fs/cgroup' to new pods, potentially bind mounting nfm-created cgroupv2, breaking other applications that read from '/sys/fs/cgroup'.

*Description of changes:*
Removing cgroupv2 creation altogether from kubernetes context. cgroupv2 is default since kubernetes 1.25, which predates earliest nfm supported version. Meaning all the kubernetes nodes NFM would run on must have a cgroupv2 mount already present. Agent will use those mounts.

### Testing
- Create/delete tests on AL2023/bottlerocket. No residues on mounts
- Verified that no visibility is lost. pod<>pod traffic from both hostns and non-hostns services are still visible


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
