### PR TITLE
Efa metrics

### DIFF
--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -109,6 +109,9 @@ tokio-util = { version = "0.7", optional = true }
 getifaddrs = { version = "0.5.0", optional = true }
 regex = { version = "1.11", optional = true }
 
+[dev-dependencies]
+tempfile = "3"
+
 [build-dependencies]
 cargo_metadata = "0.19"
 shadow-rs = "1.1.0"

--- a/nfm-controller/src/open_metrics/provider.rs
+++ b/nfm-controller/src/open_metrics/provider.rs
@@ -3,6 +3,7 @@
 
 //! Simple Prometheus metrics server for testing integration.
 
+use log::info;
 use prometheus::Registry;
 
 use std::sync::Arc;
@@ -11,6 +12,7 @@ use crate::{
     kubernetes::kubernetes_metadata_collector::KubernetesMetadataCollector,
     metadata::runtime_environment_metadata::ComputePlatform,
     open_metrics::providers::{
+        efa_metrics_provider::EfaMetricsProvider,
         interface_metrics_provider::InterfaceMetricsProvider,
         system_metrics_provider::SystemMetricsProvider,
     },
@@ -20,13 +22,20 @@ pub fn get_open_metric_providers(
     compute_platform: ComputePlatform,
     k8s_collector: Option<Arc<KubernetesMetadataCollector>>,
 ) -> Vec<Box<dyn OpenMetricProvider>> {
-    vec![
+    let mut providers: Vec<Box<dyn OpenMetricProvider>> = vec![
         Box::new(SystemMetricsProvider::new(&compute_platform)),
         Box::new(InterfaceMetricsProvider::new(
             &compute_platform,
             k8s_collector.clone(),
         )),
-    ]
+    ];
+
+    if EfaMetricsProvider::efa_devices_present() {
+        info!("EFA devices detected, enabling EFA metrics collection");
+        providers.push(Box::new(EfaMetricsProvider::new(&compute_platform)));
+    }
+
+    providers
 }
 
 pub trait OpenMetricProvider {

--- a/nfm-controller/src/open_metrics/provider.rs
+++ b/nfm-controller/src/open_metrics/provider.rs
@@ -61,8 +61,13 @@ mod tests {
 
         for platform in platforms {
             let providers = get_open_metric_providers(platform.clone(), None);
-            assert_eq!(providers.len(), 2, "Failed for platform: {:?}", platform);
-            // Verify we get both SystemMetricsProvider and InterfaceMetricsProvider
+            // 2 base providers (System + Interface), plus EFA if devices are present.
+            assert!(
+                providers.len() >= 2 && providers.len() <= 3,
+                "Unexpected provider count {} for platform: {:?}",
+                providers.len(),
+                platform
+            );
         }
     }
 
@@ -74,8 +79,7 @@ mod tests {
         let k8s_collector = Arc::new(KubernetesMetadataCollector::new());
         let providers = get_open_metric_providers(compute_platform, Some(k8s_collector));
 
-        assert_eq!(providers.len(), 2);
-        // Verify providers are created with k8s collector
+        assert!(providers.len() >= 2 && providers.len() <= 3);
     }
 
     #[test]

--- a/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
@@ -25,28 +25,85 @@ const PORTS_SUBDIR: &str = "ports";
 const HW_COUNTERS_DIR: &str = "hw_counters";
 
 const STANDARD_METRICS: &[(&str, &str)] = &[
-    ("efa_tx_bytes", "Bytes transmitted via EFA device since last scrape"),
-    ("efa_rx_bytes", "Bytes received via EFA device since last scrape"),
-    ("efa_tx_pkts", "Packets transmitted via EFA device since last scrape"),
-    ("efa_rx_pkts", "Packets received via EFA device since last scrape"),
-    ("efa_rx_drops", "Receive drops on EFA device since last scrape"),
-    ("efa_send_bytes", "RDMA send bytes on EFA device since last scrape"),
-    ("efa_recv_bytes", "RDMA recv bytes on EFA device since last scrape"),
-    ("efa_send_wrs", "RDMA send work requests on EFA device since last scrape"),
-    ("efa_recv_wrs", "RDMA recv work requests on EFA device since last scrape"),
-    ("efa_rdma_read_wrs", "RDMA read work requests on EFA device since last scrape"),
-    ("efa_rdma_read_bytes", "RDMA read bytes on EFA device since last scrape"),
-    ("efa_rdma_write_wrs", "RDMA write work requests on EFA device since last scrape"),
-    ("efa_rdma_write_bytes", "RDMA write bytes on EFA device since last scrape"),
-    ("efa_rdma_read_wr_err", "RDMA read work request errors on EFA device since last scrape"),
-    ("efa_rdma_write_wr_err", "RDMA write work request errors on EFA device since last scrape"),
-    ("efa_rdma_read_resp_bytes", "RDMA read response bytes on EFA device since last scrape"),
-    ("efa_rdma_write_recv_bytes", "RDMA write received bytes on EFA device since last scrape"),
+    (
+        "efa_tx_bytes",
+        "Bytes transmitted via EFA device since last scrape",
+    ),
+    (
+        "efa_rx_bytes",
+        "Bytes received via EFA device since last scrape",
+    ),
+    (
+        "efa_tx_pkts",
+        "Packets transmitted via EFA device since last scrape",
+    ),
+    (
+        "efa_rx_pkts",
+        "Packets received via EFA device since last scrape",
+    ),
+    (
+        "efa_rx_drops",
+        "Receive drops on EFA device since last scrape",
+    ),
+    (
+        "efa_send_bytes",
+        "RDMA send bytes on EFA device since last scrape",
+    ),
+    (
+        "efa_recv_bytes",
+        "RDMA recv bytes on EFA device since last scrape",
+    ),
+    (
+        "efa_send_wrs",
+        "RDMA send work requests on EFA device since last scrape",
+    ),
+    (
+        "efa_recv_wrs",
+        "RDMA recv work requests on EFA device since last scrape",
+    ),
+    (
+        "efa_rdma_read_wrs",
+        "RDMA read work requests on EFA device since last scrape",
+    ),
+    (
+        "efa_rdma_read_bytes",
+        "RDMA read bytes on EFA device since last scrape",
+    ),
+    (
+        "efa_rdma_write_wrs",
+        "RDMA write work requests on EFA device since last scrape",
+    ),
+    (
+        "efa_rdma_write_bytes",
+        "RDMA write bytes on EFA device since last scrape",
+    ),
+    (
+        "efa_rdma_read_wr_err",
+        "RDMA read work request errors on EFA device since last scrape",
+    ),
+    (
+        "efa_rdma_write_wr_err",
+        "RDMA write work request errors on EFA device since last scrape",
+    ),
+    (
+        "efa_rdma_read_resp_bytes",
+        "RDMA read response bytes on EFA device since last scrape",
+    ),
+    (
+        "efa_rdma_write_recv_bytes",
+        "RDMA write received bytes on EFA device since last scrape",
+    ),
 ];
 
 const SRD_METRICS: &[(&str, &str)] = &[
-    ("efa_retrans_bytes", "SRD retransmitted bytes on EFA device since last scrape (Nitro v4+)"),
-    ("efa_retrans_pkts", "SRD retransmitted packets on EFA device since last scrape (Nitro v4+)"),
+    (
+        "efa_retrans_bytes",
+        "SRD retransmitted bytes on EFA device since last scrape (Nitro v4+)",
+    ),
+    (
+        "efa_retrans_pkts",
+        "SRD retransmitted packets on EFA device since last scrape (Nitro v4+)",
+    ),
     (
         "efa_retrans_timeout_events",
         "SRD retransmission timeout events on EFA device since last scrape (Nitro v4+)",
@@ -145,7 +202,12 @@ impl EfaMetricsProvider {
     }
 
     fn total_metrics_count(&self) -> usize {
-        STANDARD_METRICS.len() + if self.srd_available { SRD_METRICS.len() } else { 0 }
+        STANDARD_METRICS.len()
+            + if self.srd_available {
+                SRD_METRICS.len()
+            } else {
+                0
+            }
     }
 
     fn seed_cache(&mut self) {
@@ -301,10 +363,7 @@ impl OpenMetricProvider for EfaMetricsProvider {
 
     fn update_metrics(&mut self) -> Result<(), anyhow::Error> {
         let device_ports = self.discover_device_ports();
-        let active_keys: Vec<String> = device_ports
-            .iter()
-            .map(|(d, p)| cache_key(d, p))
-            .collect();
+        let active_keys: Vec<String> = device_ports.iter().map(|(d, p)| cache_key(d, p)).collect();
 
         // Remove stale entries for device/port combos that no longer exist.
         self.previous_values.retain(|k, _| active_keys.contains(k));
@@ -354,7 +413,10 @@ mod tests {
     const TEST_PORT: &str = "1";
 
     fn hw_counters_path(base: &Path, device: &str, port: &str) -> PathBuf {
-        base.join(device).join(PORTS_SUBDIR).join(port).join(HW_COUNTERS_DIR)
+        base.join(device)
+            .join(PORTS_SUBDIR)
+            .join(port)
+            .join(HW_COUNTERS_DIR)
     }
 
     fn create_mock_sysfs(with_srd: bool) -> TempDir {
@@ -460,7 +522,10 @@ mod tests {
         let tmp = create_mock_sysfs(false);
         let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
         let device_ports = provider.discover_device_ports();
-        assert_eq!(device_ports, vec![("rdmap0s31".to_string(), "1".to_string())]);
+        assert_eq!(
+            device_ports,
+            vec![("rdmap0s31".to_string(), "1".to_string())]
+        );
     }
 
     #[test]

--- a/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
@@ -21,7 +21,8 @@ use log::{debug, info, warn};
 use prometheus::{IntGaugeVec, Registry};
 
 const INFINIBAND_SYSFS_PATH: &str = "/sys/class/infiniband";
-const HW_COUNTERS_SUBPATH: &str = "ports/1/hw_counters";
+const PORTS_SUBDIR: &str = "ports";
+const HW_COUNTERS_DIR: &str = "hw_counters";
 
 const STANDARD_METRICS: &[(&str, &str)] = &[
     ("efa_tx_bytes", "Bytes transmitted via EFA device since last scrape"),
@@ -65,9 +66,9 @@ struct EfaMetric;
 impl MetricLabel for EfaMetric {
     fn get_labels(compute_platform: &ComputePlatform) -> &[&str] {
         match compute_platform {
-            ComputePlatform::Ec2Plain => &["instance_id", "device"],
+            ComputePlatform::Ec2Plain => &["instance_id", "device", "port"],
             ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
-                &["instance_id", "device", "node"]
+                &["instance_id", "device", "port", "node"]
             }
         }
     }
@@ -148,24 +149,25 @@ impl EfaMetricsProvider {
     }
 
     fn seed_cache(&mut self) {
-        for device in self.discover_devices() {
-            let values = self.read_all_counters(&device);
-            self.previous_values.insert(device, values);
+        for (device, port) in self.discover_device_ports() {
+            let key = cache_key(&device, &port);
+            let values = self.read_all_counters(&device, &port);
+            self.previous_values.insert(key, values);
         }
     }
 
-    fn read_all_counters(&self, device: &str) -> Vec<u64> {
+    fn read_all_counters(&self, device: &str, port: &str) -> Vec<u64> {
         let mut values = Vec::with_capacity(self.total_metrics_count());
 
         for (metric_name, _) in STANDARD_METRICS {
             let sysfs_name = strip_efa_prefix(metric_name);
-            values.push(self.read_counter(device, sysfs_name).unwrap_or(0));
+            values.push(self.read_counter(device, port, sysfs_name).unwrap_or(0));
         }
 
         if self.srd_available {
             for (metric_name, _) in SRD_METRICS {
                 let sysfs_name = strip_efa_prefix(metric_name);
-                values.push(self.read_counter(device, sysfs_name).unwrap_or(0));
+                values.push(self.read_counter(device, port, sysfs_name).unwrap_or(0));
             }
         }
 
@@ -173,38 +175,63 @@ impl EfaMetricsProvider {
     }
 
     fn detect_srd_support(sysfs_base: &Path) -> bool {
-        let Ok(entries) = fs::read_dir(sysfs_base) else {
+        let Ok(devices) = fs::read_dir(sysfs_base) else {
             return false;
         };
 
-        for entry in entries.flatten() {
-            let counters_path = entry.path().join(HW_COUNTERS_SUBPATH);
-            let first_srd_metric = strip_efa_prefix(SRD_METRICS[0].0);
-            if counters_path.join(first_srd_metric).exists() {
-                return true;
+        let first_srd_metric = strip_efa_prefix(SRD_METRICS[0].0);
+        for device_entry in devices.flatten() {
+            let ports_path = device_entry.path().join(PORTS_SUBDIR);
+            let Ok(ports) = fs::read_dir(&ports_path) else {
+                continue;
+            };
+            for port_entry in ports.flatten() {
+                let counters_path = port_entry.path().join(HW_COUNTERS_DIR);
+                if counters_path.join(first_srd_metric).exists() {
+                    return true;
+                }
             }
         }
         false
     }
 
-    fn discover_devices(&self) -> Vec<String> {
-        match fs::read_dir(&self.sysfs_base) {
-            Ok(entries) => entries
-                .flatten()
-                .filter_map(|e| e.file_name().into_string().ok())
-                .collect(),
-            Err(e) => {
-                warn!("Failed to read EFA devices from {:?}: {}", self.sysfs_base, e);
-                Vec::new()
+    fn discover_device_ports(&self) -> Vec<(String, String)> {
+        let Ok(devices) = fs::read_dir(&self.sysfs_base) else {
+            warn!("Failed to read EFA devices from {:?}", self.sysfs_base);
+            return Vec::new();
+        };
+
+        let mut result = Vec::new();
+        for device_entry in devices.flatten() {
+            let device_name = match device_entry.file_name().into_string() {
+                Ok(name) => name,
+                Err(_) => continue,
+            };
+            let ports_path = device_entry.path().join(PORTS_SUBDIR);
+            let Ok(ports) = fs::read_dir(&ports_path) else {
+                continue;
+            };
+            for port_entry in ports.flatten() {
+                let port_name = match port_entry.file_name().into_string() {
+                    Ok(name) => name,
+                    Err(_) => continue,
+                };
+                let counters_path = port_entry.path().join(HW_COUNTERS_DIR);
+                if counters_path.is_dir() {
+                    result.push((device_name.clone(), port_name));
+                }
             }
         }
+        result
     }
 
-    fn read_counter(&self, device: &str, metric_name: &str) -> Option<u64> {
+    fn read_counter(&self, device: &str, port: &str, metric_name: &str) -> Option<u64> {
         let path = self
             .sysfs_base
             .join(device)
-            .join(HW_COUNTERS_SUBPATH)
+            .join(PORTS_SUBDIR)
+            .join(port)
+            .join(HW_COUNTERS_DIR)
             .join(metric_name);
 
         match fs::read_to_string(&path) {
@@ -222,11 +249,11 @@ impl EfaMetricsProvider {
         }
     }
 
-    fn label_values<'a>(&'a self, device: &'a str) -> Vec<&'a str> {
+    fn label_values<'a>(&'a self, device: &'a str, port: &'a str) -> Vec<&'a str> {
         match self.compute_platform {
-            ComputePlatform::Ec2Plain => vec![&self.instance_id, device],
+            ComputePlatform::Ec2Plain => vec![&self.instance_id, device, port],
             ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
-                vec![&self.instance_id, device, &self.node_name]
+                vec![&self.instance_id, device, port, &self.node_name]
             }
         }
     }
@@ -234,6 +261,10 @@ impl EfaMetricsProvider {
 
 fn strip_efa_prefix(prefixed_name: &str) -> &str {
     prefixed_name.strip_prefix("efa_").unwrap_or(prefixed_name)
+}
+
+fn cache_key(device: &str, port: &str) -> String {
+    format!("{}/{}", device, port)
 }
 
 /// Computes the delta between two counter readings. If the counter appears to
@@ -265,20 +296,25 @@ impl OpenMetricProvider for EfaMetricsProvider {
     }
 
     fn update_metrics(&mut self) -> Result<(), anyhow::Error> {
-        let devices = self.discover_devices();
+        let device_ports = self.discover_device_ports();
+        let active_keys: Vec<String> = device_ports
+            .iter()
+            .map(|(d, p)| cache_key(d, p))
+            .collect();
 
-        // Remove stale entries for devices that no longer exist.
-        self.previous_values.retain(|d, _| devices.contains(d));
+        // Remove stale entries for device/port combos that no longer exist.
+        self.previous_values.retain(|k, _| active_keys.contains(k));
 
-        for device in &devices {
-            let current_values = self.read_all_counters(device);
+        for (device, port) in &device_ports {
+            let key = cache_key(device, port);
+            let current_values = self.read_all_counters(device, port);
             let previous = self
                 .previous_values
-                .get(device)
+                .get(&key)
                 .cloned()
                 .unwrap_or_else(|| vec![0; self.total_metrics_count()]);
 
-            let label_values = self.label_values(device);
+            let label_values = self.label_values(device, port);
 
             for (i, _) in STANDARD_METRICS.iter().enumerate() {
                 let delta = compute_delta(current_values[i], previous[i]);
@@ -297,7 +333,7 @@ impl OpenMetricProvider for EfaMetricsProvider {
                 }
             }
 
-            self.previous_values.insert(device.clone(), current_values);
+            self.previous_values.insert(key, current_values);
         }
 
         Ok(())
@@ -311,20 +347,26 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    const TEST_PORT: &str = "1";
+
+    fn hw_counters_path(base: &Path, device: &str, port: &str) -> PathBuf {
+        base.join(device).join(PORTS_SUBDIR).join(port).join(HW_COUNTERS_DIR)
+    }
+
     fn create_mock_sysfs(with_srd: bool) -> TempDir {
         let tmp = TempDir::new().unwrap();
-        let device_path = tmp.path().join("rdmap0s31").join(HW_COUNTERS_SUBPATH);
-        fs::create_dir_all(&device_path).unwrap();
+        let counters = hw_counters_path(tmp.path(), "rdmap0s31", TEST_PORT);
+        fs::create_dir_all(&counters).unwrap();
 
         for (metric_name, _) in STANDARD_METRICS {
             let sysfs_name = strip_efa_prefix(metric_name);
-            fs::write(device_path.join(sysfs_name), "42\n").unwrap();
+            fs::write(counters.join(sysfs_name), "42\n").unwrap();
         }
 
         if with_srd {
             for (metric_name, _) in SRD_METRICS {
                 let sysfs_name = strip_efa_prefix(metric_name);
-                fs::write(device_path.join(sysfs_name), "7\n").unwrap();
+                fs::write(counters.join(sysfs_name), "7\n").unwrap();
             }
         }
 
@@ -360,21 +402,20 @@ mod tests {
             previous_values: HashMap::new(),
         };
 
-        // Seed cache like the real constructor does.
         provider.seed_cache();
         provider
     }
 
     fn write_counters(tmp: &TempDir, device: &str, standard_val: u64, srd_val: Option<u64>) {
-        let device_path = tmp.path().join(device).join(HW_COUNTERS_SUBPATH);
+        let counters = hw_counters_path(tmp.path(), device, TEST_PORT);
         for (metric_name, _) in STANDARD_METRICS {
             let sysfs_name = strip_efa_prefix(metric_name);
-            fs::write(device_path.join(sysfs_name), format!("{}\n", standard_val)).unwrap();
+            fs::write(counters.join(sysfs_name), format!("{}\n", standard_val)).unwrap();
         }
         if let Some(val) = srd_val {
             for (metric_name, _) in SRD_METRICS {
                 let sysfs_name = strip_efa_prefix(metric_name);
-                fs::write(device_path.join(sysfs_name), format!("{}\n", val)).unwrap();
+                fs::write(counters.join(sysfs_name), format!("{}\n", val)).unwrap();
             }
         }
     }
@@ -411,18 +452,18 @@ mod tests {
     }
 
     #[test]
-    fn test_discover_devices() {
+    fn test_discover_device_ports() {
         let tmp = create_mock_sysfs(false);
         let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
-        let devices = provider.discover_devices();
-        assert_eq!(devices, vec!["rdmap0s31"]);
+        let device_ports = provider.discover_device_ports();
+        assert_eq!(device_ports, vec![("rdmap0s31".to_string(), "1".to_string())]);
     }
 
     #[test]
     fn test_read_counter_success() {
         let tmp = create_mock_sysfs(false);
         let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
-        let value = provider.read_counter("rdmap0s31", "tx_bytes");
+        let value = provider.read_counter("rdmap0s31", TEST_PORT, "tx_bytes");
         assert_eq!(value, Some(42));
     }
 
@@ -430,7 +471,7 @@ mod tests {
     fn test_read_counter_missing_file() {
         let tmp = create_mock_sysfs(false);
         let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
-        let value = provider.read_counter("rdmap0s31", "nonexistent_metric");
+        let value = provider.read_counter("rdmap0s31", TEST_PORT, "nonexistent_metric");
         assert_eq!(value, None);
     }
 
@@ -468,7 +509,6 @@ mod tests {
         let mut registry = Registry::new();
         provider.register_to(&mut registry);
 
-        // First update after seeded cache — counters haven't changed, so delta is 0.
         let result = provider.update_metrics();
         assert!(result.is_ok());
 
@@ -492,10 +532,8 @@ mod tests {
         let mut registry = Registry::new();
         provider.register_to(&mut registry);
 
-        // First scrape: delta is 0 (cache was seeded with value 42).
         let _ = provider.update_metrics();
 
-        // Simulate counter increment: 42 -> 100 (delta should be 58).
         write_counters(&tmp, "rdmap0s31", 100, None);
 
         let _ = provider.update_metrics();
@@ -519,7 +557,6 @@ mod tests {
         let mut registry = Registry::new();
         provider.register_to(&mut registry);
 
-        // First scrape seeds, second scrape with same values -> delta 0.
         let _ = provider.update_metrics();
         let _ = provider.update_metrics();
 
@@ -538,15 +575,11 @@ mod tests {
         let mut registry = Registry::new();
         provider.register_to(&mut registry);
 
-        // First scrape (seeded at 42, read 42 -> delta 0).
         let _ = provider.update_metrics();
 
-        // Simulate counter going up.
         write_counters(&tmp, "rdmap0s31", 1000, None);
         let _ = provider.update_metrics();
 
-        // Simulate counter reset (e.g., driver reload): 1000 -> 5.
-        // Should return the current value (5) assuming counter restarted from 0.
         write_counters(&tmp, "rdmap0s31", 5, None);
         let _ = provider.update_metrics();
 
@@ -570,10 +603,8 @@ mod tests {
         let mut registry = Registry::new();
         provider.register_to(&mut registry);
 
-        // First scrape: delta 0 (seeded at 42/7).
         let _ = provider.update_metrics();
 
-        // Increment: standard 42->52 (delta 10), SRD 7->17 (delta 10).
         write_counters(&tmp, "rdmap0s31", 52, Some(17));
         let _ = provider.update_metrics();
 
@@ -591,7 +622,6 @@ mod tests {
             }
         }
 
-        // Verify SRD metric names present
         let reported_names: Vec<&str> = metric_families.iter().map(|mf| mf.get_name()).collect();
         for srd_name in &srd_names {
             assert!(reported_names.contains(srd_name));
@@ -601,14 +631,14 @@ mod tests {
     #[test]
     fn test_labels_ec2_plain() {
         let labels = EfaMetric::get_labels(&ComputePlatform::Ec2Plain);
-        assert_eq!(labels, &["instance_id", "device"]);
+        assert_eq!(labels, &["instance_id", "device", "port"]);
     }
 
     #[test]
     fn test_labels_k8s() {
         for platform in &[ComputePlatform::Ec2K8sEks, ComputePlatform::Ec2K8sVanilla] {
             let labels = EfaMetric::get_labels(platform);
-            assert_eq!(labels, &["instance_id", "device", "node"]);
+            assert_eq!(labels, &["instance_id", "device", "port", "node"]);
         }
     }
 
@@ -616,47 +646,45 @@ mod tests {
     fn test_label_values_ec2() {
         let tmp = create_mock_sysfs(false);
         let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
-        let values = provider.label_values("rdmap0s31");
-        assert_eq!(values, vec!["i-1234567890abcdef0", "rdmap0s31"]);
+        let values = provider.label_values("rdmap0s31", "1");
+        assert_eq!(values, vec!["i-1234567890abcdef0", "rdmap0s31", "1"]);
     }
 
     #[test]
     fn test_label_values_k8s() {
         let tmp = create_mock_sysfs(false);
         let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2K8sEks);
-        let values = provider.label_values("rdmap0s31");
+        let values = provider.label_values("rdmap0s31", "1");
         assert_eq!(
             values,
-            vec!["i-1234567890abcdef0", "rdmap0s31", "test-node"]
+            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node"]
         );
     }
 
     #[test]
     fn test_multiple_devices_delta() {
         let tmp = TempDir::new().unwrap();
-        let device1 = tmp.path().join("rdmap0s31").join(HW_COUNTERS_SUBPATH);
-        let device2 = tmp.path().join("rdmap1s32").join(HW_COUNTERS_SUBPATH);
-        fs::create_dir_all(&device1).unwrap();
-        fs::create_dir_all(&device2).unwrap();
+        let dev1_counters = hw_counters_path(tmp.path(), "rdmap0s31", TEST_PORT);
+        let dev2_counters = hw_counters_path(tmp.path(), "rdmap1s32", TEST_PORT);
+        fs::create_dir_all(&dev1_counters).unwrap();
+        fs::create_dir_all(&dev2_counters).unwrap();
 
         for (metric_name, _) in STANDARD_METRICS {
             let sysfs_name = strip_efa_prefix(metric_name);
-            fs::write(device1.join(sysfs_name), "100\n").unwrap();
-            fs::write(device2.join(sysfs_name), "200\n").unwrap();
+            fs::write(dev1_counters.join(sysfs_name), "100\n").unwrap();
+            fs::write(dev2_counters.join(sysfs_name), "200\n").unwrap();
         }
 
         let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
         let mut registry = Registry::new();
         provider.register_to(&mut registry);
 
-        // First scrape: delta 0 (cache seeded).
         let _ = provider.update_metrics();
 
-        // Increment device1 by 10, device2 by 50.
         for (metric_name, _) in STANDARD_METRICS {
             let sysfs_name = strip_efa_prefix(metric_name);
-            fs::write(device1.join(sysfs_name), "110\n").unwrap();
-            fs::write(device2.join(sysfs_name), "250\n").unwrap();
+            fs::write(dev1_counters.join(sysfs_name), "110\n").unwrap();
+            fs::write(dev2_counters.join(sysfs_name), "250\n").unwrap();
         }
 
         let result = provider.update_metrics();
@@ -673,6 +701,49 @@ mod tests {
             let mut sorted = values.clone();
             sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
             assert_eq!(sorted, vec![10.0, 50.0]);
+        }
+    }
+
+    #[test]
+    fn test_multiple_ports_on_single_device() {
+        let tmp = TempDir::new().unwrap();
+        let port1_counters = hw_counters_path(tmp.path(), "rdmap0s31", "1");
+        let port2_counters = hw_counters_path(tmp.path(), "rdmap0s31", "2");
+        fs::create_dir_all(&port1_counters).unwrap();
+        fs::create_dir_all(&port2_counters).unwrap();
+
+        for (metric_name, _) in STANDARD_METRICS {
+            let sysfs_name = strip_efa_prefix(metric_name);
+            fs::write(port1_counters.join(sysfs_name), "100\n").unwrap();
+            fs::write(port2_counters.join(sysfs_name), "300\n").unwrap();
+        }
+
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let mut registry = Registry::new();
+        provider.register_to(&mut registry);
+
+        let _ = provider.update_metrics();
+
+        // Increment port1 by 20, port2 by 40.
+        for (metric_name, _) in STANDARD_METRICS {
+            let sysfs_name = strip_efa_prefix(metric_name);
+            fs::write(port1_counters.join(sysfs_name), "120\n").unwrap();
+            fs::write(port2_counters.join(sysfs_name), "340\n").unwrap();
+        }
+
+        let _ = provider.update_metrics();
+
+        let metric_families = registry.gather();
+        for mf in &metric_families {
+            assert_eq!(mf.get_metric().len(), 2, "Should have 2 port entries");
+            let values: Vec<f64> = mf
+                .get_metric()
+                .iter()
+                .map(|m| m.get_gauge().get_value())
+                .collect();
+            let mut sorted = values.clone();
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            assert_eq!(sorted, vec![20.0, 40.0]);
         }
     }
 
@@ -713,15 +784,15 @@ mod tests {
     #[test]
     fn test_stale_device_cleanup() {
         let tmp = TempDir::new().unwrap();
-        let device1 = tmp.path().join("rdmap0s31").join(HW_COUNTERS_SUBPATH);
-        let device2 = tmp.path().join("rdmap1s32").join(HW_COUNTERS_SUBPATH);
-        fs::create_dir_all(&device1).unwrap();
-        fs::create_dir_all(&device2).unwrap();
+        let dev1_counters = hw_counters_path(tmp.path(), "rdmap0s31", TEST_PORT);
+        let dev2_counters = hw_counters_path(tmp.path(), "rdmap1s32", TEST_PORT);
+        fs::create_dir_all(&dev1_counters).unwrap();
+        fs::create_dir_all(&dev2_counters).unwrap();
 
         for (metric_name, _) in STANDARD_METRICS {
             let sysfs_name = strip_efa_prefix(metric_name);
-            fs::write(device1.join(sysfs_name), "100\n").unwrap();
-            fs::write(device2.join(sysfs_name), "200\n").unwrap();
+            fs::write(dev1_counters.join(sysfs_name), "100\n").unwrap();
+            fs::write(dev2_counters.join(sysfs_name), "200\n").unwrap();
         }
 
         let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
@@ -732,9 +803,8 @@ mod tests {
 
         let _ = provider.update_metrics();
 
-        // Stale entry for rdmap1s32 should be cleaned up.
         assert_eq!(provider.previous_values.len(), 1);
-        assert!(provider.previous_values.contains_key("rdmap0s31"));
-        assert!(!provider.previous_values.contains_key("rdmap1s32"));
+        assert!(provider.previous_values.contains_key("rdmap0s31/1"));
+        assert!(!provider.previous_values.contains_key("rdmap1s32/1"));
     }
 }

--- a/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
@@ -1,0 +1,687 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::{
+    metadata::{
+        imds_utils::retrieve_instance_id, k8s_metadata::K8sMetadata,
+        runtime_environment_metadata::ComputePlatform,
+    },
+    open_metrics::{
+        provider::OpenMetricProvider,
+        providers::{build_gauge_metric, MetricLabel},
+    },
+    reports::report::ReportValue,
+};
+use aws_config::imds::Client;
+use log::{info, warn};
+use prometheus::{IntGaugeVec, Registry};
+
+const INFINIBAND_SYSFS_PATH: &str = "/sys/class/infiniband";
+const HW_COUNTERS_SUBPATH: &str = "ports/1/hw_counters";
+
+const STANDARD_METRICS: &[(&str, &str)] = &[
+    ("efa_tx_bytes", "Bytes transmitted via EFA device since last scrape"),
+    ("efa_rx_bytes", "Bytes received via EFA device since last scrape"),
+    ("efa_tx_pkts", "Packets transmitted via EFA device since last scrape"),
+    ("efa_rx_pkts", "Packets received via EFA device since last scrape"),
+    ("efa_rx_drops", "Receive drops on EFA device since last scrape"),
+    ("efa_send_bytes", "RDMA send bytes on EFA device since last scrape"),
+    ("efa_recv_bytes", "RDMA recv bytes on EFA device since last scrape"),
+    ("efa_send_wrs", "RDMA send work requests on EFA device since last scrape"),
+    ("efa_recv_wrs", "RDMA recv work requests on EFA device since last scrape"),
+    ("efa_rdma_read_wrs", "RDMA read work requests on EFA device since last scrape"),
+    ("efa_rdma_read_bytes", "RDMA read bytes on EFA device since last scrape"),
+    ("efa_rdma_write_wrs", "RDMA write work requests on EFA device since last scrape"),
+    ("efa_rdma_write_bytes", "RDMA write bytes on EFA device since last scrape"),
+    ("efa_rdma_read_wr_err", "RDMA read work request errors on EFA device since last scrape"),
+    ("efa_rdma_write_wr_err", "RDMA write work request errors on EFA device since last scrape"),
+    ("efa_rdma_read_resp_bytes", "RDMA read response bytes on EFA device since last scrape"),
+    ("efa_rdma_write_recv_bytes", "RDMA write received bytes on EFA device since last scrape"),
+];
+
+const SRD_METRICS: &[(&str, &str)] = &[
+    ("efa_retrans_bytes", "SRD retransmitted bytes on EFA device since last scrape (Nitro v4+)"),
+    ("efa_retrans_pkts", "SRD retransmitted packets on EFA device since last scrape (Nitro v4+)"),
+    (
+        "efa_retrans_timeout_events",
+        "SRD retransmission timeout events on EFA device since last scrape (Nitro v4+)",
+    ),
+    (
+        "efa_impaired_remote_conn_events",
+        "Impaired remote connection events on EFA device since last scrape (Nitro v4+)",
+    ),
+    (
+        "efa_unresponsive_remote_events",
+        "Unresponsive remote events on EFA device since last scrape (Nitro v4+)",
+    ),
+];
+
+struct EfaMetric;
+
+impl MetricLabel for EfaMetric {
+    fn get_labels(compute_platform: &ComputePlatform) -> &[&str] {
+        match compute_platform {
+            ComputePlatform::Ec2Plain => &["instance_id", "device"],
+            ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
+                &["instance_id", "device", "node"]
+            }
+        }
+    }
+}
+
+pub struct EfaMetricsProvider {
+    compute_platform: ComputePlatform,
+    instance_id: String,
+    node_name: String,
+    sysfs_base: PathBuf,
+
+    standard_gauges: Vec<IntGaugeVec>,
+    srd_gauges: Vec<IntGaugeVec>,
+    srd_available: bool,
+
+    /// Cached previous sysfs counter values per (device, metric_index).
+    /// Used to compute per-scrape deltas via wrapping_sub.
+    previous_values: HashMap<String, Vec<u64>>,
+}
+
+impl EfaMetricsProvider {
+    pub fn efa_devices_present() -> bool {
+        Self::efa_devices_present_at(Path::new(INFINIBAND_SYSFS_PATH))
+    }
+
+    fn efa_devices_present_at(path: &Path) -> bool {
+        match fs::read_dir(path) {
+            Ok(entries) => entries.into_iter().any(|e| e.is_ok()),
+            Err(_) => false,
+        }
+    }
+
+    pub fn new(compute_platform: &ComputePlatform) -> Self {
+        Self::with_sysfs_base(compute_platform, PathBuf::from(INFINIBAND_SYSFS_PATH))
+    }
+
+    fn with_sysfs_base(compute_platform: &ComputePlatform, sysfs_base: PathBuf) -> Self {
+        let node_name = match K8sMetadata::default().node_name {
+            Some(ReportValue::String(node_name)) => node_name,
+            _ => "unknown".to_string(),
+        };
+
+        let srd_available = Self::detect_srd_support(&sysfs_base);
+
+        let standard_gauges = STANDARD_METRICS
+            .iter()
+            .map(|(name, desc)| build_gauge_metric::<EfaMetric>(compute_platform, name, desc))
+            .collect();
+
+        let srd_gauges = if srd_available {
+            SRD_METRICS
+                .iter()
+                .map(|(name, desc)| build_gauge_metric::<EfaMetric>(compute_platform, name, desc))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        let mut provider = EfaMetricsProvider {
+            compute_platform: compute_platform.clone(),
+            instance_id: retrieve_instance_id(&Client::builder().build()),
+            node_name,
+            sysfs_base,
+            standard_gauges,
+            srd_gauges,
+            srd_available,
+            previous_values: HashMap::new(),
+        };
+
+        // Seed the cache with current sysfs values so the first scrape produces
+        // clean deltas instead of a large historical spike.
+        provider.seed_cache();
+        provider
+    }
+
+    fn total_metrics_count(&self) -> usize {
+        STANDARD_METRICS.len() + if self.srd_available { SRD_METRICS.len() } else { 0 }
+    }
+
+    fn seed_cache(&mut self) {
+        for device in self.discover_devices() {
+            let values = self.read_all_counters(&device);
+            self.previous_values.insert(device, values);
+        }
+    }
+
+    fn read_all_counters(&self, device: &str) -> Vec<u64> {
+        let mut values = Vec::with_capacity(self.total_metrics_count());
+
+        for (metric_name, _) in STANDARD_METRICS {
+            let sysfs_name = standard_metric_name(metric_name);
+            values.push(self.read_counter(device, sysfs_name).unwrap_or(0));
+        }
+
+        if self.srd_available {
+            for (metric_name, _) in SRD_METRICS {
+                let sysfs_name = srd_metric_name(metric_name);
+                values.push(self.read_counter(device, sysfs_name).unwrap_or(0));
+            }
+        }
+
+        values
+    }
+
+    fn detect_srd_support(sysfs_base: &Path) -> bool {
+        let Ok(entries) = fs::read_dir(sysfs_base) else {
+            return false;
+        };
+
+        for entry in entries.flatten() {
+            let counters_path = entry.path().join(HW_COUNTERS_SUBPATH);
+            let first_srd_metric = srd_metric_name(SRD_METRICS[0].0);
+            if counters_path.join(first_srd_metric).exists() {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn discover_devices(&self) -> Vec<String> {
+        match fs::read_dir(&self.sysfs_base) {
+            Ok(entries) => entries
+                .flatten()
+                .filter_map(|e| e.file_name().into_string().ok())
+                .collect(),
+            Err(e) => {
+                warn!("Failed to read EFA devices from {:?}: {}", self.sysfs_base, e);
+                Vec::new()
+            }
+        }
+    }
+
+    fn read_counter(&self, device: &str, metric_name: &str) -> Option<u64> {
+        let path = self
+            .sysfs_base
+            .join(device)
+            .join(HW_COUNTERS_SUBPATH)
+            .join(metric_name);
+
+        match fs::read_to_string(&path) {
+            Ok(content) => match content.trim().parse::<u64>() {
+                Ok(value) => Some(value),
+                Err(e) => {
+                    warn!("Failed to parse EFA metric {:?}: {}", path, e);
+                    None
+                }
+            },
+            Err(e) => {
+                warn!("Failed to read EFA metric {:?}: {}", path, e);
+                None
+            }
+        }
+    }
+
+    fn label_values<'a>(&'a self, device: &'a str) -> Vec<&'a str> {
+        match self.compute_platform {
+            ComputePlatform::Ec2Plain => vec![&self.instance_id, device],
+            ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
+                vec![&self.instance_id, device, &self.node_name]
+            }
+        }
+    }
+}
+
+fn srd_metric_name(prefixed_name: &str) -> &str {
+    prefixed_name.strip_prefix("efa_").unwrap_or(prefixed_name)
+}
+
+fn standard_metric_name(prefixed_name: &str) -> &str {
+    prefixed_name.strip_prefix("efa_").unwrap_or(prefixed_name)
+}
+
+impl OpenMetricProvider for EfaMetricsProvider {
+    fn register_to(&self, registry: &mut Registry) {
+        info!(
+            platform = self.compute_platform.to_string(),
+            srd_available = self.srd_available;
+            "Registering EFA Metrics"
+        );
+
+        for gauge in &self.standard_gauges {
+            registry.register(Box::new(gauge.clone())).unwrap();
+        }
+
+        for gauge in &self.srd_gauges {
+            registry.register(Box::new(gauge.clone())).unwrap();
+        }
+    }
+
+    fn update_metrics(&mut self) -> Result<(), anyhow::Error> {
+        let devices = self.discover_devices();
+
+        for device in &devices {
+            let current_values = self.read_all_counters(device);
+            let previous = self
+                .previous_values
+                .get(device)
+                .cloned()
+                .unwrap_or_else(|| vec![0; self.total_metrics_count()]);
+
+            let label_values = self.label_values(device);
+
+            for (i, _) in STANDARD_METRICS.iter().enumerate() {
+                let delta = current_values[i].wrapping_sub(previous[i]);
+                self.standard_gauges[i]
+                    .with_label_values(&label_values)
+                    .set(delta as i64);
+            }
+
+            if self.srd_available {
+                let offset = STANDARD_METRICS.len();
+                for (i, _) in SRD_METRICS.iter().enumerate() {
+                    let delta = current_values[offset + i].wrapping_sub(previous[offset + i]);
+                    self.srd_gauges[i]
+                        .with_label_values(&label_values)
+                        .set(delta as i64);
+                }
+            }
+
+            self.previous_values.insert(device.clone(), current_values);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prometheus::Registry;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn create_mock_sysfs(with_srd: bool) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let device_path = tmp.path().join("rdmap0s31").join(HW_COUNTERS_SUBPATH);
+        fs::create_dir_all(&device_path).unwrap();
+
+        for (metric_name, _) in STANDARD_METRICS {
+            let sysfs_name = standard_metric_name(metric_name);
+            fs::write(device_path.join(sysfs_name), "42\n").unwrap();
+        }
+
+        if with_srd {
+            for (metric_name, _) in SRD_METRICS {
+                let sysfs_name = srd_metric_name(metric_name);
+                fs::write(device_path.join(sysfs_name), "7\n").unwrap();
+            }
+        }
+
+        tmp
+    }
+
+    fn create_provider_with_mock(tmp: &TempDir, platform: ComputePlatform) -> EfaMetricsProvider {
+        let sysfs_base = tmp.path().to_path_buf();
+        let srd_available = EfaMetricsProvider::detect_srd_support(&sysfs_base);
+
+        let standard_gauges = STANDARD_METRICS
+            .iter()
+            .map(|(name, desc)| build_gauge_metric::<EfaMetric>(&platform, name, desc))
+            .collect();
+
+        let srd_gauges = if srd_available {
+            SRD_METRICS
+                .iter()
+                .map(|(name, desc)| build_gauge_metric::<EfaMetric>(&platform, name, desc))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        let mut provider = EfaMetricsProvider {
+            compute_platform: platform,
+            instance_id: "i-1234567890abcdef0".to_string(),
+            node_name: "test-node".to_string(),
+            sysfs_base,
+            standard_gauges,
+            srd_gauges,
+            srd_available,
+            previous_values: HashMap::new(),
+        };
+
+        // Seed cache like the real constructor does.
+        provider.seed_cache();
+        provider
+    }
+
+    fn write_counters(tmp: &TempDir, device: &str, standard_val: u64, srd_val: Option<u64>) {
+        let device_path = tmp.path().join(device).join(HW_COUNTERS_SUBPATH);
+        for (metric_name, _) in STANDARD_METRICS {
+            let sysfs_name = standard_metric_name(metric_name);
+            fs::write(device_path.join(sysfs_name), format!("{}\n", standard_val)).unwrap();
+        }
+        if let Some(val) = srd_val {
+            for (metric_name, _) in SRD_METRICS {
+                let sysfs_name = srd_metric_name(metric_name);
+                fs::write(device_path.join(sysfs_name), format!("{}\n", val)).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn test_efa_devices_present_with_devices() {
+        let tmp = create_mock_sysfs(false);
+        assert!(EfaMetricsProvider::efa_devices_present_at(tmp.path()));
+    }
+
+    #[test]
+    fn test_efa_devices_present_empty_dir() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!EfaMetricsProvider::efa_devices_present_at(tmp.path()));
+    }
+
+    #[test]
+    fn test_efa_devices_present_no_dir() {
+        assert!(!EfaMetricsProvider::efa_devices_present_at(Path::new(
+            "/nonexistent/path"
+        )));
+    }
+
+    #[test]
+    fn test_detect_srd_support_present() {
+        let tmp = create_mock_sysfs(true);
+        assert!(EfaMetricsProvider::detect_srd_support(tmp.path()));
+    }
+
+    #[test]
+    fn test_detect_srd_support_absent() {
+        let tmp = create_mock_sysfs(false);
+        assert!(!EfaMetricsProvider::detect_srd_support(tmp.path()));
+    }
+
+    #[test]
+    fn test_discover_devices() {
+        let tmp = create_mock_sysfs(false);
+        let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let devices = provider.discover_devices();
+        assert_eq!(devices, vec!["rdmap0s31"]);
+    }
+
+    #[test]
+    fn test_read_counter_success() {
+        let tmp = create_mock_sysfs(false);
+        let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let value = provider.read_counter("rdmap0s31", "tx_bytes");
+        assert_eq!(value, Some(42));
+    }
+
+    #[test]
+    fn test_read_counter_missing_file() {
+        let tmp = create_mock_sysfs(false);
+        let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let value = provider.read_counter("rdmap0s31", "nonexistent_metric");
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn test_register_standard_metrics_only() {
+        let tmp = create_mock_sysfs(false);
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let mut registry = Registry::new();
+        provider.register_to(&mut registry);
+        let _ = provider.update_metrics();
+
+        let metric_families = registry.gather();
+        assert_eq!(metric_families.len(), STANDARD_METRICS.len());
+    }
+
+    #[test]
+    fn test_register_with_srd_metrics() {
+        let tmp = create_mock_sysfs(true);
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let mut registry = Registry::new();
+        provider.register_to(&mut registry);
+        let _ = provider.update_metrics();
+
+        let metric_families = registry.gather();
+        assert_eq!(
+            metric_families.len(),
+            STANDARD_METRICS.len() + SRD_METRICS.len()
+        );
+    }
+
+    #[test]
+    fn test_first_scrape_returns_zero_delta() {
+        let tmp = create_mock_sysfs(false);
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let mut registry = Registry::new();
+        provider.register_to(&mut registry);
+
+        // First update after seeded cache — counters haven't changed, so delta is 0.
+        let result = provider.update_metrics();
+        assert!(result.is_ok());
+
+        let metric_families = registry.gather();
+        for mf in &metric_families {
+            for metric in mf.get_metric() {
+                assert_eq!(
+                    metric.get_gauge().get_value(),
+                    0.0,
+                    "First scrape should return 0 delta for {}",
+                    mf.get_name()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_delta_after_counter_increment() {
+        let tmp = create_mock_sysfs(false);
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let mut registry = Registry::new();
+        provider.register_to(&mut registry);
+
+        // First scrape: delta is 0 (cache was seeded with value 42).
+        let _ = provider.update_metrics();
+
+        // Simulate counter increment: 42 -> 100 (delta should be 58).
+        write_counters(&tmp, "rdmap0s31", 100, None);
+
+        let _ = provider.update_metrics();
+        let metric_families = registry.gather();
+        for mf in &metric_families {
+            for metric in mf.get_metric() {
+                assert_eq!(
+                    metric.get_gauge().get_value(),
+                    58.0,
+                    "Delta should be 58 for {}",
+                    mf.get_name()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_delta_returns_zero_when_idle() {
+        let tmp = create_mock_sysfs(false);
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let mut registry = Registry::new();
+        provider.register_to(&mut registry);
+
+        // First scrape seeds, second scrape with same values -> delta 0.
+        let _ = provider.update_metrics();
+        let _ = provider.update_metrics();
+
+        let metric_families = registry.gather();
+        for mf in &metric_families {
+            for metric in mf.get_metric() {
+                assert_eq!(metric.get_gauge().get_value(), 0.0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_delta_with_counter_wraparound() {
+        let tmp = create_mock_sysfs(false);
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let mut registry = Registry::new();
+        provider.register_to(&mut registry);
+
+        // First scrape (seeded at 42, read 42 -> delta 0).
+        let _ = provider.update_metrics();
+
+        // Simulate wraparound: counter goes from 42 to a smaller value (e.g., u64::MAX - 10 + 42 = wraps).
+        // Set counter to u64::MAX - 5 (very large), then next to 10.
+        write_counters(&tmp, "rdmap0s31", u64::MAX - 5, None);
+        let _ = provider.update_metrics();
+
+        // Now wrap: u64::MAX - 5 -> 10 means delta = 10 - (MAX-5) via wrapping_sub = 16.
+        write_counters(&tmp, "rdmap0s31", 10, None);
+        let _ = provider.update_metrics();
+
+        let metric_families = registry.gather();
+        for mf in &metric_families {
+            for metric in mf.get_metric() {
+                assert_eq!(
+                    metric.get_gauge().get_value(),
+                    16.0,
+                    "Wraparound delta should be 16 for {}",
+                    mf.get_name()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_delta_with_srd_metrics() {
+        let tmp = create_mock_sysfs(true);
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let mut registry = Registry::new();
+        provider.register_to(&mut registry);
+
+        // First scrape: delta 0 (seeded at 42/7).
+        let _ = provider.update_metrics();
+
+        // Increment: standard 42->52 (delta 10), SRD 7->17 (delta 10).
+        write_counters(&tmp, "rdmap0s31", 52, Some(17));
+        let _ = provider.update_metrics();
+
+        let metric_families = registry.gather();
+        let srd_names: Vec<&str> = SRD_METRICS.iter().map(|(name, _)| *name).collect();
+
+        for mf in &metric_families {
+            for metric in mf.get_metric() {
+                assert_eq!(
+                    metric.get_gauge().get_value(),
+                    10.0,
+                    "Delta should be 10 for {}",
+                    mf.get_name()
+                );
+            }
+        }
+
+        // Verify SRD metric names present
+        let reported_names: Vec<&str> = metric_families.iter().map(|mf| mf.get_name()).collect();
+        for srd_name in &srd_names {
+            assert!(reported_names.contains(srd_name));
+        }
+    }
+
+    #[test]
+    fn test_labels_ec2_plain() {
+        let labels = EfaMetric::get_labels(&ComputePlatform::Ec2Plain);
+        assert_eq!(labels, &["instance_id", "device"]);
+    }
+
+    #[test]
+    fn test_labels_k8s() {
+        for platform in &[ComputePlatform::Ec2K8sEks, ComputePlatform::Ec2K8sVanilla] {
+            let labels = EfaMetric::get_labels(platform);
+            assert_eq!(labels, &["instance_id", "device", "node"]);
+        }
+    }
+
+    #[test]
+    fn test_label_values_ec2() {
+        let tmp = create_mock_sysfs(false);
+        let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let values = provider.label_values("rdmap0s31");
+        assert_eq!(values, vec!["i-1234567890abcdef0", "rdmap0s31"]);
+    }
+
+    #[test]
+    fn test_label_values_k8s() {
+        let tmp = create_mock_sysfs(false);
+        let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2K8sEks);
+        let values = provider.label_values("rdmap0s31");
+        assert_eq!(
+            values,
+            vec!["i-1234567890abcdef0", "rdmap0s31", "test-node"]
+        );
+    }
+
+    #[test]
+    fn test_multiple_devices_delta() {
+        let tmp = TempDir::new().unwrap();
+        let device1 = tmp.path().join("rdmap0s31").join(HW_COUNTERS_SUBPATH);
+        let device2 = tmp.path().join("rdmap1s32").join(HW_COUNTERS_SUBPATH);
+        fs::create_dir_all(&device1).unwrap();
+        fs::create_dir_all(&device2).unwrap();
+
+        for (metric_name, _) in STANDARD_METRICS {
+            let sysfs_name = standard_metric_name(metric_name);
+            fs::write(device1.join(sysfs_name), "100\n").unwrap();
+            fs::write(device2.join(sysfs_name), "200\n").unwrap();
+        }
+
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let mut registry = Registry::new();
+        provider.register_to(&mut registry);
+
+        // First scrape: delta 0 (cache seeded).
+        let _ = provider.update_metrics();
+
+        // Increment device1 by 10, device2 by 50.
+        for (metric_name, _) in STANDARD_METRICS {
+            let sysfs_name = standard_metric_name(metric_name);
+            fs::write(device1.join(sysfs_name), "110\n").unwrap();
+            fs::write(device2.join(sysfs_name), "250\n").unwrap();
+        }
+
+        let result = provider.update_metrics();
+        assert!(result.is_ok());
+
+        let metric_families = registry.gather();
+        for mf in &metric_families {
+            assert_eq!(mf.get_metric().len(), 2, "Should have 2 devices");
+            let values: Vec<f64> = mf
+                .get_metric()
+                .iter()
+                .map(|m| m.get_gauge().get_value())
+                .collect();
+            let mut sorted = values.clone();
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            assert_eq!(sorted, vec![10.0, 50.0]);
+        }
+    }
+
+    #[test]
+    fn test_metric_names_have_efa_prefix() {
+        let tmp = create_mock_sysfs(true);
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        let mut registry = Registry::new();
+        provider.register_to(&mut registry);
+
+        let _ = provider.update_metrics();
+        let metric_families = registry.gather();
+
+        for mf in &metric_families {
+            assert!(
+                mf.get_name().starts_with("efa_"),
+                "Metric name '{}' does not start with 'efa_'",
+                mf.get_name()
+            );
+        }
+    }
+}

--- a/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
@@ -287,11 +287,15 @@ impl OpenMetricProvider for EfaMetricsProvider {
         );
 
         for gauge in &self.standard_gauges {
-            registry.register(Box::new(gauge.clone())).unwrap();
+            registry
+                .register(Box::new(gauge.clone()))
+                .expect("EFA metric registration");
         }
 
         for gauge in &self.srd_gauges {
-            registry.register(Box::new(gauge.clone())).unwrap();
+            registry
+                .register(Box::new(gauge.clone()))
+                .expect("EFA metric registration");
         }
     }
 

--- a/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
@@ -17,7 +17,7 @@ use crate::{
     reports::report::ReportValue,
 };
 use aws_config::imds::Client;
-use log::{info, warn};
+use log::{debug, info, warn};
 use prometheus::{IntGaugeVec, Registry};
 
 const INFINIBAND_SYSFS_PATH: &str = "/sys/class/infiniband";
@@ -158,13 +158,13 @@ impl EfaMetricsProvider {
         let mut values = Vec::with_capacity(self.total_metrics_count());
 
         for (metric_name, _) in STANDARD_METRICS {
-            let sysfs_name = standard_metric_name(metric_name);
+            let sysfs_name = strip_efa_prefix(metric_name);
             values.push(self.read_counter(device, sysfs_name).unwrap_or(0));
         }
 
         if self.srd_available {
             for (metric_name, _) in SRD_METRICS {
-                let sysfs_name = srd_metric_name(metric_name);
+                let sysfs_name = strip_efa_prefix(metric_name);
                 values.push(self.read_counter(device, sysfs_name).unwrap_or(0));
             }
         }
@@ -179,7 +179,7 @@ impl EfaMetricsProvider {
 
         for entry in entries.flatten() {
             let counters_path = entry.path().join(HW_COUNTERS_SUBPATH);
-            let first_srd_metric = srd_metric_name(SRD_METRICS[0].0);
+            let first_srd_metric = strip_efa_prefix(SRD_METRICS[0].0);
             if counters_path.join(first_srd_metric).exists() {
                 return true;
             }
@@ -216,7 +216,7 @@ impl EfaMetricsProvider {
                 }
             },
             Err(e) => {
-                warn!("Failed to read EFA metric {:?}: {}", path, e);
+                debug!("Failed to read EFA metric {:?}: {}", path, e);
                 None
             }
         }
@@ -232,12 +232,19 @@ impl EfaMetricsProvider {
     }
 }
 
-fn srd_metric_name(prefixed_name: &str) -> &str {
+fn strip_efa_prefix(prefixed_name: &str) -> &str {
     prefixed_name.strip_prefix("efa_").unwrap_or(prefixed_name)
 }
 
-fn standard_metric_name(prefixed_name: &str) -> &str {
-    prefixed_name.strip_prefix("efa_").unwrap_or(prefixed_name)
+/// Computes the delta between two counter readings. If the counter appears to
+/// have reset (current < previous), returns the current value assuming the
+/// counter restarted from 0.
+fn compute_delta(current: u64, previous: u64) -> u64 {
+    if current >= previous {
+        current - previous
+    } else {
+        current
+    }
 }
 
 impl OpenMetricProvider for EfaMetricsProvider {
@@ -260,6 +267,9 @@ impl OpenMetricProvider for EfaMetricsProvider {
     fn update_metrics(&mut self) -> Result<(), anyhow::Error> {
         let devices = self.discover_devices();
 
+        // Remove stale entries for devices that no longer exist.
+        self.previous_values.retain(|d, _| devices.contains(d));
+
         for device in &devices {
             let current_values = self.read_all_counters(device);
             let previous = self
@@ -271,7 +281,7 @@ impl OpenMetricProvider for EfaMetricsProvider {
             let label_values = self.label_values(device);
 
             for (i, _) in STANDARD_METRICS.iter().enumerate() {
-                let delta = current_values[i].wrapping_sub(previous[i]);
+                let delta = compute_delta(current_values[i], previous[i]);
                 self.standard_gauges[i]
                     .with_label_values(&label_values)
                     .set(delta as i64);
@@ -280,7 +290,7 @@ impl OpenMetricProvider for EfaMetricsProvider {
             if self.srd_available {
                 let offset = STANDARD_METRICS.len();
                 for (i, _) in SRD_METRICS.iter().enumerate() {
-                    let delta = current_values[offset + i].wrapping_sub(previous[offset + i]);
+                    let delta = compute_delta(current_values[offset + i], previous[offset + i]);
                     self.srd_gauges[i]
                         .with_label_values(&label_values)
                         .set(delta as i64);
@@ -307,13 +317,13 @@ mod tests {
         fs::create_dir_all(&device_path).unwrap();
 
         for (metric_name, _) in STANDARD_METRICS {
-            let sysfs_name = standard_metric_name(metric_name);
+            let sysfs_name = strip_efa_prefix(metric_name);
             fs::write(device_path.join(sysfs_name), "42\n").unwrap();
         }
 
         if with_srd {
             for (metric_name, _) in SRD_METRICS {
-                let sysfs_name = srd_metric_name(metric_name);
+                let sysfs_name = strip_efa_prefix(metric_name);
                 fs::write(device_path.join(sysfs_name), "7\n").unwrap();
             }
         }
@@ -358,12 +368,12 @@ mod tests {
     fn write_counters(tmp: &TempDir, device: &str, standard_val: u64, srd_val: Option<u64>) {
         let device_path = tmp.path().join(device).join(HW_COUNTERS_SUBPATH);
         for (metric_name, _) in STANDARD_METRICS {
-            let sysfs_name = standard_metric_name(metric_name);
+            let sysfs_name = strip_efa_prefix(metric_name);
             fs::write(device_path.join(sysfs_name), format!("{}\n", standard_val)).unwrap();
         }
         if let Some(val) = srd_val {
             for (metric_name, _) in SRD_METRICS {
-                let sysfs_name = srd_metric_name(metric_name);
+                let sysfs_name = strip_efa_prefix(metric_name);
                 fs::write(device_path.join(sysfs_name), format!("{}\n", val)).unwrap();
             }
         }
@@ -522,7 +532,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delta_with_counter_wraparound() {
+    fn test_delta_with_counter_reset_returns_current() {
         let tmp = create_mock_sysfs(false);
         let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
         let mut registry = Registry::new();
@@ -531,13 +541,13 @@ mod tests {
         // First scrape (seeded at 42, read 42 -> delta 0).
         let _ = provider.update_metrics();
 
-        // Simulate wraparound: counter goes from 42 to a smaller value (e.g., u64::MAX - 10 + 42 = wraps).
-        // Set counter to u64::MAX - 5 (very large), then next to 10.
-        write_counters(&tmp, "rdmap0s31", u64::MAX - 5, None);
+        // Simulate counter going up.
+        write_counters(&tmp, "rdmap0s31", 1000, None);
         let _ = provider.update_metrics();
 
-        // Now wrap: u64::MAX - 5 -> 10 means delta = 10 - (MAX-5) via wrapping_sub = 16.
-        write_counters(&tmp, "rdmap0s31", 10, None);
+        // Simulate counter reset (e.g., driver reload): 1000 -> 5.
+        // Should return the current value (5) assuming counter restarted from 0.
+        write_counters(&tmp, "rdmap0s31", 5, None);
         let _ = provider.update_metrics();
 
         let metric_families = registry.gather();
@@ -545,8 +555,8 @@ mod tests {
             for metric in mf.get_metric() {
                 assert_eq!(
                     metric.get_gauge().get_value(),
-                    16.0,
-                    "Wraparound delta should be 16 for {}",
+                    5.0,
+                    "Counter reset should return current value for {}",
                     mf.get_name()
                 );
             }
@@ -630,7 +640,7 @@ mod tests {
         fs::create_dir_all(&device2).unwrap();
 
         for (metric_name, _) in STANDARD_METRICS {
-            let sysfs_name = standard_metric_name(metric_name);
+            let sysfs_name = strip_efa_prefix(metric_name);
             fs::write(device1.join(sysfs_name), "100\n").unwrap();
             fs::write(device2.join(sysfs_name), "200\n").unwrap();
         }
@@ -644,7 +654,7 @@ mod tests {
 
         // Increment device1 by 10, device2 by 50.
         for (metric_name, _) in STANDARD_METRICS {
-            let sysfs_name = standard_metric_name(metric_name);
+            let sysfs_name = strip_efa_prefix(metric_name);
             fs::write(device1.join(sysfs_name), "110\n").unwrap();
             fs::write(device2.join(sysfs_name), "250\n").unwrap();
         }
@@ -683,5 +693,48 @@ mod tests {
                 mf.get_name()
             );
         }
+    }
+
+    #[test]
+    fn test_compute_delta_normal() {
+        assert_eq!(compute_delta(100, 42), 58);
+    }
+
+    #[test]
+    fn test_compute_delta_same_value() {
+        assert_eq!(compute_delta(42, 42), 0);
+    }
+
+    #[test]
+    fn test_compute_delta_reset_returns_current() {
+        assert_eq!(compute_delta(5, 1000), 5);
+    }
+
+    #[test]
+    fn test_stale_device_cleanup() {
+        let tmp = TempDir::new().unwrap();
+        let device1 = tmp.path().join("rdmap0s31").join(HW_COUNTERS_SUBPATH);
+        let device2 = tmp.path().join("rdmap1s32").join(HW_COUNTERS_SUBPATH);
+        fs::create_dir_all(&device1).unwrap();
+        fs::create_dir_all(&device2).unwrap();
+
+        for (metric_name, _) in STANDARD_METRICS {
+            let sysfs_name = strip_efa_prefix(metric_name);
+            fs::write(device1.join(sysfs_name), "100\n").unwrap();
+            fs::write(device2.join(sysfs_name), "200\n").unwrap();
+        }
+
+        let mut provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2Plain);
+        assert_eq!(provider.previous_values.len(), 2);
+
+        // Remove device2 from sysfs.
+        fs::remove_dir_all(tmp.path().join("rdmap1s32")).unwrap();
+
+        let _ = provider.update_metrics();
+
+        // Stale entry for rdmap1s32 should be cleaned up.
+        assert_eq!(provider.previous_values.len(), 1);
+        assert!(provider.previous_values.contains_key("rdmap0s31"));
+        assert!(!provider.previous_values.contains_key("rdmap1s32"));
     }
 }

--- a/nfm-controller/src/open_metrics/providers/mod.rs
+++ b/nfm-controller/src/open_metrics/providers/mod.rs
@@ -7,6 +7,7 @@ use prometheus::{IntGaugeVec, Opts};
 
 use crate::metadata::runtime_environment_metadata::ComputePlatform;
 
+pub mod efa_metrics_provider;
 pub mod interface_metrics_provider;
 pub mod system_metrics_provider;
 


### PR DESCRIPTION
### Summary
Adds EFA metrics collection to the NFM agent's /metrics endpoint. Reads hardware counters from _/sys/class/infiniband/<device>/ports/<port>/hw_counters/_ and exposes 17 standard + 5 SRD (Nitro v4+ only) metrics as per-scrape delta gauges. Only enabled when EFA devices are detected at startup.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
