### PR TITLE
EFA metrics - Pod labels

### DIFF
--- a/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
+++ b/charts/amazon-network-flow-monitor-agent/templates/daemonSet.yaml
@@ -109,6 +109,11 @@ spec:
             - name: host-cgroup
               mountPath: /host-cgroup
               readOnly: true
+          {{- if eq .Values.env.OPEN_METRICS "on" }}
+            - name: kubelet-pod-resources
+              mountPath: /var/lib/kubelet/pod-resources
+              readOnly: true
+          {{- end }}
           {{- if .Values.caCerts.enabled }}
             - name: ca-bundle
               mountPath: {{ .Values.caCerts.mountPath }}/{{ .Values.caCerts.fileName }}
@@ -152,6 +157,12 @@ spec:
             type: Directory
         - name: config
           emptyDir: {}
+      {{- if eq .Values.env.OPEN_METRICS "on" }}
+        - name: kubelet-pod-resources
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+            type: Directory
+      {{- end }}
       {{- if .Values.caCerts.enabled }}
         - name: ca-bundle
           secret:

--- a/charts/amazon-network-flow-monitor-agent/templates/serviceAccount.yaml
+++ b/charts/amazon-network-flow-monitor-agent/templates/serviceAccount.yaml
@@ -24,6 +24,11 @@ rules:
     - apiGroups: ["", "discovery.k8s.io"]
       resources: ["pods", "endpointslices"]
       verbs: ["get", "list", "watch"]
+  {{- if eq .Values.env.OPEN_METRICS "on" }}
+    - apiGroups: [""]
+      resources: ["nodes"]
+      verbs: ["get"]
+  {{- end }}
 
 ---
 

--- a/nfm-controller/Cargo.toml
+++ b/nfm-controller/Cargo.toml
@@ -30,6 +30,9 @@ open-metrics = [
     "dep:tokio-util",
     "dep:getifaddrs",
     "dep:regex",
+    "dep:tonic",
+    "dep:tower",
+    "dep:tokio-stream",
 ]
 
 [profile.dev]
@@ -78,6 +81,9 @@ opentelemetry-proto = { version = "0.27", features = [
     "gen-tonic",
     "with-serde",
 ] }
+tonic = { version = "0.12", optional = true }
+tower = { version = "0.4", optional = true }
+tokio-stream = { version = "0.1", optional = true }
 procfs = "0.16"
 prost = "0.13"
 rand = "0.8"

--- a/nfm-controller/src/kubernetes/efa_pod_resources.rs
+++ b/nfm-controller/src/kubernetes/efa_pod_resources.rs
@@ -37,11 +37,17 @@ pub struct EfaPodResourcesWatcher {
     device_map: Arc<Mutex<EfaDeviceToPodMap>>,
 }
 
-impl EfaPodResourcesWatcher {
-    pub fn new() -> Self {
+impl Default for EfaPodResourcesWatcher {
+    fn default() -> Self {
         Self {
             device_map: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+}
+
+impl EfaPodResourcesWatcher {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn device_map(&self) -> Arc<Mutex<EfaDeviceToPodMap>> {
@@ -240,10 +246,7 @@ impl EfaPodResourcesWatcher {
             .connect_with_connector(tower::service_fn(move |_| async move {
                 UnixStream::connect(KUBELET_SOCKET_PATH)
                     .await
-                    .map(|stream| {
-                        let io = hyper_util::rt::TokioIo::new(stream);
-                        io
-                    })
+                    .map(hyper_util::rt::TokioIo::new)
             }))
             .await?;
 

--- a/nfm-controller/src/kubernetes/efa_pod_resources.rs
+++ b/nfm-controller/src/kubernetes/efa_pod_resources.rs
@@ -1,0 +1,366 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Watches Kubernetes pods that use EFA devices and maps EFA device names to pods
+//! by querying the Kubelet PodResources gRPC API.
+
+use std::collections::HashMap;
+use std::env;
+use std::sync::{Arc, Mutex};
+
+use futures::StreamExt;
+use k8s_openapi::api::core::v1::{Node, Pod};
+use kube::runtime::watcher::{self, watcher as kube_watcher, Event};
+use kube::runtime::WatchStreamExt;
+use kube::{Api, Client};
+use log::{debug, info, warn};
+
+use super::podresources_v1::pod_resources_lister_client::PodResourcesListerClient;
+use super::podresources_v1::ListPodResourcesRequest;
+
+const KUBELET_SOCKET_PATH: &str = "/var/lib/kubelet/pod-resources/kubelet.sock";
+const EFA_RESOURCE_NAME: &str = "vpc.amazonaws.com/efa";
+
+/// Pod information associated with an EFA device.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EfaPodInfo {
+    pub pod_name: String,
+    pub pod_namespace: String,
+}
+
+/// Maps EFA device IDs (as reported by the device plugin) to the pod using them.
+pub type EfaDeviceToPodMap = HashMap<String, EfaPodInfo>;
+
+/// Client that watches pods requesting EFA resources and maintains a device→pod mapping
+/// by querying the Kubelet PodResources API.
+pub struct EfaPodResourcesWatcher {
+    device_map: Arc<Mutex<EfaDeviceToPodMap>>,
+}
+
+impl EfaPodResourcesWatcher {
+    pub fn new() -> Self {
+        Self {
+            device_map: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn device_map(&self) -> Arc<Mutex<EfaDeviceToPodMap>> {
+        Arc::clone(&self.device_map)
+    }
+
+    pub fn start(&self) {
+        let device_map = Arc::clone(&self.device_map);
+        tokio::spawn(async move {
+            let node_name = match Self::node_has_efa_allocatable().await {
+                Some(name) => name,
+                None => {
+                    info!(
+                        "EFA device plugin not registered on this node, \
+                         skipping PodResources watcher"
+                    );
+                    return;
+                }
+            };
+            Self::watch_efa_pods(device_map, &node_name).await;
+        });
+        info!("EFA PodResources watcher starting");
+    }
+
+    async fn node_has_efa_allocatable() -> Option<String> {
+        let node_name = match env::var("K8S_NODE_NAME") {
+            Ok(name) => name,
+            Err(_) => {
+                warn!("K8S_NODE_NAME not set, cannot check node allocatable resources");
+                return None;
+            }
+        };
+
+        let client = match Client::try_default().await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("Failed to create K8s client for node check: {}", e);
+                return None;
+            }
+        };
+
+        let nodes: Api<Node> = Api::all(client);
+        match nodes.get(&node_name).await {
+            Ok(node) => {
+                let has_efa = node
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.allocatable.as_ref())
+                    .and_then(|alloc| alloc.get(EFA_RESOURCE_NAME))
+                    .map(|q| q.0 != "0")
+                    .unwrap_or(false);
+
+                if has_efa {
+                    info!(
+                        "EFA device plugin detected on node (vpc.amazonaws.com/efa is allocatable)"
+                    );
+                    Some(node_name)
+                } else {
+                    debug!(
+                        "Node {} does not have EFA in allocatable resources",
+                        node_name
+                    );
+                    None
+                }
+            }
+            Err(e) => {
+                warn!("Failed to get node {}: {}", node_name, e);
+                None
+            }
+        }
+    }
+
+    async fn watch_efa_pods(device_map: Arc<Mutex<EfaDeviceToPodMap>>, node_name: &str) {
+        let client = match Client::try_default().await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("Failed to create K8s client for EFA pod watcher: {}", e);
+                return;
+            }
+        };
+
+        let api: Api<Pod> = Api::all(client);
+        let watcher_config = watcher::Config::default()
+            .page_size(150)
+            .fields(&format!("spec.nodeName={}", node_name));
+        let stream = kube_watcher(api, watcher_config).default_backoff();
+
+        stream
+            .for_each(|event| {
+                let device_map = Arc::clone(&device_map);
+                async move {
+                    match event {
+                        Ok(Event::Apply(pod)) => {
+                            if Self::pod_requests_efa(&pod) {
+                                debug!(
+                                    "EFA pod event (apply): {}/{}",
+                                    pod.metadata.namespace.as_deref().unwrap_or(""),
+                                    pod.metadata.name.as_deref().unwrap_or("")
+                                );
+                                Self::refresh_device_map(&device_map).await;
+                            }
+                        }
+                        Ok(Event::InitApply(_)) => {}
+                        Ok(Event::Delete(pod)) => {
+                            if Self::pod_requests_efa(&pod) {
+                                debug!(
+                                    "EFA pod event (delete): {}/{}",
+                                    pod.metadata.namespace.as_deref().unwrap_or(""),
+                                    pod.metadata.name.as_deref().unwrap_or("")
+                                );
+                                Self::refresh_device_map(&device_map).await;
+                            }
+                        }
+                        Ok(Event::Init) => {}
+                        Ok(Event::InitDone) => {
+                            info!("EFA pod watcher initial list complete, refreshing device map");
+                            Self::refresh_device_map(&device_map).await;
+                        }
+                        Err(e) => {
+                            warn!("EFA pod watcher error: {}", e);
+                        }
+                    }
+                }
+            })
+            .await;
+    }
+
+    fn pod_requests_efa(pod: &Pod) -> bool {
+        let Some(spec) = &pod.spec else {
+            return false;
+        };
+        for container in &spec.containers {
+            if let Some(resources) = &container.resources {
+                if let Some(limits) = &resources.limits {
+                    if limits.contains_key(EFA_RESOURCE_NAME) {
+                        return true;
+                    }
+                }
+                if let Some(requests) = &resources.requests {
+                    if requests.contains_key(EFA_RESOURCE_NAME) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    // Pod events tell us which pod changed but not which device IDs the device plugin
+    // assigned to it, only the Kubelet PodResources API has that.
+    async fn refresh_device_map(device_map: &Arc<Mutex<EfaDeviceToPodMap>>) {
+        match Self::query_pod_resources().await {
+            Ok(new_map) => {
+                let mut map = device_map.lock().unwrap();
+                *map = new_map;
+                debug!("EFA device map refreshed: {} entries", map.len());
+            }
+            Err(e) => {
+                warn!("Failed to query PodResources API: {}", e);
+            }
+        }
+    }
+
+    async fn query_pod_resources() -> Result<EfaDeviceToPodMap, anyhow::Error> {
+        let channel = Self::connect_to_kubelet().await?;
+        let mut client = PodResourcesListerClient::new(channel);
+
+        let response = client.list(ListPodResourcesRequest {}).await?;
+
+        let mut map = EfaDeviceToPodMap::new();
+        for pod_resource in &response.get_ref().pod_resources {
+            let pod_info = EfaPodInfo {
+                pod_name: pod_resource.name.clone(),
+                pod_namespace: pod_resource.namespace.clone(),
+            };
+
+            for container in &pod_resource.containers {
+                for device in &container.devices {
+                    if device.resource_name == EFA_RESOURCE_NAME {
+                        for device_id in &device.device_ids {
+                            map.insert(device_id.clone(), pod_info.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(map)
+    }
+
+    async fn connect_to_kubelet() -> Result<tonic::transport::Channel, anyhow::Error> {
+        use tokio::net::UnixStream;
+        use tonic::transport::Endpoint;
+
+        let endpoint = Endpoint::from_static("http://[::]:50051")
+            .connect_with_connector(tower::service_fn(move |_| async move {
+                UnixStream::connect(KUBELET_SOCKET_PATH)
+                    .await
+                    .map(|stream| {
+                        let io = hyper_util::rt::TokioIo::new(stream);
+                        io
+                    })
+            }))
+            .await?;
+
+        Ok(endpoint)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{Container, PodSpec, ResourceRequirements};
+    use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+    use std::collections::BTreeMap;
+
+    fn make_pod_with_efa(name: &str, namespace: &str, efa_count: &str) -> Pod {
+        let mut limits = BTreeMap::new();
+        limits.insert(
+            EFA_RESOURCE_NAME.to_string(),
+            Quantity(efa_count.to_string()),
+        );
+
+        Pod {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(namespace.to_string()),
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                containers: vec![Container {
+                    name: "main".to_string(),
+                    resources: Some(ResourceRequirements {
+                        limits: Some(limits),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn make_pod_without_efa(name: &str, namespace: &str) -> Pod {
+        Pod {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(namespace.to_string()),
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                containers: vec![Container {
+                    name: "main".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_pod_requests_efa_with_efa_limits() {
+        let pod = make_pod_with_efa("training-pod", "ml", "4");
+        assert!(EfaPodResourcesWatcher::pod_requests_efa(&pod));
+    }
+
+    #[test]
+    fn test_pod_requests_efa_without_efa() {
+        let pod = make_pod_without_efa("web-pod", "default");
+        assert!(!EfaPodResourcesWatcher::pod_requests_efa(&pod));
+    }
+
+    #[test]
+    fn test_pod_requests_efa_no_spec() {
+        let pod = Pod {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("broken".to_string()),
+                ..Default::default()
+            },
+            spec: None,
+            ..Default::default()
+        };
+        assert!(!EfaPodResourcesWatcher::pod_requests_efa(&pod));
+    }
+
+    #[test]
+    fn test_pod_requests_efa_in_requests_field() {
+        let mut requests = BTreeMap::new();
+        requests.insert(EFA_RESOURCE_NAME.to_string(), Quantity("1".to_string()));
+
+        let pod = Pod {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("req-pod".to_string()),
+                namespace: Some("ml".to_string()),
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                containers: vec![Container {
+                    name: "main".to_string(),
+                    resources: Some(ResourceRequirements {
+                        requests: Some(requests),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(EfaPodResourcesWatcher::pod_requests_efa(&pod));
+    }
+
+    #[test]
+    fn test_new_creates_empty_map() {
+        let watcher = EfaPodResourcesWatcher::new();
+        let map_arc = watcher.device_map();
+        let map = map_arc.lock().unwrap();
+        assert!(map.is_empty());
+    }
+}

--- a/nfm-controller/src/kubernetes/mod.rs
+++ b/nfm-controller/src/kubernetes/mod.rs
@@ -1,5 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "open-metrics")]
+pub mod efa_pod_resources;
 pub mod flow_metadata;
 pub mod kubernetes_metadata_collector;
+#[cfg(feature = "open-metrics")]
+pub mod podresources_v1;

--- a/nfm-controller/src/kubernetes/podresources_v1.rs
+++ b/nfm-controller/src/kubernetes/podresources_v1.rs
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Hand-written types for the Kubelet PodResources v1 gRPC API (GA, additive-only changes).
+//! Avoids a protoc/tonic-build dependency; prost ignores unknown fields so upstream additions are safe.
+//! Based on: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1/api.proto
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct ListPodResourcesRequest {}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct ListPodResourcesResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub pod_resources: Vec<PodResources>,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct PodResources {
+    #[prost(string, tag = "1")]
+    pub name: String,
+    #[prost(string, tag = "2")]
+    pub namespace: String,
+    #[prost(message, repeated, tag = "3")]
+    pub containers: Vec<ContainerResources>,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct ContainerResources {
+    #[prost(string, tag = "1")]
+    pub name: String,
+    #[prost(message, repeated, tag = "2")]
+    pub devices: Vec<ContainerDevices>,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct ContainerDevices {
+    #[prost(string, tag = "1")]
+    pub resource_name: String,
+    #[prost(string, repeated, tag = "2")]
+    pub device_ids: Vec<String>,
+}
+
+pub mod pod_resources_lister_client {
+    use super::{ListPodResourcesRequest, ListPodResourcesResponse};
+
+    #[derive(Clone)]
+    pub struct PodResourcesListerClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+
+    impl PodResourcesListerClient<tonic::transport::Channel> {
+        pub fn new(channel: tonic::transport::Channel) -> Self {
+            let inner = tonic::client::Grpc::new(channel);
+            Self { inner }
+        }
+    }
+
+    impl<T> PodResourcesListerClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<Box<dyn std::error::Error + Send + Sync>> + std::fmt::Display,
+        T::ResponseBody: tonic::codegen::Body<Data = tonic::codegen::Bytes> + Send + 'static,
+        <T::ResponseBody as tonic::codegen::Body>::Error:
+            Into<Box<dyn std::error::Error + Send + Sync>> + Send,
+    {
+        pub async fn list(
+            &mut self,
+            request: impl tonic::IntoRequest<ListPodResourcesRequest>,
+        ) -> Result<tonic::Response<ListPodResourcesResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service not ready: {}", e))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = tonic::codegen::http::uri::PathAndQuery::from_static(
+                "/v1.PodResourcesLister/List",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}

--- a/nfm-controller/src/kubernetes/podresources_v1.rs
+++ b/nfm-controller/src/kubernetes/podresources_v1.rs
@@ -71,9 +71,8 @@ pub mod pod_resources_lister_client {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service not ready: {}", e))
             })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = tonic::codegen::http::uri::PathAndQuery::from_static(
-                "/v1.PodResourcesLister/List",
-            );
+            let path =
+                tonic::codegen::http::uri::PathAndQuery::from_static("/v1.PodResourcesLister/List");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/nfm-controller/src/open_metrics/provider.rs
+++ b/nfm-controller/src/open_metrics/provider.rs
@@ -68,8 +68,8 @@ mod tests {
     use crate::metadata::runtime_environment_metadata::ComputePlatform;
     use std::sync::Arc;
 
-    #[test]
-    fn test_get_open_metric_providers_all_platforms() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_open_metric_providers_all_platforms() {
         let platforms = vec![
             ComputePlatform::Ec2Plain,
             ComputePlatform::Ec2K8sEks,
@@ -88,8 +88,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_get_open_metric_providers_with_k8s_collector() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_open_metric_providers_with_k8s_collector() {
         use crate::kubernetes::kubernetes_metadata_collector::KubernetesMetadataCollector;
 
         let compute_platform = ComputePlatform::Ec2K8sEks;

--- a/nfm-controller/src/open_metrics/provider.rs
+++ b/nfm-controller/src/open_metrics/provider.rs
@@ -9,7 +9,10 @@ use prometheus::Registry;
 use std::sync::Arc;
 
 use crate::{
-    kubernetes::kubernetes_metadata_collector::KubernetesMetadataCollector,
+    kubernetes::{
+        efa_pod_resources::EfaPodResourcesWatcher,
+        kubernetes_metadata_collector::KubernetesMetadataCollector,
+    },
     metadata::runtime_environment_metadata::ComputePlatform,
     open_metrics::providers::{
         efa_metrics_provider::EfaMetricsProvider,
@@ -32,7 +35,21 @@ pub fn get_open_metric_providers(
 
     if EfaMetricsProvider::efa_devices_present() {
         info!("EFA devices detected, enabling EFA metrics collection");
-        providers.push(Box::new(EfaMetricsProvider::new(&compute_platform)));
+
+        let device_to_pod_map = match compute_platform {
+            ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
+                let watcher = EfaPodResourcesWatcher::new();
+                let map = watcher.device_map();
+                watcher.start();
+                Some(map)
+            }
+            ComputePlatform::Ec2Plain => None,
+        };
+
+        providers.push(Box::new(EfaMetricsProvider::new(
+            &compute_platform,
+            device_to_pod_map,
+        )));
     }
 
     providers

--- a/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
@@ -125,7 +125,7 @@ impl MetricLabel for EfaMetric {
         match compute_platform {
             ComputePlatform::Ec2Plain => &["instance_id", "device", "port"],
             ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
-                &["instance_id", "device", "port", "node"]
+                &["instance_id", "device", "port", "node", "pod"]
             }
         }
     }
@@ -315,7 +315,7 @@ impl EfaMetricsProvider {
         match self.compute_platform {
             ComputePlatform::Ec2Plain => vec![&self.instance_id, device, port],
             ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
-                vec![&self.instance_id, device, port, &self.node_name]
+                vec![&self.instance_id, device, port, &self.node_name, ""]
             }
         }
     }
@@ -707,7 +707,7 @@ mod tests {
     fn test_labels_k8s() {
         for platform in &[ComputePlatform::Ec2K8sEks, ComputePlatform::Ec2K8sVanilla] {
             let labels = EfaMetric::get_labels(platform);
-            assert_eq!(labels, &["instance_id", "device", "port", "node"]);
+            assert_eq!(labels, &["instance_id", "device", "port", "node", "pod"]);
         }
     }
 
@@ -726,7 +726,7 @@ mod tests {
         let values = provider.label_values("rdmap0s31", "1");
         assert_eq!(
             values,
-            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node"]
+            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", ""]
         );
     }
 

--- a/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
@@ -4,8 +4,10 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use crate::{
+    kubernetes::efa_pod_resources::EfaDeviceToPodMap,
     metadata::{
         imds_utils::retrieve_instance_id, k8s_metadata::K8sMetadata,
         runtime_environment_metadata::ComputePlatform,
@@ -144,6 +146,10 @@ pub struct EfaMetricsProvider {
     /// Cached previous sysfs counter values per (device, metric_index).
     /// Used to compute per-scrape deltas via wrapping_sub.
     previous_values: HashMap<String, Vec<u64>>,
+
+    /// Shared mapping from EFA device IDs to pod info, populated by the
+    /// EfaPodResourcesWatcher when the EFA device plugin is present.
+    device_to_pod_map: Option<Arc<Mutex<EfaDeviceToPodMap>>>,
 }
 
 impl EfaMetricsProvider {
@@ -158,11 +164,22 @@ impl EfaMetricsProvider {
         }
     }
 
-    pub fn new(compute_platform: &ComputePlatform) -> Self {
-        Self::with_sysfs_base(compute_platform, PathBuf::from(INFINIBAND_SYSFS_PATH))
+    pub fn new(
+        compute_platform: &ComputePlatform,
+        device_to_pod_map: Option<Arc<Mutex<EfaDeviceToPodMap>>>,
+    ) -> Self {
+        Self::with_sysfs_base(
+            compute_platform,
+            PathBuf::from(INFINIBAND_SYSFS_PATH),
+            device_to_pod_map,
+        )
     }
 
-    fn with_sysfs_base(compute_platform: &ComputePlatform, sysfs_base: PathBuf) -> Self {
+    fn with_sysfs_base(
+        compute_platform: &ComputePlatform,
+        sysfs_base: PathBuf,
+        device_to_pod_map: Option<Arc<Mutex<EfaDeviceToPodMap>>>,
+    ) -> Self {
         let node_name = match K8sMetadata::default().node_name {
             Some(ReportValue::String(node_name)) => node_name,
             _ => "unknown".to_string(),
@@ -193,6 +210,7 @@ impl EfaMetricsProvider {
             srd_gauges,
             srd_available,
             previous_values: HashMap::new(),
+            device_to_pod_map,
         };
 
         // Seed the cache with current sysfs values so the first scrape produces
@@ -311,13 +329,32 @@ impl EfaMetricsProvider {
         }
     }
 
-    fn label_values<'a>(&'a self, device: &'a str, port: &'a str) -> Vec<&'a str> {
+    fn label_values(&self, device: &str, port: &str) -> Vec<String> {
         match self.compute_platform {
-            ComputePlatform::Ec2Plain => vec![&self.instance_id, device, port],
+            ComputePlatform::Ec2Plain => {
+                vec![self.instance_id.clone(), device.to_string(), port.to_string()]
+            }
             ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
-                vec![&self.instance_id, device, port, &self.node_name, ""]
+                let pod_name = self.resolve_pod_for_device(device);
+                vec![
+                    self.instance_id.clone(),
+                    device.to_string(),
+                    port.to_string(),
+                    self.node_name.clone(),
+                    pod_name,
+                ]
             }
         }
+    }
+
+    fn resolve_pod_for_device(&self, device: &str) -> String {
+        let Some(map_arc) = &self.device_to_pod_map else {
+            return "unknown".to_string();
+        };
+        let map = map_arc.lock().unwrap();
+        map.get(device)
+            .map(|info| info.pod_name.clone())
+            .unwrap_or_else(|| "unknown".to_string())
     }
 }
 
@@ -378,11 +415,12 @@ impl OpenMetricProvider for EfaMetricsProvider {
                 .unwrap_or_else(|| vec![0; self.total_metrics_count()]);
 
             let label_values = self.label_values(device, port);
+            let label_refs: Vec<&str> = label_values.iter().map(|s| s.as_str()).collect();
 
             for (i, _) in STANDARD_METRICS.iter().enumerate() {
                 let delta = compute_delta(current_values[i], previous[i]);
                 self.standard_gauges[i]
-                    .with_label_values(&label_values)
+                    .with_label_values(&label_refs)
                     .set(delta as i64);
             }
 
@@ -391,7 +429,7 @@ impl OpenMetricProvider for EfaMetricsProvider {
                 for (i, _) in SRD_METRICS.iter().enumerate() {
                     let delta = compute_delta(current_values[offset + i], previous[offset + i]);
                     self.srd_gauges[i]
-                        .with_label_values(&label_values)
+                        .with_label_values(&label_refs)
                         .set(delta as i64);
                 }
             }
@@ -440,6 +478,14 @@ mod tests {
     }
 
     fn create_provider_with_mock(tmp: &TempDir, platform: ComputePlatform) -> EfaMetricsProvider {
+        create_provider_with_mock_and_pod_map(tmp, platform, None)
+    }
+
+    fn create_provider_with_mock_and_pod_map(
+        tmp: &TempDir,
+        platform: ComputePlatform,
+        device_to_pod_map: Option<Arc<Mutex<EfaDeviceToPodMap>>>,
+    ) -> EfaMetricsProvider {
         let sysfs_base = tmp.path().to_path_buf();
         let srd_available = EfaMetricsProvider::detect_srd_support(&sysfs_base);
 
@@ -466,6 +512,7 @@ mod tests {
             srd_gauges,
             srd_available,
             previous_values: HashMap::new(),
+            device_to_pod_map,
         };
 
         provider.seed_cache();
@@ -726,7 +773,7 @@ mod tests {
         let values = provider.label_values("rdmap0s31", "1");
         assert_eq!(
             values,
-            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", ""]
+            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown"]
         );
     }
 
@@ -875,5 +922,67 @@ mod tests {
         assert_eq!(provider.previous_values.len(), 1);
         assert!(provider.previous_values.contains_key("rdmap0s31/1"));
         assert!(!provider.previous_values.contains_key("rdmap1s32/1"));
+    }
+
+    #[test]
+    fn test_label_values_k8s_with_pod_map() {
+        use crate::kubernetes::efa_pod_resources::EfaPodInfo;
+
+        let tmp = create_mock_sysfs(false);
+        let mut device_map = EfaDeviceToPodMap::new();
+        device_map.insert(
+            "rdmap0s31".to_string(),
+            EfaPodInfo {
+                pod_name: "training-job-worker-0".to_string(),
+                pod_namespace: "ml".to_string(),
+            },
+        );
+        let pod_map = Arc::new(Mutex::new(device_map));
+
+        let provider = create_provider_with_mock_and_pod_map(
+            &tmp,
+            ComputePlatform::Ec2K8sEks,
+            Some(pod_map),
+        );
+        let values = provider.label_values("rdmap0s31", "1");
+        assert_eq!(
+            values,
+            vec![
+                "i-1234567890abcdef0",
+                "rdmap0s31",
+                "1",
+                "test-node",
+                "training-job-worker-0"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_label_values_k8s_with_pod_map_device_not_found() {
+        let tmp = create_mock_sysfs(false);
+        let device_map = EfaDeviceToPodMap::new();
+        let pod_map = Arc::new(Mutex::new(device_map));
+
+        let provider = create_provider_with_mock_and_pod_map(
+            &tmp,
+            ComputePlatform::Ec2K8sEks,
+            Some(pod_map),
+        );
+        let values = provider.label_values("rdmap0s31", "1");
+        assert_eq!(
+            values,
+            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown"]
+        );
+    }
+
+    #[test]
+    fn test_label_values_k8s_without_pod_map() {
+        let tmp = create_mock_sysfs(false);
+        let provider = create_provider_with_mock(&tmp, ComputePlatform::Ec2K8sEks);
+        let values = provider.label_values("rdmap0s31", "1");
+        assert_eq!(
+            values,
+            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown"]
+        );
     }
 }

--- a/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
@@ -127,7 +127,7 @@ impl MetricLabel for EfaMetric {
         match compute_platform {
             ComputePlatform::Ec2Plain => &["instance_id", "device", "port"],
             ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
-                &["instance_id", "device", "port", "node", "pod"]
+                &["instance_id", "device", "port", "node", "pod", "namespace"]
             }
         }
     }
@@ -335,26 +335,27 @@ impl EfaMetricsProvider {
                 vec![self.instance_id.clone(), device.to_string(), port.to_string()]
             }
             ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
-                let pod_name = self.resolve_pod_for_device(device);
+                let (pod_name, pod_namespace) = self.resolve_pod_for_device(device);
                 vec![
                     self.instance_id.clone(),
                     device.to_string(),
                     port.to_string(),
                     self.node_name.clone(),
                     pod_name,
+                    pod_namespace,
                 ]
             }
         }
     }
 
-    fn resolve_pod_for_device(&self, device: &str) -> String {
+    fn resolve_pod_for_device(&self, device: &str) -> (String, String) {
         let Some(map_arc) = &self.device_to_pod_map else {
-            return "unknown".to_string();
+            return ("unknown".to_string(), "unknown".to_string());
         };
         let map = map_arc.lock().unwrap();
         map.get(device)
-            .map(|info| info.pod_name.clone())
-            .unwrap_or_else(|| "unknown".to_string())
+            .map(|info| (info.pod_name.clone(), info.pod_namespace.clone()))
+            .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()))
     }
 }
 
@@ -754,7 +755,7 @@ mod tests {
     fn test_labels_k8s() {
         for platform in &[ComputePlatform::Ec2K8sEks, ComputePlatform::Ec2K8sVanilla] {
             let labels = EfaMetric::get_labels(platform);
-            assert_eq!(labels, &["instance_id", "device", "port", "node", "pod"]);
+            assert_eq!(labels, &["instance_id", "device", "port", "node", "pod", "namespace"]);
         }
     }
 
@@ -773,7 +774,7 @@ mod tests {
         let values = provider.label_values("rdmap0s31", "1");
         assert_eq!(
             values,
-            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown"]
+            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown", "unknown"]
         );
     }
 
@@ -952,7 +953,8 @@ mod tests {
                 "rdmap0s31",
                 "1",
                 "test-node",
-                "training-job-worker-0"
+                "training-job-worker-0",
+                "ml"
             ]
         );
     }
@@ -971,7 +973,7 @@ mod tests {
         let values = provider.label_values("rdmap0s31", "1");
         assert_eq!(
             values,
-            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown"]
+            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown", "unknown"]
         );
     }
 
@@ -982,7 +984,7 @@ mod tests {
         let values = provider.label_values("rdmap0s31", "1");
         assert_eq!(
             values,
-            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown"]
+            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown", "unknown"]
         );
     }
 }

--- a/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
@@ -332,7 +332,11 @@ impl EfaMetricsProvider {
     fn label_values(&self, device: &str, port: &str) -> Vec<String> {
         match self.compute_platform {
             ComputePlatform::Ec2Plain => {
-                vec![self.instance_id.clone(), device.to_string(), port.to_string()]
+                vec![
+                    self.instance_id.clone(),
+                    device.to_string(),
+                    port.to_string(),
+                ]
             }
             ComputePlatform::Ec2K8sEks | ComputePlatform::Ec2K8sVanilla => {
                 let (pod_name, pod_namespace) = self.resolve_pod_for_device(device);
@@ -755,7 +759,10 @@ mod tests {
     fn test_labels_k8s() {
         for platform in &[ComputePlatform::Ec2K8sEks, ComputePlatform::Ec2K8sVanilla] {
             let labels = EfaMetric::get_labels(platform);
-            assert_eq!(labels, &["instance_id", "device", "port", "node", "pod", "namespace"]);
+            assert_eq!(
+                labels,
+                &["instance_id", "device", "port", "node", "pod", "namespace"]
+            );
         }
     }
 
@@ -774,7 +781,14 @@ mod tests {
         let values = provider.label_values("rdmap0s31", "1");
         assert_eq!(
             values,
-            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown", "unknown"]
+            vec![
+                "i-1234567890abcdef0",
+                "rdmap0s31",
+                "1",
+                "test-node",
+                "unknown",
+                "unknown"
+            ]
         );
     }
 
@@ -940,11 +954,8 @@ mod tests {
         );
         let pod_map = Arc::new(Mutex::new(device_map));
 
-        let provider = create_provider_with_mock_and_pod_map(
-            &tmp,
-            ComputePlatform::Ec2K8sEks,
-            Some(pod_map),
-        );
+        let provider =
+            create_provider_with_mock_and_pod_map(&tmp, ComputePlatform::Ec2K8sEks, Some(pod_map));
         let values = provider.label_values("rdmap0s31", "1");
         assert_eq!(
             values,
@@ -965,15 +976,19 @@ mod tests {
         let device_map = EfaDeviceToPodMap::new();
         let pod_map = Arc::new(Mutex::new(device_map));
 
-        let provider = create_provider_with_mock_and_pod_map(
-            &tmp,
-            ComputePlatform::Ec2K8sEks,
-            Some(pod_map),
-        );
+        let provider =
+            create_provider_with_mock_and_pod_map(&tmp, ComputePlatform::Ec2K8sEks, Some(pod_map));
         let values = provider.label_values("rdmap0s31", "1");
         assert_eq!(
             values,
-            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown", "unknown"]
+            vec![
+                "i-1234567890abcdef0",
+                "rdmap0s31",
+                "1",
+                "test-node",
+                "unknown",
+                "unknown"
+            ]
         );
     }
 
@@ -984,7 +999,14 @@ mod tests {
         let values = provider.label_values("rdmap0s31", "1");
         assert_eq!(
             values,
-            vec!["i-1234567890abcdef0", "rdmap0s31", "1", "test-node", "unknown", "unknown"]
+            vec![
+                "i-1234567890abcdef0",
+                "rdmap0s31",
+                "1",
+                "test-node",
+                "unknown",
+                "unknown"
+            ]
         );
     }
 }


### PR DESCRIPTION
## EFA device-to-pod attribution via Kubelet PodResources API
### Summary
* Add pod and namespace labels to EFA metrics on K8s platforms by querying the Kubelet PodResources gRPC API to map EFA device IDs to the pods that own them
* Introduce a pod watcher that triggers device map refreshes when EFA pods are created/deleted, scoped to the local node via field selector
* Gracefully degrade to "unknown" when the EFA device plugin is not installed or no pod owns the device
* Plugin `aws-efa-k8s-device-plugin` is required to resolve pod resolution.
### Changes
* `nfm-controller/src/kubernetes/podresources_v1.rs` — Hand-written prost types for the Kubelet PodResources v1 gRPC API (List RPC only)
* `nfm-controller/src/kubernetes/efa_pod_resources.rs` — EfaPodResourcesWatcher: checks node allocatable for EFA, watches local pods via field selector, queries PodResources API on changes to build device→pod map
* `nfm-controller/src/open_metrics/provider.rs` — Wires up the watcher on K8s platforms and passes the shared device map to EfaMetricsProvider
* `nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs` — Resolves pod name and namespace from the device map; adds pod and namespace labels to K8s EFA metrics
* `nfm-controller/Cargo.toml` — Adds tonic, tower, tokio-stream as optional deps behind open-metrics feature
* `charts/.../daemonSet.yaml` — Mounts /var/lib/kubelet/pod-resources (read-only) when OPEN_METRICS=on
* `charts/.../serviceAccount.yaml` — Adds nodes get RBAC rule when OPEN_METRICS=on

### Test

Deployed locally.

**With dependency plugin installed**
<img width="1649" height="1121" alt="Screenshot 2026-06-26 at 14 53 06" src="https://github.com/user-attachments/assets/10b9c1ad-f122-439d-8af2-147d98557673" />

**Without dependency plugin installed**
<img width="1657" height="1143" alt="Screenshot 2026-06-26 at 15 33 23" src="https://github.com/user-attachments/assets/2f2371ca-ff82-4157-b2e4-c23be16435c3" />

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
