### PR TITLE
Fix script injection finding and use distinctive test port

### DIFF
--- a/.ci/integration-tests/k8s-scripts/run-test.sh
+++ b/.ci/integration-tests/k8s-scripts/run-test.sh
@@ -23,6 +23,9 @@ export KUBECONFIG="$KUBECONFIG_PATH"
 NAMESPACE="amazon-cloudwatch-${TARGET_ARCH:-default}"
 TEST_NAMESPACE="nfm-test-${TARGET_ARCH:-default}"
 PUBLISH_SECS=5
+# Use a distinctive port unlikely to collide with other traffic on the node.
+# This lets us verify the agent captured *our* test flows specifically.
+TEST_PORT=54321
 
 echo "=== Running K8s integration tests ==="
 
@@ -37,8 +40,8 @@ if [ -n "$TARGET_ARCH" ]; then
   echo "Restricting test pods to ${TARGET_ARCH} nodes"
 fi
 
-# Deploy a simple HTTP server as a test workload
-echo "Deploying test server..."
+# Deploy a simple HTTP server on a distinctive port.
+echo "Deploying test server on port ${TEST_PORT}..."
 kubectl apply -n "$TEST_NAMESPACE" -f - <<EOF
 apiVersion: v1
 kind: Pod
@@ -65,14 +68,14 @@ ${NODE_SELECTOR}
                   self.end_headers()
                   self.wfile.write(b'hello from nfm-test-server')
               def log_message(self, *a): pass
-          socketserver.TCPServer(('0.0.0.0', 8080), H).serve_forever()
+          socketserver.TCPServer(('0.0.0.0', ${TEST_PORT}), H).serve_forever()
           "
       ports:
-        - containerPort: 8080
+        - containerPort: ${TEST_PORT}
       readinessProbe:
         httpGet:
           path: /
-          port: 8080
+          port: ${TEST_PORT}
         initialDelaySeconds: 5
         periodSeconds: 2
 ---
@@ -84,8 +87,8 @@ spec:
   selector:
     app: nfm-test-server
   ports:
-    - port: 8080
-      targetPort: 8080
+    - port: ${TEST_PORT}
+      targetPort: ${TEST_PORT}
 EOF
 
 # Wait for the test server to be ready
@@ -124,9 +127,9 @@ ${NODE_SELECTOR}
         - /bin/sh
         - -c
         - |
-          echo "Starting requests to test-server..." && \
+          echo "Starting requests to test-server on port ${TEST_PORT}..." && \
           for i in \$(seq 1 10); do
-            curl -sf http://test-server.${TEST_NAMESPACE}.svc.cluster.local:8080/ && \
+            curl -sf http://test-server.${TEST_NAMESPACE}.svc.cluster.local:${TEST_PORT}/ && \
               echo "Request \$i: OK" || echo "Request \$i: FAILED"
             sleep 1
           done && \
@@ -197,6 +200,21 @@ else
   else
     echo "  Agent shows no evidence of BPF aggregation"
   fi
+  echo ""
+  echo "Last 50 log lines:"
+  tail -50 "$LOGFILE"
+  exit 1
+fi
+
+# Verify 2: Agent captured our specific test traffic (port 54321).
+# This confirms the agent is tracking the exact flows we generated,
+# not just reporting traffic from unrelated processes on the node.
+if grep -q "${TEST_PORT}" "$LOGFILE"; then
+  echo "[PASS] Agent captured test traffic on port ${TEST_PORT}"
+else
+  echo "[FAIL] Agent did not capture traffic on test port ${TEST_PORT}"
+  echo "  The agent is publishing reports but none contain our test flow."
+  echo "  This may indicate a BPF filtering issue or insufficient wait time."
   echo ""
   echo "Last 50 log lines:"
   tail -50 "$LOGFILE"

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -304,11 +304,13 @@ jobs:
           done
 
       - name: Generate TPS reports and graphs
+        env:
+          TEST_ID_SUFFIX: ${{ github.event.number || github.run_id }}
         run: |
           cd .ci/load-tests
 
-          PR_TEST_ID="pr-${{ github.event.number || github.run_id }}"
-          MAIN_TEST_ID="main-${{ github.event.number || github.run_id }}"
+          PR_TEST_ID="pr-${TEST_ID_SUFFIX}"
+          MAIN_TEST_ID="main-${TEST_ID_SUFFIX}"
           TPS_VALUES="10000,20000,30000,40000,60000,80000,100000"
 
           # Generate TPS reports for PR
@@ -368,21 +370,24 @@ jobs:
 
       - name: Upload graphs to gh-perf-images branch
         if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          CURRENT_SHA: ${{ github.sha }}
         run: |
           git stash push -m "Temporary stash for graph upload" || true
           git fetch origin gh-perf-images:gh-perf-images 2>/dev/null || git checkout -b gh-perf-images
           git checkout gh-perf-images
 
-          mkdir -p perf-images/pr-${{ github.event.number }}
-          cp pr-results/graphs/*.png perf-images/pr-${{ github.event.number }}/ 2>/dev/null || true
+          mkdir -p "perf-images/pr-${PR_NUMBER}"
+          cp pr-results/graphs/*.png "perf-images/pr-${PR_NUMBER}/" 2>/dev/null || true
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add perf-images/pr-${{ github.event.number }}/
-          git commit -m "Add performance graphs for PR #${{ github.event.number }}" || true
+          git add "perf-images/pr-${PR_NUMBER}/"
+          git commit -m "Add performance graphs for PR #${PR_NUMBER}" || true
           git push origin gh-perf-images || true
 
-          git checkout ${{ github.sha }}
+          git checkout "${CURRENT_SHA}"
           git stash pop || true
 
       - name: Comment PR with performance results
@@ -426,8 +431,10 @@ jobs:
             comment += comparison + '\n\n';
 
             if (graphs.length > 0) {
+              const repo = `${context.repo.owner}/${context.repo.repo}`;
+              const prNumber = context.issue.number;
               graphs.forEach(graph => {
-                const graphUrl = `https://raw.githubusercontent.com/${{ github.repository }}/gh-perf-images/perf-images/pr-${{ github.event.number }}/${graph}`;
+                const graphUrl = `https://raw.githubusercontent.com/${repo}/gh-perf-images/perf-images/pr-${prNumber}/${graph}`;
                 comment += `![${graph}](${graphUrl})\n\n`;
               });
             }


### PR DESCRIPTION
## Summary

- **Fix script injection finding:** Move `${{ github.event.number }}` and `${{ github.sha }}` interpolations from inline `run:` scripts to `env:` blocks in `load-tests.yml`. This prevents potential script injection via GitHub context values. Also replaced `${{ github.repository }}` in `github-script` with `context.repo` API.
- **Use distinctive test port in K8s integration tests:** Changed test server from port 8080 to 54321 so we can verify the agent captured *our* specific test traffic, not unrelated traffic from other processes on the node. Added explicit verification that port 54321 appears in agent logs.

## Test plan

- [ ] Load Tests workflow passes (script logic unchanged, only injection pattern fixed)
- [ ] K8s integration tests pass with the new port 54321