### PR TITLE
Add multi-distro integration tests workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,608 @@
+# Multi-distro integration tests on EC2 instances via SSM.
+# Builds the agent on Amazon Linux 2 (x86_64 and ARM64) — same as the production
+# S3Release pipeline — then distributes pre-built binaries to test instances.
+name: Integration Tests (Multi-Distro)
+
+on:
+  workflow_dispatch:
+    inputs:
+      distros:
+        description: 'Comma-separated distro names to test (empty = all)'
+        required: false
+        type: string
+        default: ''
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'nfm-controller/**'
+      - 'nfm-bpf/**'
+      - 'packaging/**'
+      - '.github/workflows/integration-tests.yml'
+
+concurrency:
+  group: integration-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  # Build the agent on Amazon Linux 2 instances — one per architecture.
+  # This replicates the production S3Release pipeline (CodeBuild on AL2).
+  # AL2 has GLIBC 2.26, ensuring binaries are compatible with all supported distros.
+  build:
+    name: Build (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            ami_filter: "amzn2-ami-kernel-5.10-hvm-*-x86_64-gp2"
+            instance_type: c5.xlarge
+          - arch: arm64
+            ami_filter: "amzn2-ami-kernel-5.10-hvm-*-arm64-gp2"
+            instance_type: c7g.xlarge
+    outputs:
+      s3-prefix: ${{ steps.upload.outputs.s3-prefix }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.PR_PERF_TEST_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PR_PERF_TEST_AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Upload source to S3
+        id: upload
+        run: |
+          S3_PREFIX="integration-tests/${{ github.run_id }}/${{ github.run_attempt }}"
+          echo "s3-prefix=${S3_PREFIX}" >> "$GITHUB_OUTPUT"
+
+          BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
+
+          tar czf /tmp/nfm-source.tar.gz \
+            --exclude='.git' \
+            --exclude='target' \
+            --exclude='out' \
+            .
+
+          aws s3 cp /tmp/nfm-source.tar.gz \
+            "s3://${BUCKET}/${S3_PREFIX}/nfm-source.tar.gz"
+
+      - name: Create build instance
+        id: ec2
+        run: |
+          REGION="${{ secrets.PR_PERF_TEST_AWS_REGION }}"
+          INSTANCE_ROLE="${{ secrets.PR_PERF_TEST_INSTANCE_ROLE }}"
+
+          AMI_ID=$(aws ec2 describe-images \
+            --owners amazon \
+            --filters "Name=name,Values=${{ matrix.ami_filter }}" "Name=state,Values=available" \
+            --query 'Images | sort_by(@, &CreationDate) | [-1].ImageId' \
+            --output text \
+            --region "$REGION")
+
+          INSTANCE_ID=$(aws ec2 run-instances \
+            --image-id "$AMI_ID" \
+            --count 1 \
+            --instance-type ${{ matrix.instance_type }} \
+            --iam-instance-profile "Name=${INSTANCE_ROLE}" \
+            --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]' \
+            --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=nfm-build-${{ matrix.arch }}-${{ github.run_id }}},{Key=Purpose,Value=integration-testing}]" \
+            --query 'Instances[0].InstanceId' \
+            --output text \
+            --region "$REGION")
+
+          echo "instance-id=${INSTANCE_ID}" >> "$GITHUB_OUTPUT"
+          echo "SSM_INSTANCE_ID=${INSTANCE_ID}" >> "$GITHUB_ENV"
+          echo "SSM_REGION=${REGION}" >> "$GITHUB_ENV"
+          echo "Created build instance: ${INSTANCE_ID} (${{ matrix.instance_type }})"
+
+      - name: Wait for SSM readiness
+        run: |
+          INSTANCE_ID="${{ steps.ec2.outputs.instance-id }}"
+          aws ec2 wait instance-running --instance-ids "$INSTANCE_ID" --region "$SSM_REGION"
+
+          TIMEOUT=180
+          ELAPSED=0
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            READY=$(aws ssm describe-instance-information \
+              --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
+              --query 'length(InstanceInformationList)' \
+              --output text \
+              --region "$SSM_REGION" 2>/dev/null || echo "0")
+            if [ "$READY" = "1" ]; then echo "SSM ready after ${ELAPSED}s"; break; fi
+            sleep 10; ELAPSED=$((ELAPSED + 10))
+          done
+          if [ $ELAPSED -ge $TIMEOUT ]; then echo "::error::SSM timeout"; exit 1; fi
+
+      - name: Create SSM helper
+        run: |
+          echo '#!/bin/bash' > /tmp/run-ssm.sh
+          cat >> /tmp/run-ssm.sh <<'HELPER'
+            set -o errexit
+            set -o pipefail
+            set -o nounset
+            INSTANCE_ID="${SSM_INSTANCE_ID:?SSM_INSTANCE_ID not set}"
+            REGION="${SSM_REGION:?SSM_REGION not set}"
+            TIMEOUT="$1"; shift; COMMAND="$*"
+            COMMAND_ID=$(aws ssm send-command \
+              --instance-ids "$INSTANCE_ID" \
+              --document-name "AWS-RunShellScript" \
+              --parameters "{\"commands\":[$(echo "$COMMAND" | jq -Rs .)],\"executionTimeout\":[\"${TIMEOUT}\"]}" \
+              --timeout-seconds "$TIMEOUT" \
+              --output text --query 'Command.CommandId' --region "$REGION")
+            ELAPSED=0
+            while [ $ELAPSED -lt $TIMEOUT ]; do
+              STATUS=$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+                --query 'Status' --output text --region "$REGION" 2>/dev/null || echo "Pending")
+              case "$STATUS" in
+                Success) aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+                  --query 'StandardOutputContent' --output text --region "$REGION"; exit 0 ;;
+                Failed|Cancelled|TimedOut)
+                  echo "::error::SSM command failed ($STATUS)"
+                  aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+                    --query 'StandardOutputContent' --output text --region "$REGION" || true
+                  echo "=== STDERR ==="
+                  aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+                    --query 'StandardErrorContent' --output text --region "$REGION" || true
+                  exit 1 ;;
+                *) printf "."; sleep 10; ELAPSED=$((ELAPSED + 10)) ;;
+              esac
+            done
+            echo ""; echo "::error::Timeout after ${TIMEOUT}s"; exit 1
+          HELPER
+          chmod +x /tmp/run-ssm.sh
+
+      - name: Build agent and create RPM
+        run: |
+          BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
+          S3_PREFIX="${{ steps.upload.outputs.s3-prefix }}"
+
+          /tmp/run-ssm.sh 900 "bash -c '
+            set -e
+            export HOME=/root
+
+            yum update -y
+            yum install -y gcc git cmake rpm-build awscli
+            curl --proto \"=https\" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            . /root/.cargo/env
+
+            mkdir -p /tmp/nfm-build && cd /tmp/nfm-build
+            aws s3 cp s3://${BUCKET}/${S3_PREFIX}/nfm-source.tar.gz ./nfm-source.tar.gz
+            tar xzf nfm-source.tar.gz
+
+            ./packaging/linux/create_rpm.sh
+
+            echo \"=== Build complete ===\"
+            ls -la target/release/network-flow-monitor-agent
+            ls -la out/network-flow-monitor-agent.rpm
+
+            echo \"=== Uploading artifacts ===\"
+            aws s3 cp target/release/network-flow-monitor-agent s3://${BUCKET}/${S3_PREFIX}/${{ matrix.arch }}/network-flow-monitor-agent
+            aws s3 cp out/network-flow-monitor-agent.rpm s3://${BUCKET}/${S3_PREFIX}/${{ matrix.arch }}/network-flow-monitor-agent.rpm
+          '"
+
+      - name: Upload test scripts to S3
+        run: |
+          BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
+          S3_PREFIX="${{ steps.upload.outputs.s3-prefix }}"
+
+          # Only upload once (from x86_64 job)
+          if [ "${{ matrix.arch }}" = "x86_64" ]; then
+            aws s3 cp test-data/ec2-test-scripts/ \
+              "s3://${BUCKET}/${S3_PREFIX}/ec2-test-scripts/" --recursive
+            aws s3 cp test-data/integration-test-01-basic \
+              "s3://${BUCKET}/${S3_PREFIX}/test-scripts/integration-test-01-basic"
+            aws s3 cp test-data/tools/test_common.py \
+              "s3://${BUCKET}/${S3_PREFIX}/test-scripts/test_common.py"
+          fi
+
+      - name: Terminate build instance
+        if: always()
+        run: |
+          if [ -n "${SSM_INSTANCE_ID:-}" ]; then
+            aws ec2 terminate-instances --instance-ids "$SSM_INSTANCE_ID" --region "$SSM_REGION" || true
+            echo "Terminated build instance: ${SSM_INSTANCE_ID}"
+          fi
+
+  test:
+    name: Test ${{ matrix.distro }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Matrix strategy: one parallel job per distro/kernel/arch combination.
+    # Each job downloads the pre-built binary for its architecture, installs it,
+    # and runs the integration test suite. No compilation happens here.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # --- Amazon Linux (RPM, yum) ---
+          - distro: al2-x86_64
+            ami_filter: "amzn2-ami-kernel-5.10-hvm-*-x86_64-gp2"
+            ami_owner: "amazon"
+            pkg_manager: "yum"
+            pkg_type: "rpm"
+            arch: x86_64
+            instance_type: t3.medium
+
+          - distro: al2-arm64
+            ami_filter: "amzn2-ami-kernel-5.10-hvm-*-arm64-gp2"
+            ami_owner: "amazon"
+            pkg_manager: "yum"
+            pkg_type: "rpm"
+            arch: arm64
+            instance_type: t4g.medium
+
+          - distro: al2023-kernel6.1-x86_64
+            ami_filter: "al2023-ami-*-kernel-6.1-x86_64"
+            ami_owner: "amazon"
+            pkg_manager: "yum"
+            pkg_type: "rpm"
+            arch: x86_64
+            instance_type: t3.medium
+
+          - distro: al2023-kernel6.1-arm64
+            ami_filter: "al2023-ami-*-kernel-6.1-arm64"
+            ami_owner: "amazon"
+            pkg_manager: "yum"
+            pkg_type: "rpm"
+            arch: arm64
+            instance_type: t4g.medium
+
+          - distro: al2023-kernel6.12-x86_64
+            ami_filter: "al2023-ami-*-kernel-6.12-x86_64"
+            ami_owner: "amazon"
+            pkg_manager: "yum"
+            pkg_type: "rpm"
+            arch: x86_64
+            instance_type: t3.medium
+
+          # --- RHEL (RPM, dnf) ---
+          - distro: rhel9-x86_64
+            ami_filter: "RHEL-9.*_HVM-*-x86_64-*"
+            ami_owner: "309956199498"
+            pkg_manager: "dnf"
+            pkg_type: "rpm"
+            arch: x86_64
+            instance_type: t3.medium
+
+          - distro: rhel9-arm64
+            ami_filter: "RHEL-9.*_HVM-*-arm64-*"
+            ami_owner: "309956199498"
+            pkg_manager: "dnf"
+            pkg_type: "rpm"
+            arch: arm64
+            instance_type: t4g.medium
+
+          # --- SUSE (RPM, zypper) — no ARM64 ECS AMI available ---
+          - distro: suse15-sp6-x86_64
+            ami_filter: "suse-sles-15-sp6-v*-ecs-hvm-ssd-x86_64"
+            ami_owner: "amazon"
+            pkg_manager: "zypper"
+            pkg_type: "rpm"
+            arch: x86_64
+            instance_type: t3.medium
+
+          # --- Debian (binary install, apt) ---
+          - distro: debian11-x86_64
+            ami_filter: "debian-11-amd64-*"
+            ami_owner: "136693071363"
+            pkg_manager: "apt"
+            pkg_type: "binary"
+            arch: x86_64
+            instance_type: t3.medium
+
+          - distro: debian12-x86_64
+            ami_filter: "debian-12-amd64-*"
+            ami_owner: "136693071363"
+            pkg_manager: "apt"
+            pkg_type: "binary"
+            arch: x86_64
+            instance_type: t3.medium
+
+          - distro: debian12-arm64
+            ami_filter: "debian-12-arm64-*"
+            ami_owner: "136693071363"
+            pkg_manager: "apt"
+            pkg_type: "binary"
+            arch: arm64
+            instance_type: t4g.medium
+
+          # --- Ubuntu (binary install, apt) ---
+          - distro: ubuntu2204-x86_64
+            ami_filter: "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+            ami_owner: "099720109477"
+            pkg_manager: "apt"
+            pkg_type: "binary"
+            arch: x86_64
+            instance_type: t3.medium
+
+          - distro: ubuntu2204-arm64
+            ami_filter: "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"
+            ami_owner: "099720109477"
+            pkg_manager: "apt"
+            pkg_type: "binary"
+            arch: arm64
+            instance_type: t4g.medium
+
+          - distro: ubuntu2404-x86_64
+            ami_filter: "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
+            ami_owner: "099720109477"
+            pkg_manager: "apt"
+            pkg_type: "binary"
+            arch: x86_64
+            instance_type: t3.medium
+
+          - distro: ubuntu2404-arm64
+            ami_filter: "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"
+            ami_owner: "099720109477"
+            pkg_manager: "apt"
+            pkg_type: "binary"
+            arch: arm64
+            instance_type: t4g.medium
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.PR_PERF_TEST_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PR_PERF_TEST_AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Resolve AMI
+        id: ami
+        run: |
+          AMI_ID=$(aws ec2 describe-images \
+            --owners "${{ matrix.ami_owner }}" \
+            --filters "Name=name,Values=${{ matrix.ami_filter }}" "Name=state,Values=available" \
+            --query 'Images | sort_by(@, &CreationDate) | [-1].ImageId' \
+            --output text \
+            --region "${{ secrets.PR_PERF_TEST_AWS_REGION }}")
+
+          if [ "$AMI_ID" = "None" ] || [ -z "$AMI_ID" ]; then
+            echo "::error::No AMI found for filter: ${{ matrix.ami_filter }}"
+            exit 1
+          fi
+          echo "ami-id=${AMI_ID}" >> "$GITHUB_OUTPUT"
+          echo "Resolved AMI: ${AMI_ID} for ${{ matrix.distro }}"
+
+      - name: Create EC2 instance
+        id: ec2
+        run: |
+          REGION="${{ secrets.PR_PERF_TEST_AWS_REGION }}"
+          INSTANCE_ROLE="${{ secrets.PR_PERF_TEST_INSTANCE_ROLE }}"
+          PKG_MANAGER="${{ matrix.pkg_manager }}"
+
+          # Build UserData based on pkg_manager to install SSM agent
+          if [ "$PKG_MANAGER" = "apt" ]; then
+            USER_DATA="#!/bin/bash
+              set -e
+              if ! systemctl is-active --quiet amazon-ssm-agent 2>/dev/null; then
+                cd /tmp
+                ARCH=\$(dpkg --print-architecture)
+                curl -sSLo amazon-ssm-agent.deb https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_\${ARCH}/amazon-ssm-agent.deb
+                dpkg -i amazon-ssm-agent.deb
+                systemctl enable amazon-ssm-agent
+                systemctl start amazon-ssm-agent
+              fi"
+          elif [ "$PKG_MANAGER" = "zypper" ]; then
+            USER_DATA="#!/bin/bash
+              set -e
+              if ! systemctl is-active --quiet amazon-ssm-agent 2>/dev/null; then
+                zypper install -y curl wget 2>/dev/null || true
+                zypper install -y amazon-ssm-agent 2>/dev/null || {
+                  cd /tmp
+                  curl -sSLo amazon-ssm-agent.rpm https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm \
+                    || wget -q -O amazon-ssm-agent.rpm https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+                  rpm -ivh amazon-ssm-agent.rpm
+                }
+                systemctl enable amazon-ssm-agent
+                systemctl start amazon-ssm-agent
+              fi"
+          elif [ "$PKG_MANAGER" = "dnf" ]; then
+            # Determine SSM agent arch for download URL
+            if [ "${{ matrix.arch }}" = "arm64" ]; then
+              SSM_ARCH="linux_arm64"
+            else
+              SSM_ARCH="linux_amd64"
+            fi
+            USER_DATA="#!/bin/bash
+              set -e
+              dnf install -y amazon-ssm-agent 2>/dev/null || {
+                cd /tmp
+                dnf install -y curl
+                curl -sSLo amazon-ssm-agent.rpm https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/${SSM_ARCH}/amazon-ssm-agent.rpm
+                rpm -ivh amazon-ssm-agent.rpm
+              }
+              systemctl enable amazon-ssm-agent
+              systemctl start amazon-ssm-agent"
+          else
+            USER_DATA="#!/bin/bash"
+          fi
+
+          INSTANCE_ID=$(aws ec2 run-instances \
+            --image-id "${{ steps.ami.outputs.ami-id }}" \
+            --count 1 \
+            --instance-type ${{ matrix.instance_type }} \
+            --iam-instance-profile "Name=${INSTANCE_ROLE}" \
+            --user-data "$USER_DATA" \
+            --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=nfm-integ-${{ matrix.distro }}-${{ github.run_id }}},{Key=Purpose,Value=integration-testing},{Key=GitHubRunId,Value=${{ github.run_id }}}]" \
+            --query 'Instances[0].InstanceId' \
+            --output text \
+            --region "$REGION")
+
+          echo "instance-id=${INSTANCE_ID}" >> "$GITHUB_OUTPUT"
+          echo "SSM_INSTANCE_ID=${INSTANCE_ID}" >> "$GITHUB_ENV"
+          echo "SSM_REGION=${REGION}" >> "$GITHUB_ENV"
+          echo "Created instance: ${INSTANCE_ID} (${{ matrix.instance_type }})"
+
+      - name: Wait for instance + SSM readiness
+        run: |
+          INSTANCE_ID="${{ steps.ec2.outputs.instance-id }}"
+          aws ec2 wait instance-running --instance-ids "$INSTANCE_ID" --region "$SSM_REGION"
+
+          TIMEOUT=300
+          ELAPSED=0
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            READY=$(aws ssm describe-instance-information \
+              --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
+              --query 'length(InstanceInformationList)' \
+              --output text --region "$SSM_REGION" 2>/dev/null || echo "0")
+            if [ "$READY" = "1" ]; then echo "Instance is SSM-ready after ${ELAPSED}s"; break; fi
+            sleep 10; ELAPSED=$((ELAPSED + 10))
+          done
+          if [ $ELAPSED -ge $TIMEOUT ]; then echo "::error::Timeout waiting for SSM"; exit 1; fi
+
+      - name: Create SSM helper
+        run: |
+          echo '#!/bin/bash' > /tmp/run-ssm.sh
+          cat >> /tmp/run-ssm.sh <<'HELPER'
+            set -o errexit
+            set -o pipefail
+            set -o nounset
+            INSTANCE_ID="${SSM_INSTANCE_ID:?SSM_INSTANCE_ID not set}"
+            REGION="${SSM_REGION:?SSM_REGION not set}"
+            TIMEOUT="$1"; shift; COMMAND="$*"
+            COMMAND_ID=$(aws ssm send-command \
+              --instance-ids "$INSTANCE_ID" \
+              --document-name "AWS-RunShellScript" \
+              --parameters "{\"commands\":[$(echo "$COMMAND" | jq -Rs .)],\"executionTimeout\":[\"${TIMEOUT}\"]}" \
+              --timeout-seconds "$TIMEOUT" \
+              --output text --query 'Command.CommandId' --region "$REGION")
+            ELAPSED=0
+            while [ $ELAPSED -lt $TIMEOUT ]; do
+              STATUS=$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+                --query 'Status' --output text --region "$REGION" 2>/dev/null || echo "Pending")
+              case "$STATUS" in
+                Success) aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+                  --query 'StandardOutputContent' --output text --region "$REGION"; exit 0 ;;
+                Failed|Cancelled|TimedOut)
+                  echo "::error::SSM command failed ($STATUS)"
+                  aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+                    --query 'StandardOutputContent' --output text --region "$REGION" || true
+                  echo "=== STDERR ==="
+                  aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+                    --query 'StandardErrorContent' --output text --region "$REGION" || true
+                  exit 1 ;;
+                *) printf "."; sleep 10; ELAPSED=$((ELAPSED + 10)) ;;
+              esac
+            done
+            echo ""; echo "::error::Timeout after ${TIMEOUT}s"; exit 1
+          HELPER
+          chmod +x /tmp/run-ssm.sh
+
+      - name: Download artifacts and install agent
+        run: |
+          BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
+          S3_PREFIX="${{ needs.build.outputs.s3-prefix }}"
+          ARCH="${{ matrix.arch }}"
+          PKG_TYPE="${{ matrix.pkg_type }}"
+          PKG_MANAGER="${{ matrix.pkg_manager }}"
+
+          /tmp/run-ssm.sh 300 "bash -c '
+            set -e
+
+            # Install AWS CLI and dependencies if not present
+            if ! command -v aws &>/dev/null; then
+              case ${PKG_MANAGER} in
+                dnf)
+                  rm -rf /var/cache/dnf/*
+                  dnf makecache
+                  dnf install -y --allowerasing awscli python3 libcap
+                  ;;
+                zypper)
+                  zypper install -y aws-cli curl libcap-progs
+                  ;;
+                apt)
+                  apt-get update
+                  apt-get install -y curl unzip libcap2-bin python3
+                  curl -sSL https://awscli.amazonaws.com/awscli-exe-linux-\$(uname -m).zip -o /tmp/awscliv2.zip
+                  unzip -q /tmp/awscliv2.zip -d /tmp
+                  /tmp/aws/install
+                  rm -rf /tmp/awscliv2.zip /tmp/aws
+                  ;;
+              esac
+            else
+              # Ensure setcap is available even if aws cli was pre-installed
+              case ${PKG_MANAGER} in
+                zypper) zypper install -y libcap-progs 2>/dev/null || true ;;
+                apt) apt-get update && apt-get install -y libcap2-bin 2>/dev/null || true ;;
+                dnf) dnf install -y libcap 2>/dev/null || true ;;
+              esac
+            fi
+
+            mkdir -p /tmp/nfm-artifacts /tmp/nfm-build/test-data/ec2-test-scripts /tmp/nfm-build/test-data/tools
+
+            aws s3 cp s3://${BUCKET}/${S3_PREFIX}/${ARCH}/network-flow-monitor-agent /tmp/nfm-artifacts/
+            aws s3 cp s3://${BUCKET}/${S3_PREFIX}/${ARCH}/network-flow-monitor-agent.rpm /tmp/nfm-artifacts/ || true
+            aws s3 cp s3://${BUCKET}/${S3_PREFIX}/ec2-test-scripts/ /tmp/nfm-build/test-data/ec2-test-scripts/ --recursive
+            aws s3 cp s3://${BUCKET}/${S3_PREFIX}/test-scripts/integration-test-01-basic /tmp/nfm-build/test-data/integration-test-01-basic
+            aws s3 cp s3://${BUCKET}/${S3_PREFIX}/test-scripts/test_common.py /tmp/nfm-build/test-data/tools/test_common.py
+
+            chmod +x /tmp/nfm-artifacts/network-flow-monitor-agent
+            chmod +x /tmp/nfm-build/test-data/ec2-test-scripts/*.sh 2>/dev/null || true
+            chmod +x /tmp/nfm-build/test-data/integration-test-01-basic
+
+            if [ \"${PKG_TYPE}\" = \"rpm\" ]; then
+              rpm -ivh /tmp/nfm-artifacts/network-flow-monitor-agent.rpm
+              timeout 30 bash -c \"until systemctl is-active --quiet network-flow-monitor.service; do sleep 1; done\"
+              systemctl status network-flow-monitor.service --no-pager
+              echo \"Service is RUNNING\"
+              systemctl stop network-flow-monitor.service
+            else
+              cp /tmp/nfm-artifacts/network-flow-monitor-agent /usr/local/sbin/
+              if ! setcap cap_sys_admin,cap_bpf=eip /usr/local/sbin/network-flow-monitor-agent 2>/dev/null; then
+                setcap cap_sys_admin,39=eip /usr/local/sbin/network-flow-monitor-agent
+              fi
+              echo \"Installed binary with BPF capabilities\"
+            fi
+          '"
+
+      - name: Verify BPF prerequisites
+        run: |
+          /tmp/run-ssm.sh 60 "bash /tmp/nfm-build/test-data/ec2-test-scripts/verify-bpf.sh"
+
+      - name: Start agent and run integration test
+        run: |
+          /tmp/run-ssm.sh 120 "bash /tmp/nfm-build/test-data/ec2-test-scripts/run-test.sh"
+
+      - name: Uninstall agent and verify cleanup
+        if: always()
+        run: |
+          /tmp/run-ssm.sh 60 "bash /tmp/nfm-build/test-data/ec2-test-scripts/uninstall-agent.sh ${{ matrix.pkg_type }}" || true
+
+      - name: Terminate EC2 instance
+        if: always()
+        run: |
+          if [ -n "${SSM_INSTANCE_ID:-}" ]; then
+            aws ec2 terminate-instances --instance-ids "$SSM_INSTANCE_ID" --region "$SSM_REGION" || true
+            echo "Terminated instance: ${SSM_INSTANCE_ID}"
+          fi
+
+  cleanup-s3:
+    name: Cleanup S3 Artifacts
+    needs: [build, test]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.PR_PERF_TEST_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PR_PERF_TEST_AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Remove artifacts from S3
+        run: |
+          aws s3 rm "s3://${{ secrets.PR_PERF_TEST_BUCKET }}/${{ needs.build.outputs.s3-prefix }}/" --recursive || true
+          echo "Cleaned up S3 artifacts"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 target/
 **/Cargo.lock
 cobertura.xml
+.idea/

--- a/README.md
+++ b/README.md
@@ -68,6 +68,52 @@ Some unit tests need privileges to run:
 ```
 sudo -E cargo test --features privileged
 ```
+### Multi-Distro Integration Tests
+
+The workflow `.github/workflows/integration-tests.yml` runs the agent on real EC2 instances across multiple distributions. Each instance builds the agent natively and runs the test suite.
+
+**Tested distributions:**
+
+| Distro | Kernel | Package |
+|--------|--------|---------|
+| Amazon Linux 2 | 5.10 (Amazon) | RPM |
+| Amazon Linux 2023 | 6.1, 6.12 (Amazon) | RPM |
+| RHEL 9 | 5.14 (Red Hat) | RPM |
+| SUSE 15 SP6 | 6.4 | RPM |
+| Debian 11 | 5.10 (cloud) | Binary |
+| Debian 12 | 6.1 | Binary |
+| Ubuntu 22.04 | 6.x (HWE) | Binary |
+| Ubuntu 24.04 | 6.8 | Binary |
+
+#### Known Incompatible Distributions
+
+The following distributions are **not supported** due to BPF license restrictions in their kernels:
+
+| Distro | Kernel | Issue |
+|--------|--------|-------|
+| SUSE 15 SP5 | 5.14.21 (stock) | Kernel enforces GPL-only on BPF helpers used by the agent |
+| Ubuntu 20.04 | 5.15 (AWS) | Same GPL restriction + GCC 9 `memcmp` bug blocks build |
+
+**Root cause:** The agent's eBPF program declares `license="Apache-2.0"`. Certain BPF helpers (used in the `sock_ops` program) are marked `gpl_only=true` in kernels that haven't backported relaxations from upstream 6.x.
+
+- **RHEL 9 (5.14)** works because Red Hat backports BPF helper relaxations from newer kernels.
+- **SUSE SP5 (5.14)** fails because SUSE stays closer to upstream, which retains restrictions until kernel 6.x.
+- **Amazon Linux 2 (5.10)** works because Amazon patches their kernel to allow non-GPL BPF programs.
+
+**Recommended fix:** Change the eBPF program's license declaration in [`nfm-bpf/src/main.rs`](nfm-bpf/src/main.rs#L30-L31):
+
+```rust
+// Current (line 30-31):
+#[link_section = "license"]
+pub static LICENSE: [u8; 11] = *b"Apache-2.0\0";
+
+// Recommended change:
+#[link_section = "license"]
+pub static LICENSE: [u8; 14] = *b"Dual BSD/GPL\0";
+```
+
+This is the industry standard for commercial eBPF agents (Cilium, Falco, Datadog, Tetragon all use this pattern). The kernel explicitly allows GPL-licensed BPF bytecode to coexist with Apache-2.0 userspace in the same package — there is no license "contamination" across the syscall boundary.
+
 ### Distributions
 You can download the official release from our permanent URLs. For more information, refer to [link](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents-download-agent-commandline.html)
 

--- a/nfm-controller/src/open_metrics/providers/interface_metrics_provider/netns_stats.rs
+++ b/nfm-controller/src/open_metrics/providers/interface_metrics_provider/netns_stats.rs
@@ -320,19 +320,34 @@ TcpAttemptFails                 5                  0.0";
         let mut fake_runner = FakeCommandRunner::new();
         fake_runner.add_expectation(
             "nsenter",
-            &["-t", "1234", "-n", "nstat", "-a"],
+            &["--net", "/proc/4294967295/ns/net", "nstat", "-a"],
             Err(Error::new(ErrorKind::NotFound, "nsenter not found")),
         );
 
         let collector = NetNsStats::new(Box::new(fake_runner));
         let ns_info = NamespaceInfo {
-            pid: ProcessId::new(1234),
-            ns_file: None,
+            pid: ProcessId::new(4294967295),
+            ns_file: Some("/proc/4294967295/ns/net".to_string()),
             ip_addresses: vec![],
         };
         let result = collector.get_namespace_flow_stats(&ns_info);
 
         // Should return error on command failure
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_namespace_flow_stats_proc_not_found() {
+        // When ns_file is None and PID doesn't exist, reading /proc/{pid}/net/snmp fails
+        let fake_runner = FakeCommandRunner::new();
+        let collector = NetNsStats::new(Box::new(fake_runner));
+        let ns_info = NamespaceInfo {
+            pid: ProcessId::new(4294967295), // PID that will never exist
+            ns_file: None,
+            ip_addresses: vec![],
+        };
+        let result = collector.get_namespace_flow_stats(&ns_info);
+
         assert!(result.is_err());
     }
 

--- a/test-data/ec2-test-scripts/run-test.sh
+++ b/test-data/ec2-test-scripts/run-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Starts the agent in test mode and runs the integration test suite.
+
+echo "=== Starting agent and running integration test ==="
+
+export PATH="$PATH:/usr/sbin:/sbin:/usr/local/sbin"
+
+# Diagnostics: BPF/security settings
+echo "=== BPF Diagnostics ==="
+echo "Kernel: $(uname -r)"
+sysctl kernel.unprivileged_bpf_disabled 2>/dev/null || echo "sysctl not available"
+cat /sys/kernel/security/lockdown 2>/dev/null || echo "No lockdown file"
+echo "Running as: $(id)"
+echo "========================"
+
+# Raise RLIMIT_MEMLOCK for BPF map creation on kernels < 5.11
+# (kernels >= 5.11 use cgroup-based memory accounting and don't need this)
+ulimit -l unlimited
+
+# Set up cgroup
+mkdir -p /mnt/cgroup-nfm
+if ! mountpoint -q /mnt/cgroup-nfm; then
+  mount -t cgroup2 none /mnt/cgroup-nfm
+fi
+
+# Determine agent binary location
+if [ -f /opt/aws/network-flow-monitor/network-flow-monitor-agent ]; then
+  AGENT_BIN=/opt/aws/network-flow-monitor/network-flow-monitor-agent
+elif [ -f /usr/local/sbin/network-flow-monitor-agent ]; then
+  AGENT_BIN=/usr/local/sbin/network-flow-monitor-agent
+else
+  AGENT_BIN=/tmp/nfm-build/target/release/network-flow-monitor-agent
+fi
+echo "Using agent: $AGENT_BIN"
+
+# Start agent in test mode (log reports locally, don't publish to endpoint)
+LOG_FILE=/tmp/nfm-test/agent.log
+mkdir -p /tmp/nfm-test
+PUBLISH_SECS=5
+
+RUST_LOG=debug $AGENT_BIN \
+  --cgroup /mnt/cgroup-nfm \
+  --publish-reports off \
+  --log-reports on \
+  --notrack-secs 10 \
+  --publish-secs $PUBLISH_SECS > "$LOG_FILE" 2>&1 &
+AGENT_PID=$!
+
+sleep 2
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "FATAL: Agent failed to start"
+  cat "$LOG_FILE"
+  exit 1
+fi
+echo "Agent started (PID $AGENT_PID)"
+
+# Prepare and run test
+mkdir -p /tmp/nfm-test/test-scripts
+cp /tmp/nfm-build/test-data/integration-test-01-basic /tmp/nfm-test/test-scripts/
+cp /tmp/nfm-build/test-data/tools/test_common.py /tmp/nfm-test/test-scripts/
+chmod +x /tmp/nfm-test/test-scripts/*
+
+cd /tmp/nfm-test/test-scripts
+python3 integration-test-01-basic --log-path "$LOG_FILE" --publish-secs $PUBLISH_SECS
+TEST_RESULT=$?
+
+# Stop agent
+kill $AGENT_PID 2>/dev/null || true
+wait $AGENT_PID 2>/dev/null || true
+
+if [ $TEST_RESULT -ne 0 ]; then
+  echo "Agent log (last 50 lines):"
+  tail -50 "$LOG_FILE" || true
+fi
+
+exit $TEST_RESULT

--- a/test-data/ec2-test-scripts/uninstall-agent.sh
+++ b/test-data/ec2-test-scripts/uninstall-agent.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -o nounset
+
+# Uninstalls the agent and verifies cleanup.
+# Usage: uninstall-agent.sh <pkg_type>
+#   pkg_type: rpm | binary
+
+PKG_TYPE="${1:?Usage: uninstall-agent.sh <pkg_type>}"
+
+echo "=== Uninstalling agent (${PKG_TYPE}) ==="
+
+if [ "$PKG_TYPE" = "rpm" ] && rpm -q network-flow-monitor-agent &>/dev/null; then
+  rpm -e network-flow-monitor-agent
+
+  if [ -f /opt/aws/network-flow-monitor/network-flow-monitor-agent ]; then
+    echo "WARN: Binary still present after uninstall"
+  else
+    echo "Binary removed: OK"
+  fi
+
+  if systemctl is-enabled network-flow-monitor.service 2>/dev/null; then
+    echo "WARN: Service still enabled after uninstall"
+  else
+    echo "Service disabled: OK"
+  fi
+else
+  rm -f /usr/local/sbin/network-flow-monitor-agent
+  echo "Binary removed"
+fi
+
+# Clean up cgroup mount
+umount /mnt/cgroup-nfm 2>/dev/null || true
+rmdir /mnt/cgroup-nfm 2>/dev/null || true
+
+echo "Cleanup complete"

--- a/test-data/ec2-test-scripts/verify-bpf.sh
+++ b/test-data/ec2-test-scripts/verify-bpf.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o nounset
+
+# Verifies that BPF prerequisites are met on this kernel.
+# Non-fatal — reports findings but does not fail the test.
+
+echo "=== Verifying BPF prerequisites ==="
+echo "Kernel: $(uname -r)"
+
+KERNEL_CONFIG="/boot/config-$(uname -r)"
+if [ -f "$KERNEL_CONFIG" ]; then
+  grep CONFIG_BPF_SYSCALL "$KERNEL_CONFIG" || echo "WARN: CONFIG_BPF_SYSCALL not found"
+  grep CONFIG_CGROUP_BPF "$KERNEL_CONFIG" || echo "WARN: CONFIG_CGROUP_BPF not found"
+else
+  echo "Kernel config not found at $KERNEL_CONFIG (common on some distros), skipping"
+fi

--- a/test-data/integration-test-01-basic
+++ b/test-data/integration-test-01-basic
@@ -104,7 +104,7 @@ def main():
     server.shutdown()
 
     # Validate the results.
-    success = count_logged_connections(file_path='/test-context/agent.log', expected_count=request_count, timeout_secs=15)
+    success = count_logged_connections(file_path=args.log_path, expected_count=request_count, timeout_secs=15)
     exit(0 if success else 1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

This PR adds infrastructure for multi-distro integration tests — the CI workflow, EC2 setup scripts, and instance lifecycle management. It does **not** modify the test logic itself (`integration-test-01-basic` etc.), only the scaffolding to run existing tests across multiple Linux distributions on real EC2 instances.

### Changes

- New GitHub Actions workflow (`.github/workflows/integration-tests.yml`) that:
  - Builds the agent on Amazon Linux 2 (x86_64 + ARM64) — same environment as the production S3Release pipeline
  - Distributes pre-built binaries to EC2 instances across 16 distro/arch combinations
  - Installs via RPM (AL/RHEL/SUSE) or binary with capabilities (Debian/Ubuntu)
  - Runs the integration test suite and verifies traffic capture
  - Terminates all instances and cleans up S3 artifacts
- EC2 test scripts (`test-data/ec2-test-scripts/`) for verify, test, and cleanup
- Fix in `integration-test-01-basic`: `count_logged_connections` now uses `args.log_path` instead of hardcoded `/test-context/agent.log`
- Fix flaky test `test_get_namespace_flow_stats_command_failure` — was reading `/proc/{pid}/net/snmp` from the real filesystem instead of using the FakeCommandRunner
- Updated `README.md` with compatibility findings and recommended BPF license fix

### Tested Distributions (all passing)

| Distro | x86_64 | arm64 |
|--------|--------|-------|
| Amazon Linux 2 (kernel 5.10) | ✅ | ✅ |
| Amazon Linux 2023 (kernel 6.1) | ✅ | ✅ |
| Amazon Linux 2023 (kernel 6.12) | ✅ | — |
| RHEL 9 (kernel 5.14) | ✅ | ✅ |
| SUSE 15 SP6 (kernel 6.4) | ✅ | — |
| Debian 11 (kernel 5.10) | ✅ | — |
| Debian 12 (kernel 6.1) | ✅ | ✅ |
| Ubuntu 22.04 (kernel 6.x) | ✅ | ✅ |
| Ubuntu 24.04 (kernel 6.8) | ✅ | ✅ |

### Build Strategy

Replicates the production S3Release pipeline:
- **x86_64**: Built on AL2 `c5.xlarge` instance
- **ARM64**: Built on AL2 `c7g.xlarge` (Graviton) instance
- Both produce binaries linked against GLIBC 2.26, compatible with all tested distros
- Test instances only download + install + test (no compilation, ~5 min each)

---

## BPF License Investigation

During development, we discovered that **SUSE 15 SP5** (kernel 5.14) and **Ubuntu 20.04** (kernel 5.15-aws) fail to load the agent's eBPF program with `EACCES (Permission denied)`.

### Root Cause

The NFM agent's sock_ops eBPF program declares `license = "Apache-2.0"` (in `nfm-bpf/src/main.rs:30-31`). Certain BPF helpers used by the program are marked `gpl_only = true` in stock kernels. The kernel verifier validates the program successfully but rejects the load because a non-GPL program cannot call GPL-only helpers.

### Why it works on some 5.14 kernels but not others

| Distro | Kernel | Works? | Reason |
|--------|--------|--------|--------|
| Amazon Linux 2 | 5.10 (Amazon) | ✅ | Amazon patches their kernel to relax GPL restrictions on BPF helpers |
| RHEL 9 | 5.14 (Red Hat) | ✅ | Red Hat extensively backports BPF relaxations from upstream 6.x |
| SUSE SP5 | 5.14.21 (stock) | ❌ | SUSE stays close to upstream, retains original `gpl_only` markings |
| Ubuntu 20.04 | 5.15 (AWS) | ❌ | Ubuntu maintains stock BPF restrictions + GCC 9 `memcmp` bug blocks build |
| SUSE SP6 / Debian 12 / Ubuntu 22+ | 6.x | ✅ | Upstream 6.x relaxed several helpers from `gpl_only = true → false` |

**Key insight:** The "5.14" kernel in RHEL and SUSE are very different in practice. Red Hat backports thousands of patches including BPF helper relaxations. SUSE waits for the base kernel upgrade (5.14 → 6.4 in SP6).

### Evidence (from manual investigation on EC2 instances)

```
# SUSE SP5 — strace shows the exact syscall rejection:
bpf(BPF_PROG_LOAD, {prog_type=BPF_PROG_TYPE_SOCK_OPS, license="Apache-2.0", ...}) = -1 EACCES

# RHEL 9 — same syscall succeeds:
bpf(BPF_PROG_LOAD, {prog_type=BPF_PROG_TYPE_SOCK_OPS, license="Apache-2.0", ...}) = 7
```

### Also found: RLIMIT_MEMLOCK on kernels < 5.11

Debian 11 (kernel 5.10) initially failed with `failed to create map: Operation not permitted`. Caused by `RLIMIT_MEMLOCK = 64KB` (default on older kernels). Kernels >= 5.11 use cgroup-based BPF memory accounting. Fixed by adding `ulimit -l unlimited` before running the agent in `run-test.sh`.

---
