### PR TITLE
Increase SSM timeouts for verify-bpf and uninstall steps

### DIFF
--- a/.github/workflows/integration-tests-ec2.yml
+++ b/.github/workflows/integration-tests-ec2.yml
@@ -446,7 +446,7 @@ jobs:
 
       - name: Verify BPF prerequisites
         run: |
-          .ci/common/scripts/run-ssm.sh 60 "bash /tmp/nfm-ci/tests/ec2-test-scripts/verify-bpf.sh"
+          .ci/common/scripts/run-ssm.sh 300 "bash /tmp/nfm-ci/tests/ec2-test-scripts/verify-bpf.sh"
 
       - name: Start agent and run integration test
         run: |
@@ -455,7 +455,7 @@ jobs:
       - name: Uninstall agent and verify cleanup
         if: always()
         run: |
-          .ci/common/scripts/run-ssm.sh 60 "bash /tmp/nfm-ci/tests/ec2-test-scripts/uninstall-agent.sh ${{ matrix.pkg_type }}" || true
+          .ci/common/scripts/run-ssm.sh 300 "bash /tmp/nfm-ci/tests/ec2-test-scripts/uninstall-agent.sh ${{ matrix.pkg_type }}" || true
 
       - name: Terminate EC2 instance
         if: always()


### PR DESCRIPTION
## Summary

- Increase SSM command timeout from 60s to 300s for the `verify-bpf` and `uninstall-agent` steps in the EC2 integration test workflow.
- The SSM agent serializes command execution. An SSM State Manager association (`EpoxyChronicleInstallationDocument`) runs automatically on newly launched instances, takes ~62s on AL2023, and blocks subsequent SSM commands in the queue.
- With the previous 60s timeout, our commands would time out waiting in the queue before they could even start executing (actual execution takes <1s).

## Test plan

- [ ] Verify AL2023 integration test jobs (`al2023-kernel6.1-arm64`, `al2023-kernel6.1-x86_64`, `al2023-kernel6.12-x86_64`) pass consistently
- [ ] Confirm no regression on other distros (AL2, Ubuntu, Debian, RHEL, SUSE)