### PR TITLE
ci: parallelize CI workflow and remove obsolete load-test fallback

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+# CI pipeline for network-flow-monitor-agent.
 name: CI
 
 on:
@@ -6,17 +7,18 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-    branches: [ main ]
 
 permissions:
   contents: read
 
 jobs:
-  validate:
-    name: Validate
+  # Clippy warnings + rustfmt check
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -24,16 +26,53 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
           override: true
-      - name: Run tests
-        run: cargo test --release
-      - name: Run clipply
+
+      - name: Run clippy
         run: cargo clippy -- -D warnings
+
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+  # Unit tests in release mode
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run tests
+        run: cargo test --release
+
+  # Code coverage via tarpaulin, reported to Codecov
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
+
       - name: Install conntrack
         run: sudo apt-get update && sudo apt-get install -y conntrack
+
+      - name: Build BPF object
+        run: cargo build --release
+
       - name: Check code coverage
         run: |
           BPF_OBJECT_PATH="${{ github.workspace }}/target/ebpf/bpfel-unknown-none/release/nfm-bpf" \
@@ -44,26 +83,46 @@ jobs:
           --exclude nfm-bpf \
           --exclude-files '**/build.rs' \
           --out xml
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Build release binaries and run Docker-based integration tests
+  integration:
+    name: Integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
       - name: Check environment
         run: |
           cat /etc/os-release
           ldd --version
+
       - name: Build release binary
         run: cargo build --release
+
       - name: Build verifier binary
         run: cargo build --release --package report-verifier
+
       - name: Run integration tests
         run: |
           docker build -t integration-test -f .ci/common/tests/Dockerfile.test .
           docker run --privileged -t integration-test
+
       - name: Upload release binary
         uses: actions/upload-artifact@v4
         with:
           name: network-flow-monitor-agent
-          path:  ./target/release/network-flow-monitor-agent
+          path: ./target/release/network-flow-monitor-agent
           retention-days: 3
           if-no-files-found: error

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -86,24 +86,14 @@ jobs:
           S3_PREFIX="load-tests/${{ github.run_id }}/${{ github.run_attempt }}"
           BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
 
-          # TODO: Remove this fallback once this PR is merged to main.
-          # The build (main) job checks out main which still has the old layout.
-          if [ -d ".ci/load-tests/bin" ]; then
-            SCRIPTS_DIR=".ci/load-tests/bin"
-            CONFIG_FILE=".ci/load-tests/configs/instance-config.json"
-          else
-            SCRIPTS_DIR="load-generator/bin"
-            CONFIG_FILE="load-generator/instance-config.json"
-          fi
-
           tar --transform 's/.*\///g' -czf ${{ matrix.ref }}-bundle.tgz \
             target/release/network-flow-monitor-agent \
             target/release/tcp-tester \
-            ${SCRIPTS_DIR}/*
+            .ci/load-tests/bin/*
 
           aws s3 cp ${{ matrix.ref }}-bundle.tgz "s3://${BUCKET}/${S3_PREFIX}/${{ matrix.ref }}-bundle.tgz"
-          aws s3 cp ${SCRIPTS_DIR}/bpftop "s3://${BUCKET}/${S3_PREFIX}/bpftop"
-          aws s3 cp ${CONFIG_FILE} "s3://${BUCKET}/${S3_PREFIX}/instance-config.json"
+          aws s3 cp .ci/load-tests/bin/bpftop "s3://${BUCKET}/${S3_PREFIX}/bpftop"
+          aws s3 cp .ci/load-tests/configs/instance-config.json "s3://${BUCKET}/${S3_PREFIX}/instance-config.json"
 
   # Run one perf test per (ref × instance_type × tps) combination
   perf-test:


### PR DESCRIPTION
## Summary

- Split monolithic `validate` job into 4 parallel jobs (`lint`, `test`, `coverage`, `integration`) to reduce total CI time
- Remove obsolete `load-generator/` fallback in `load-tests.yml` since the `.ci/` restructure (#108) is already merged to main
- Fix invalid `branches` filter on `workflow_dispatch` (silently ignored by GitHub Actions)

## Changes

| Job | Purpose |
|-----|---------|
| `lint` | clippy + rustfmt check |
| `test` | unit tests in release mode |
| `coverage` | tarpaulin instrumentation + Codecov upload |
| `integration` | build binaries + Docker integration tests + artifact upload |

## Test plan

- [ ] Verify all 4 CI jobs run in parallel and pass
- [ ] Verify Codecov receives the coverage report correctly
- [ ] Verify load-test build jobs pass (no more `load-generator/` fallback needed)