### PR TITLE
Add Kubernetes integration tests on real EKS clusters

### DIFF
--- a/.ci/integration-tests/k8s-scripts/deploy-agent.sh
+++ b/.ci/integration-tests/k8s-scripts/deploy-agent.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Deploys the NFM agent to a Kubernetes cluster via Helm chart.
+#
+# Usage: deploy-agent.sh <image-uri> <kubeconfig> [values-override-file] [arch]
+#
+# Arguments:
+#   image-uri              Full Docker image URI (registry/repo:tag)
+#   kubeconfig             Path to kubeconfig file
+#   values-override-file   (Optional) Path to a Helm values override file
+#   arch                   (Optional) Target architecture (amd64 or arm64).
+#                          If set, restricts the DaemonSet to only nodes of this arch.
+#
+# The agent is deployed as a DaemonSet using the project's Helm chart.
+# It waits for all pods to be ready before returning.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+IMAGE_URI="$1"
+KUBECONFIG_PATH="$2"
+VALUES_OVERRIDE="${3:-}"
+TARGET_ARCH="${4:-}"
+
+export KUBECONFIG="$KUBECONFIG_PATH"
+
+CHART_DIR="$(cd "$(dirname "$0")/../../.." && pwd)/charts/amazon-network-flow-monitor-agent"
+# Use arch-specific namespace and release name to avoid collisions when
+# amd64 and arm64 jobs run concurrently on the same cluster.
+NAMESPACE="amazon-cloudwatch-${TARGET_ARCH:-default}"
+RELEASE_NAME="nfm-agent-test-${TARGET_ARCH:-default}"
+
+echo "=== Deploying NFM agent via Helm ==="
+echo "  Image:     ${IMAGE_URI}"
+echo "  Chart:     ${CHART_DIR}"
+echo "  Namespace: ${NAMESPACE}"
+
+# Clean up any stale state from a previous failed run.
+# Delete and recreate the namespace to ensure no orphaned resources or
+# stuck Helm releases (which can't be uninstalled if in "pending" state).
+kubectl delete namespace "$NAMESPACE" --ignore-not-found --wait=true 2>/dev/null || true
+kubectl create namespace "$NAMESPACE"
+
+# Build Helm install command
+HELM_CMD=(helm upgrade --install "$RELEASE_NAME" "$CHART_DIR"
+  --namespace "$NAMESPACE"
+  --set "image.override=${IMAGE_URI}"
+  --set "env.RUST_LOG=debug"
+  --set "env.LOG_REPORTS=on"
+  --wait
+  --timeout 5m
+)
+
+# When arch is specified, restrict to matching nodes and use arch-specific
+# names for cluster-scoped resources to avoid conflicts between parallel jobs.
+if [ -n "$TARGET_ARCH" ]; then
+  HELM_CMD+=(--set "affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=kubernetes.io/arch")
+  HELM_CMD+=(--set "affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In")
+  HELM_CMD+=(--set "affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=${TARGET_ARCH}")
+  HELM_CMD+=(--set "clusterRole.name=aws-network-flow-monitor-agent-role-${TARGET_ARCH}")
+  HELM_CMD+=(--set "clusterRoleBinding.name=aws-network-flow-monitor-agent-role-binding-${TARGET_ARCH}")
+  HELM_CMD+=(--set "serviceAccount.name=aws-network-flow-monitor-agent-sa-${TARGET_ARCH}")
+  HELM_CMD+=(--set "daemonSet.name=aws-network-flow-monitor-agent-${TARGET_ARCH}")
+  echo "  Arch:      ${TARGET_ARCH} (restricting to ${TARGET_ARCH} nodes only)"
+fi
+
+if [ -n "$VALUES_OVERRIDE" ] && [ -f "$VALUES_OVERRIDE" ]; then
+  HELM_CMD+=(--values "$VALUES_OVERRIDE")
+  echo "  Overrides: ${VALUES_OVERRIDE}"
+fi
+
+echo ""
+echo "Running: ${HELM_CMD[*]}"
+"${HELM_CMD[@]}"
+
+echo ""
+echo "=== Helm release deployed ==="
+helm list --namespace "$NAMESPACE"
+
+echo ""
+echo "=== DaemonSet status ==="
+kubectl get daemonset -n "$NAMESPACE" -o wide
+
+echo ""
+echo "=== Pod status ==="
+kubectl get pods -n "$NAMESPACE" -o wide
+
+# Verify all DaemonSet pods are running
+echo ""
+echo "Waiting for all DaemonSet pods to be Running..."
+DS_NAME="aws-network-flow-monitor-agent${TARGET_ARCH:+-${TARGET_ARCH}}"
+for i in $(seq 1 30); do
+  DESIRED=$(kubectl get daemonset "$DS_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo "0")
+  READY=$(kubectl get daemonset "$DS_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.status.numberReady}' 2>/dev/null || echo "0")
+
+  if [ "$DESIRED" -gt 0 ] && [ "$READY" -eq "$DESIRED" ]; then
+    echo "All pods ready (${READY}/${DESIRED})"
+    break
+  fi
+
+  if [ $i -eq 30 ]; then
+    echo "ERROR: DaemonSet pods did not become ready within 5 minutes"
+    echo "=== Pod descriptions ==="
+    kubectl describe pods -n "$NAMESPACE" || true
+    echo "=== Pod logs ==="
+    kubectl logs -n "$NAMESPACE" -l "name=$DS_NAME" --tail=50 || true
+    exit 1
+  fi
+  sleep 10
+done
+
+# Verify eBPF program is loaded (check agent logs for successful start)
+echo ""
+echo "=== Verifying eBPF program loaded ==="
+PODS=$(kubectl get pods -n "$NAMESPACE" -l "name=$DS_NAME" \
+  -o jsonpath='{.items[*].metadata.name}')
+
+for POD in $PODS; do
+  echo "--- Pod: ${POD} ---"
+  # Check that the agent started and loaded ebpf program successfully
+  if kubectl logs -n "$NAMESPACE" "$POD" -c "$DS_NAME" --tail=30 2>/dev/null | \
+     grep -q "Aggregating across sockets\|Aggregation complete\|Publishing report"; then
+    echo "  eBPF program loaded successfully"
+  else
+    echo "  WARNING: Could not confirm BPF attachment, dumping recent logs:"
+    kubectl logs -n "$NAMESPACE" "$POD" -c "$DS_NAME" --tail=30 2>/dev/null || true
+  fi
+done
+
+echo ""
+echo "=== Agent deployment complete ==="

--- a/.ci/integration-tests/k8s-scripts/run-test.sh
+++ b/.ci/integration-tests/k8s-scripts/run-test.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# Runs the integration test suite against the NFM agent deployed in Kubernetes.
+#
+# Usage: run-test.sh <kubeconfig> [arch]
+#
+# This script:
+#   1. Deploys a test workload (client + server pods) to generate TCP traffic
+#   2. Waits for the agent to observe and report the connections
+#   3. Validates the agent logs contain the expected flow data
+#
+# Prerequisites:
+#   - NFM agent DaemonSet is already running (via deploy-agent.sh)
+#   - Agent is deployed with LOG_REPORTS=on and publishing enabled
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+KUBECONFIG_PATH="$1"
+TARGET_ARCH="${2:-}"
+export KUBECONFIG="$KUBECONFIG_PATH"
+
+NAMESPACE="amazon-cloudwatch-${TARGET_ARCH:-default}"
+TEST_NAMESPACE="nfm-test-${TARGET_ARCH:-default}"
+PUBLISH_SECS=5
+
+echo "=== Running K8s integration tests ==="
+
+# Create test namespace
+kubectl create namespace "$TEST_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+# Build nodeSelector YAML snippet if arch is specified
+NODE_SELECTOR=""
+if [ -n "$TARGET_ARCH" ]; then
+  NODE_SELECTOR="  nodeSelector:
+    kubernetes.io/arch: ${TARGET_ARCH}"
+  echo "Restricting test pods to ${TARGET_ARCH} nodes"
+fi
+
+# Deploy a simple HTTP server as a test workload
+echo "Deploying test server..."
+kubectl apply -n "$TEST_NAMESPACE" -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-server
+  labels:
+    app: nfm-test-server
+spec:
+${NODE_SELECTOR}
+  containers:
+    - name: server
+      image: public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
+      command:
+        - /bin/sh
+        - -c
+        - |
+          microdnf install -y python3 && \
+          python3 -c "
+          import http.server, socketserver
+          class H(http.server.SimpleHTTPRequestHandler):
+              def do_GET(self):
+                  self.send_response(200)
+                  self.send_header('Content-type','text/plain')
+                  self.end_headers()
+                  self.wfile.write(b'hello from nfm-test-server')
+              def log_message(self, *a): pass
+          socketserver.TCPServer(('0.0.0.0', 8080), H).serve_forever()
+          "
+      ports:
+        - containerPort: 8080
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 8080
+        initialDelaySeconds: 5
+        periodSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-server
+spec:
+  selector:
+    app: nfm-test-server
+  ports:
+    - port: 8080
+      targetPort: 8080
+EOF
+
+# Wait for the test server to be ready
+echo "Waiting for test server to be ready..."
+kubectl wait --for=condition=Ready pod/test-server -n "$TEST_NAMESPACE" --timeout=120s
+
+SERVER_POD_IP=$(kubectl get pod test-server -n "$TEST_NAMESPACE" \
+  -o jsonpath='{.status.podIP}')
+SERVER_HOST_IP=$(kubectl get pod test-server -n "$TEST_NAMESPACE" \
+  -o jsonpath='{.status.hostIP}')
+echo "Test server ready at pod IP: ${SERVER_POD_IP} (host: ${SERVER_HOST_IP})"
+
+# Deploy a client pod that makes repeated HTTP requests
+echo "Deploying test client..."
+kubectl apply -n "$TEST_NAMESPACE" -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-client
+  labels:
+    app: nfm-test-client
+spec:
+${NODE_SELECTOR}
+  # Schedule on the same node as the server for predictable flow observation
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: nfm-test-server
+          topologyKey: kubernetes.io/hostname
+  containers:
+    - name: client
+      image: public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
+      command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Starting requests to test-server..." && \
+          for i in \$(seq 1 10); do
+            curl -sf http://test-server.${TEST_NAMESPACE}.svc.cluster.local:8080/ && \
+              echo "Request \$i: OK" || echo "Request \$i: FAILED"
+            sleep 1
+          done && \
+          echo "REQUESTS_COMPLETE" && \
+          sleep 30
+  restartPolicy: Never
+EOF
+
+# Wait for client pod to complete its requests
+echo "Waiting for test client to complete requests..."
+for i in $(seq 1 60); do
+  CLIENT_LOGS=$(kubectl logs test-client -n "$TEST_NAMESPACE" 2>/dev/null || echo "")
+  if echo "$CLIENT_LOGS" | grep -q "REQUESTS_COMPLETE"; then
+    echo "Client completed all requests"
+    break
+  fi
+  if [ $i -eq 60 ]; then
+    echo "ERROR: Client did not complete within timeout"
+    echo "Client logs:"
+    kubectl logs test-client -n "$TEST_NAMESPACE" || true
+    exit 1
+  fi
+  sleep 5
+done
+
+# Wait for agent to process, aggregate, and publish.
+# Publishing interval is ~5s; wait long enough for at least 2 full cycles.
+echo "Waiting for agent to publish reports (${PUBLISH_SECS}s interval × 6)..."
+sleep $((PUBLISH_SECS * 6))
+
+# Validate: check agent logs on the node where the test pods ran
+echo ""
+echo "=== Validating agent published flow reports ==="
+
+# Find the agent pod running on the same node as the test server
+DS_NAME="aws-network-flow-monitor-agent${TARGET_ARCH:+-${TARGET_ARCH}}"
+AGENT_POD=$(kubectl get pods -n "$NAMESPACE" \
+  --field-selector "spec.nodeName=$(kubectl get pod test-server -n "$TEST_NAMESPACE" -o jsonpath='{.spec.nodeName}')" \
+  -l "name=$DS_NAME" \
+  -o jsonpath='{.items[0].metadata.name}')
+
+if [ -z "$AGENT_POD" ]; then
+  echo "ERROR: Could not find agent pod on the test node"
+  kubectl get pods -n "$NAMESPACE" -o wide
+  exit 1
+fi
+
+echo "Checking agent pod: ${AGENT_POD}"
+
+# Validate the agent is publishing reports (end-to-end: BPF → aggregation → publish).
+# Write logs to a file to avoid shell variable size/encoding issues.
+LOGFILE="/tmp/agent-logs-check.txt"
+kubectl logs -n "$NAMESPACE" "$AGENT_POD" \
+  -c "$DS_NAME" --tail=1000 > "$LOGFILE" 2>/dev/null || true
+
+echo "Agent log size: $(wc -l < "$LOGFILE") lines"
+
+if grep -q "Publishing report" "$LOGFILE"; then
+  echo "[PASS] Agent is publishing flow reports"
+else
+  echo "[FAIL] Agent is not publishing reports"
+  echo ""
+  # Provide diagnostic context
+  if grep -q "Aggregation complete" "$LOGFILE"; then
+    echo "  Agent IS aggregating but NOT publishing — likely a permissions or endpoint issue"
+  elif grep -q "Aggregating across sockets" "$LOGFILE"; then
+    echo "  Agent IS running BPF but NOT aggregating — may need more time or has a processing error"
+  else
+    echo "  Agent shows no evidence of BPF aggregation"
+  fi
+  echo ""
+  echo "Last 50 log lines:"
+  tail -50 "$LOGFILE"
+  exit 1
+fi
+
+# Verify 3: No crash loops or restarts
+RESTARTS=$(kubectl get pod "$AGENT_POD" -n "$NAMESPACE" \
+  -o jsonpath='{.status.containerStatuses[?(@.name=="'$DS_NAME'")].restartCount}' 2>/dev/null || echo "0")
+if [ "${RESTARTS:-0}" -eq 0 ]; then
+  echo "[PASS] Agent container has zero restarts"
+else
+  echo "[FAIL] Agent container restarted ${RESTARTS} times"
+  echo "=== Previous container logs ==="
+  kubectl logs -n "$NAMESPACE" "$AGENT_POD" -c "$DS_NAME" --previous --tail=30 || true
+  exit 1
+fi
+
+# Verify 4: Init container (rmem_max setup) ran successfully
+INIT_STATUS=$(kubectl get pod "$AGENT_POD" -n "$NAMESPACE" \
+  -o jsonpath='{.status.initContainerStatuses[0].state.terminated.reason}' 2>/dev/null || echo "")
+if [ "$INIT_STATUS" = "Completed" ]; then
+  echo "[PASS] Init container (rmem_max setup) completed successfully"
+else
+  echo "[WARN] Init container status: ${INIT_STATUS:-unknown}"
+fi
+
+# Verify 5: Cleanup sidecar is running
+CLEANUP_RUNNING=$(kubectl get pod "$AGENT_POD" -n "$NAMESPACE" \
+  -o jsonpath='{.status.containerStatuses[?(@.name=="cleanup")].ready}' 2>/dev/null || echo "false")
+if [ "$CLEANUP_RUNNING" = "true" ]; then
+  echo "[PASS] Cleanup sidecar is running"
+else
+  echo "[WARN] Cleanup sidecar status: ${CLEANUP_RUNNING}"
+fi
+
+echo ""
+echo "=== All K8s integration tests passed ==="

--- a/.ci/load-tests/tcp-tester-bpf/Cargo.toml
+++ b/.ci/load-tests/tcp-tester-bpf/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aya-ebpf = "*"
-aya-log-ebpf = "*"
-aya-log-common = "*"
+aya-ebpf = "0.1"
+aya-log-ebpf = "0.1"
+aya-log-common = "0.1"
 
 network-types = "0.0.4"
 tcp-tester-common = { path = "../tcp-tester-common", default-features = false, features=["bpf"] }

--- a/.github/workflows/integration-tests-ec2.yml
+++ b/.github/workflows/integration-tests-ec2.yml
@@ -1,7 +1,7 @@
 # Multi-distro integration tests on EC2 instances via SSM.
 # Builds the agent on Amazon Linux 2 (x86_64 and ARM64) — same as the production
 # S3Release pipeline — then distributes pre-built binaries to test instances.
-name: Integration Tests (Multi-Distro)
+name: Integration Tests (EC2 Multi-Distro)
 
 on:
   workflow_dispatch:
@@ -18,11 +18,11 @@ on:
       - 'nfm-bpf/**'
       - 'packaging/**'
       - '.ci/common/**'
-      - '.ci/integration-tests/**'
-      - '.github/workflows/integration-tests.yml'
+      - '.ci/integration-tests/ec2-scripts/**'
+      - '.github/workflows/integration-tests-ec2.yml'
 
 concurrency:
-  group: integration-tests-${{ github.ref }}
+  group: integration-tests-ec2-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -378,13 +378,23 @@ jobs:
           .ci/common/scripts/run-ssm.sh 300 "bash -c '
             set -e
 
+            # Wait for cloud-init to finish, then retry package installs if lock is held.
+            if command -v cloud-init &>/dev/null; then
+              cloud-init status --wait &>/dev/null 2>&1 || true
+            fi
+
             # Install AWS CLI and dependencies if not present
             if ! command -v aws &>/dev/null; then
               case ${PKG_MANAGER} in
                 dnf)
                   rm -rf /var/cache/dnf/*
-                  dnf makecache
-                  dnf install -y --allowerasing awscli python3 libcap
+                  for attempt in \$(seq 1 12); do
+                    if dnf install -y --allowerasing awscli python3 libcap; then
+                      break
+                    fi
+                    echo \"dnf install failed (attempt \${attempt}/12), retrying in 10s...\"
+                    sleep 10
+                  done
                   ;;
                 zypper)
                   zypper install -y aws-cli curl libcap-progs
@@ -472,11 +482,11 @@ jobs:
           aws s3 rm "s3://${{ secrets.PR_PERF_TEST_BUCKET }}/${{ needs.build.outputs.s3-prefix }}/" --recursive || true
           echo "Cleaned up S3 artifacts"
 
-  # Gate job for branch protection. Add "Integration Tests Gate" as a required
+  # Gate job for branch protection. Add "Integration Tests (EC2) Gate" as a required
   # status check — it passes when all test matrix jobs succeed, and is skipped
   # (which GitHub treats as passing) when the workflow doesn't run due to path filters.
   gate:
-    name: Integration Tests Gate
+    name: Integration Tests (EC2) Gate
     needs: [build, test]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests-k8s.yml
+++ b/.github/workflows/integration-tests-k8s.yml
@@ -1,0 +1,279 @@
+# Kubernetes integration tests on pre-created EKS clusters.
+# Builds the agent container image, deploys it via Helm to persistent EKS clusters
+# (managed by CDK), and runs the integration test suite across multiple K8s versions,
+# node AMI families (AL2023, Bottlerocket), and architectures (amd64, arm64).
+name: Integration Tests (Kubernetes)
+
+on:
+  workflow_dispatch:
+    inputs:
+      k8s_versions:
+        description: 'Comma-separated K8s versions to test (empty = all)'
+        required: false
+        type: string
+        default: ''
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'nfm-controller/**'
+      - 'nfm-bpf/**'
+      - 'charts/**'
+      - 'Dockerfile.k8s'
+      - '.ci/common/**'
+      - '.ci/integration-tests/k8s-scripts/**'
+      - '.github/workflows/integration-tests-k8s.yml'
+
+concurrency:
+  group: integration-tests-k8s-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  # Pre-created cluster naming convention: nfm-integ-{version}-{family}
+  # Clusters are managed by CDK (NetworkSonarMonitoringAgentReleaseStressTestCDK).
+  # To add/remove K8s versions or AMI families, update the CDK stack's
+  # github-integration-config.json and redeploy — then update the matrix below.
+  CLUSTER_PREFIX: nfm-integ
+
+jobs:
+  # Build container images on native EC2 instances using the production Dockerfile.k8s.
+  # Each arch gets its own EC2 (c5.xlarge for amd64, c7g.xlarge for arm64) so the
+  # docker build runs natively — no QEMU emulation needed.
+  build-arch:
+    name: Build (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            ami_filter: "al2023-ami-*-kernel-6.1-x86_64"
+            instance_type: c5.xlarge
+          - arch: arm64
+            ami_filter: "al2023-ami-*-kernel-6.1-arm64"
+            instance_type: c7g.2xlarge
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.PR_PERF_TEST_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PR_PERF_TEST_AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Upload source to S3
+        id: upload
+        run: |
+          S3_PREFIX="k8s-integ/${{ github.run_id }}/${{ github.run_attempt }}"
+          echo "s3-prefix=${S3_PREFIX}" >> "$GITHUB_OUTPUT"
+          BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
+
+          tar czf /tmp/nfm-source.tar.gz --exclude='.git' --exclude='target' --exclude='out' .
+          aws s3 cp /tmp/nfm-source.tar.gz "s3://${BUCKET}/${S3_PREFIX}/nfm-source.tar.gz"
+
+      - name: Create build EC2 instance
+        id: ec2
+        run: |
+          REGION="${{ secrets.PR_PERF_TEST_AWS_REGION }}"
+          AMI_ID=$(.ci/common/scripts/resolve-ami.sh "$REGION" "${{ matrix.ami_filter }}")
+
+          .ci/common/scripts/launch-instance.sh \
+            --ami-id "$AMI_ID" \
+            --instance-type "${{ matrix.instance_type }}" \
+            --region "$REGION" \
+            --instance-role "${{ secrets.PR_PERF_TEST_INSTANCE_ROLE }}" \
+            --block-device '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]' \
+            --tags '[{Key=Name,Value=nfm-k8s-build-${{ matrix.arch }}-${{ github.run_id }}},{Key=Purpose,Value=integration-testing}]'
+
+      - name: Wait for SSM readiness
+        run: .ci/common/scripts/wait-ssm.sh "${{ steps.ec2.outputs.instance-id }}" "$SSM_REGION" 180
+
+      - name: Build and push container image on EC2
+        run: |
+          BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
+          S3_PREFIX="${{ steps.upload.outputs.s3-prefix }}"
+          ECR_REGISTRY="${{ secrets.PR_PERF_TEST_ECR_REGISTRY }}"
+          ECR_REGION="${{ secrets.PR_PERF_TEST_AWS_REGION }}"
+          REPO_NAME="nfm-agent-integration-test"
+          IMAGE_TAG="integ-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}"
+          IMAGE_URI="${ECR_REGISTRY}/${REPO_NAME}:${IMAGE_TAG}"
+
+          .ci/common/scripts/run-ssm.sh 900 "bash -c '
+            set -e
+            export HOME=/root
+
+            # Install Docker
+            yum install -y docker awscli
+            systemctl start docker
+
+            # ECR login
+            aws ecr get-login-password --region ${ECR_REGION} | \
+              docker login --username AWS --password-stdin ${ECR_REGISTRY}
+
+            # Download source and build image using production Dockerfile
+            mkdir -p /tmp/nfm-build && cd /tmp/nfm-build
+            aws s3 cp s3://${BUCKET}/${S3_PREFIX}/nfm-source.tar.gz ./nfm-source.tar.gz
+            tar xzf nfm-source.tar.gz
+
+            docker build -f Dockerfile.k8s -t ${IMAGE_URI} .
+            docker push ${IMAGE_URI}
+
+            echo \"=== Image pushed: ${IMAGE_URI} ===\"
+          '"
+
+      - name: Terminate build instance
+        if: always()
+        run: .ci/common/scripts/terminate-instance.sh
+
+      - name: Cleanup S3 build artifacts
+        if: always()
+        run: |
+          aws s3 rm "s3://${{ secrets.PR_PERF_TEST_BUCKET }}/${{ steps.upload.outputs.s3-prefix }}/" --recursive || true
+
+  # Deploy the agent to pre-created EKS clusters and run tests.
+  # Clusters are managed by CDK — see env.CLUSTER_PREFIX comment above.
+  # To add new test cases, update BOTH the CDK config AND the matrix below.
+  test:
+    name: K8s ${{ matrix.k8s_version }} / ${{ matrix.ami_family }} / ${{ matrix.arch }}
+    needs: build-arch
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: ["1.30", "1.32", "1.34", "1.36"]
+        ami_family: [AL2023, Bottlerocket]
+        arch: [amd64, arm64]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.PR_PERF_TEST_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PR_PERF_TEST_AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Install kubectl and Helm
+        run: |
+          curl -LO "https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl"
+          chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - name: Connect to pre-created EKS cluster
+        id: cluster
+        run: |
+          K8S_VER=$(echo "${{ matrix.k8s_version }}" | tr '.' '-')
+          CLUSTER_NAME="${{ env.CLUSTER_PREFIX }}-${K8S_VER}-${{ matrix.ami_family }}"
+          echo "cluster-name=${CLUSTER_NAME}" >> "$GITHUB_OUTPUT"
+
+          aws eks update-kubeconfig \
+            --name "$CLUSTER_NAME" \
+            --region "${{ secrets.PR_PERF_TEST_AWS_REGION }}" \
+            --kubeconfig "/tmp/kubeconfig-${CLUSTER_NAME}"
+
+          export KUBECONFIG="/tmp/kubeconfig-${CLUSTER_NAME}"
+          echo "Connected to cluster: ${CLUSTER_NAME}"
+          kubectl get nodes -o wide
+
+      - name: Deploy agent via Helm
+        run: |
+          KUBECONFIG="/tmp/kubeconfig-${{ steps.cluster.outputs.cluster-name }}"
+          IMAGE_URI="${{ secrets.PR_PERF_TEST_ECR_REGISTRY }}/nfm-agent-integration-test:integ-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}"
+
+          .ci/integration-tests/k8s-scripts/deploy-agent.sh \
+            "$IMAGE_URI" \
+            "$KUBECONFIG" \
+            "" \
+            "${{ matrix.arch }}"
+
+      - name: Run integration tests
+        run: |
+          KUBECONFIG="/tmp/kubeconfig-${{ steps.cluster.outputs.cluster-name }}"
+          .ci/integration-tests/k8s-scripts/run-test.sh "$KUBECONFIG" "${{ matrix.arch }}"
+
+      - name: Uninstall agent
+        if: always()
+        run: |
+          KUBECONFIG="/tmp/kubeconfig-${{ steps.cluster.outputs.cluster-name }}"
+          NS="amazon-cloudwatch-${{ matrix.arch }}"
+          helm uninstall "nfm-agent-test-${{ matrix.arch }}" --namespace "$NS" --kubeconfig "$KUBECONFIG" 2>/dev/null || true
+          kubectl delete namespace "nfm-test-${{ matrix.arch }}" --kubeconfig "$KUBECONFIG" --ignore-not-found 2>/dev/null || true
+          kubectl delete namespace "$NS" --kubeconfig "$KUBECONFIG" --ignore-not-found 2>/dev/null || true
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          KUBECONFIG="/tmp/kubeconfig-${{ steps.cluster.outputs.cluster-name }}"
+          NS="amazon-cloudwatch-${{ matrix.arch }}"
+          export KUBECONFIG
+
+          echo "=== Node status ==="
+          kubectl get nodes -o wide || true
+
+          echo ""
+          echo "=== DaemonSet details ==="
+          kubectl describe daemonset -n "$NS" || true
+
+          echo ""
+          echo "=== Agent pod logs (all pods) ==="
+          for POD in $(kubectl get pods -n "$NS" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "--- ${POD} ---"
+            kubectl logs -n "$NS" "$POD" -c aws-network-flow-monitor-agent --tail=100 || true
+            echo ""
+          done
+
+          echo ""
+          echo "=== Events ==="
+          kubectl get events -n "$NS" --sort-by='.lastTimestamp' || true
+
+  # Cleanup ECR images after all tests finish
+  cleanup-image:
+    name: Cleanup ECR Image
+    needs: [build-arch, test]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.PR_PERF_TEST_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PR_PERF_TEST_AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Delete test images from ECR
+        run: |
+          IMAGE_TAG="integ-${{ github.run_id }}-${{ github.run_attempt }}"
+          REGION="${{ secrets.PR_PERF_TEST_AWS_REGION }}"
+          REPO="nfm-agent-integration-test"
+
+          aws ecr batch-delete-image --repository-name "$REPO" --region "$REGION" \
+            --image-ids "imageTag=${IMAGE_TAG}-amd64" "imageTag=${IMAGE_TAG}-arm64" || true
+          echo "Cleaned up ECR images for tag: ${IMAGE_TAG}"
+
+  # Gate job for branch protection.
+  gate:
+    name: Integration Tests (K8s) Gate
+    needs: [build-arch, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.build-arch.result }}" = "failure" ] || \
+             [ "${{ needs.test.result }}" = "failure" ]; then
+            echo "::error::Kubernetes integration tests failed"
+            exit 1
+          fi
+          echo "All Kubernetes integration tests passed"

--- a/README.md
+++ b/README.md
@@ -68,22 +68,38 @@ Some unit tests need privileges to run:
 ```
 sudo -E cargo test --features privileged
 ```
-### Multi-Distro Integration Tests
+### Integration Tests
 
-The workflow `.github/workflows/integration-tests.yml` runs the agent on real EC2 instances across multiple distributions. Each instance builds the agent natively and runs the test suite.
+#### EC2 Multi-Distro (`integration-tests-ec2.yml`)
+
+Runs the agent on real EC2 instances across multiple distributions via SSM. Each instance installs a pre-built binary and runs the test suite.
 
 **Tested distributions:**
 
-| Distro | Kernel | Package |
-|--------|--------|---------|
-| Amazon Linux 2 | 5.10 (Amazon) | RPM |
-| Amazon Linux 2023 | 6.1, 6.12 (Amazon) | RPM |
-| RHEL 9 | 5.14 (Red Hat) | RPM |
-| SUSE 15 SP6 | 6.4 | RPM |
-| Debian 11 | 5.10 (cloud) | Binary |
-| Debian 12 | 6.1 | Binary |
-| Ubuntu 22.04 | 6.x (HWE) | Binary |
-| Ubuntu 24.04 | 6.8 | Binary |
+| Distro | Kernel | Package | Architectures |
+|--------|--------|---------|---------------|
+| Amazon Linux 2 | 5.10 (Amazon) | RPM | x86_64, arm64 |
+| Amazon Linux 2023 | 6.1 (Amazon) | RPM | x86_64, arm64 |
+| Amazon Linux 2023 | 6.12 (Amazon) | RPM | x86_64 |
+| RHEL 9 | 5.14 (Red Hat) | RPM | x86_64, arm64 |
+| SUSE 15 SP6 | 6.4 | RPM | x86_64 |
+| Debian 11 | 5.10 (cloud) | Binary | x86_64 |
+| Debian 12 | 6.1 | Binary | x86_64, arm64 |
+| Ubuntu 22.04 | 6.x (HWE) | Binary | x86_64, arm64 |
+| Ubuntu 24.04 | 6.8 | Binary | x86_64, arm64 |
+
+#### Kubernetes (`integration-tests-k8s.yml`)
+
+Deploys the agent via Helm chart to pre-created EKS clusters and validates BPF attachment and flow capture. Tests across multiple Kubernetes versions, node AMI families, and architectures. Clusters are managed by CDK (`NetworkSonarMonitoringAgentReleaseStressTestCDK`).
+
+**Test matrix:**
+
+| K8s Version | AL2023 | Bottlerocket | Architectures |
+|-------------|--------|--------------|---------------|
+| 1.30 | ✅ | ✅ | amd64, arm64 |
+| 1.32 | ✅ | ✅ | amd64, arm64 |
+| 1.34 | ✅ | ✅ | amd64, arm64 |
+| 1.36 (latest) | ✅ | ✅ | amd64, arm64 |
 
 #### Known Incompatible Distributions
 
@@ -93,26 +109,6 @@ The following distributions are **not supported** due to BPF license restriction
 |--------|--------|-------|
 | SUSE 15 SP5 | 5.14.21 (stock) | Kernel enforces GPL-only on BPF helpers used by the agent |
 | Ubuntu 20.04 | 5.15 (AWS) | Same GPL restriction + GCC 9 `memcmp` bug blocks build |
-
-**Root cause:** The agent's eBPF program declares `license="Apache-2.0"`. Certain BPF helpers (used in the `sock_ops` program) are marked `gpl_only=true` in kernels that haven't backported relaxations from upstream 6.x.
-
-- **RHEL 9 (5.14)** works because Red Hat backports BPF helper relaxations from newer kernels.
-- **SUSE SP5 (5.14)** fails because SUSE stays closer to upstream, which retains restrictions until kernel 6.x.
-- **Amazon Linux 2 (5.10)** works because Amazon patches their kernel to allow non-GPL BPF programs.
-
-**Recommended fix:** Change the eBPF program's license declaration in [`nfm-bpf/src/main.rs`](nfm-bpf/src/main.rs#L30-L31):
-
-```rust
-// Current (line 30-31):
-#[link_section = "license"]
-pub static LICENSE: [u8; 11] = *b"Apache-2.0\0";
-
-// Recommended change:
-#[link_section = "license"]
-pub static LICENSE: [u8; 14] = *b"Dual BSD/GPL\0";
-```
-
-This is the industry standard for commercial eBPF agents (Cilium, Falco, Datadog, Tetragon all use this pattern). The kernel explicitly allows GPL-licensed BPF bytecode to coexist with Apache-2.0 userspace in the same package — there is no license "contamination" across the syscall boundary.
 
 ### Distributions
 You can download the official release from our permanent URLs. For more information, refer to [link](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents-download-agent-commandline.html)


### PR DESCRIPTION
## Summary

- Rename `integration-tests.yml` → `integration-tests-ec2.yml` to clarify scope
- Add `integration-tests-k8s.yml` workflow that tests the agent on pre-created EKS clusters
- Add supporting scripts under `.ci/integration-tests/k8s-scripts/`
- Fix EC2 integration test flakiness on RHEL 9 (dnf lock retry)

## Kubernetes integration tests

Deploys the agent via Helm to persistent EKS clusters. Tests BPF attachment and flow capture across multiple Kubernetes versions, node AMI families, and architectures.

**Test matrix (4 × 2 × 2 = 16 combinations):**

| K8s Version | AMI Families | Architectures |
|-------------|--------------|---------------|
| 1.30, 1.32, 1.34, 1.36 | AL2023, Bottlerocket | amd64, arm64 |

**How it works:**
1. **Build** — Compiles the agent natively on EC2 (AL2, one per arch) and pushes container images to ECR
2. **Test** — Connects to pre-created clusters, deploys via Helm with arch-specific isolation (namespace, DaemonSet, ClusterRole), generates traffic, validates flow capture
3. **Cleanup** — Uninstalls Helm release and deletes ECR images

## EC2 integration test fix

Added `cloud-init status --wait` + `dnf install` retry loop to handle RHEL 9's `dnf-automatic` holding the RPM lock at boot time.

## Test plan

- [x] All 16 Kubernetes integration tests pass
- [x] All EC2 integration tests pass (including RHEL 9)
- [x] Load tests unaffected
- [x] CI and CodeQL pass
