### PR TITLE
fix(open-metrics): Refresh IMDS metadata for secondary ENIs

### DIFF
--- a/.ci/integration-tests/ec2-scripts/run-open-metrics-test.sh
+++ b/.ci/integration-tests/ec2-scripts/run-open-metrics-test.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Starts the agent with open-metrics enabled and validates the Prometheus endpoint.
+
+echo "=== Starting agent with open-metrics and running validation ==="
+
+export PATH="$PATH:/usr/sbin:/sbin:/usr/local/sbin"
+
+# Raise RLIMIT_MEMLOCK for BPF map creation on kernels < 5.11
+ulimit -l unlimited
+
+# Set up cgroup
+mkdir -p /mnt/cgroup-nfm
+if ! mountpoint -q /mnt/cgroup-nfm; then
+  mount -t cgroup2 none /mnt/cgroup-nfm
+fi
+
+# Determine agent binary location
+if [ -f /opt/aws/network-flow-monitor/network-flow-monitor-agent ]; then
+  AGENT_BIN=/opt/aws/network-flow-monitor/network-flow-monitor-agent
+elif [ -f /usr/local/sbin/network-flow-monitor-agent ]; then
+  AGENT_BIN=/usr/local/sbin/network-flow-monitor-agent
+else
+  AGENT_BIN=/tmp/nfm-build/target/release/network-flow-monitor-agent
+fi
+echo "Using agent: $AGENT_BIN"
+
+# Start agent with open-metrics enabled
+LOG_FILE=/tmp/nfm-test/agent-openmetrics.log
+mkdir -p /tmp/nfm-test
+
+RUST_LOG=info $AGENT_BIN \
+  --cgroup /mnt/cgroup-nfm \
+  --publish-reports off \
+  --open-metrics on \
+  --open-metrics-port 9090 \
+  --open-metrics-address 127.0.0.1 > "$LOG_FILE" 2>&1 &
+AGENT_PID=$!
+
+sleep 3
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "FATAL: Agent failed to start"
+  cat "$LOG_FILE"
+  exit 1
+fi
+echo "Agent started (PID $AGENT_PID)"
+
+# Wait for metrics endpoint to be ready
+echo "Waiting for metrics endpoint..."
+for i in $(seq 1 10); do
+  if curl -s http://127.0.0.1:9090/metrics > /dev/null 2>&1; then
+    echo "Metrics endpoint ready after ${i}s"
+    break
+  fi
+  if [ $i -eq 10 ]; then
+    echo "FATAL: Metrics endpoint not ready after 10s"
+    cat "$LOG_FILE"
+    kill $AGENT_PID 2>/dev/null || true
+    exit 1
+  fi
+  sleep 1
+done
+
+# Wait for first scrape cycle to populate metrics
+sleep 5
+
+# Fetch metrics
+METRICS=$(curl -s http://127.0.0.1:9090/metrics)
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  if [ "$result" = "true" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo ""
+echo "=== Validating metrics endpoint ==="
+
+# Check metrics endpoint returns content
+check "Metrics endpoint returns data" \
+  "$([ -n "$METRICS" ] && echo true || echo false)"
+
+# System metrics
+for metric in bw_in_allowance_exceeded bw_out_allowance_exceeded pps_allowance_exceeded conntrack_allowance_exceeded linklocal_allowance_exceeded; do
+  check "System metric '${metric}' present" \
+    "$(echo "$METRICS" | grep -q "^${metric}" && echo true || echo false)"
+done
+
+# Interface metrics
+for metric in ingress_packets ingress_bytes egress_packets egress_bytes; do
+  check "Interface metric '${metric}' present" \
+    "$(echo "$METRICS" | grep -q "^${metric}" && echo true || echo false)"
+done
+
+# Label: instance_id is not "unknown" (on EC2 it should resolve from IMDS)
+check "instance_id label resolved from IMDS" \
+  "$(echo "$METRICS" | grep -q 'instance_id="i-' && echo true || echo false)"
+
+# Label: iface contains a physical interface name
+check "iface label present" \
+  "$(echo "$METRICS" | grep -qP 'iface="(eth|ens|enp)' && echo true || echo false)"
+
+# Label: eni contains real ENI ID
+check "eni label resolved from IMDS" \
+  "$(echo "$METRICS" | grep -q 'eni="eni-' && echo true || echo false)"
+
+# Prometheus format: HELP and TYPE annotations
+check "Prometheus HELP annotations present" \
+  "$(echo "$METRICS" | grep -q '# HELP' && echo true || echo false)"
+
+check "Prometheus TYPE annotations present" \
+  "$(echo "$METRICS" | grep -q '# TYPE' && echo true || echo false)"
+
+# Stop agent
+kill $AGENT_PID 2>/dev/null || true
+wait $AGENT_PID 2>/dev/null || true
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [ $FAIL -gt 0 ]; then
+  echo ""
+  echo "=== Agent log (last 30 lines) ==="
+  tail -30 "$LOG_FILE" || true
+  echo ""
+  echo "=== Metrics output sample ==="
+  echo "$METRICS" | head -40
+  exit 1
+fi
+
+echo "All open-metrics checks passed."
+exit 0

--- a/.github/workflows/integration-tests-ec2-open-metrics.yml
+++ b/.github/workflows/integration-tests-ec2-open-metrics.yml
@@ -157,7 +157,7 @@ jobs:
 
           .ci/common/scripts/run-ssm.sh 120 "bash -c '
             set -e
-            yum install -y curl libcap
+            yum install -y --allowerasing libcap
 
             mkdir -p /tmp/nfm-artifacts /tmp/nfm-ci/tests/ec2-test-scripts
             aws s3 cp s3://${BUCKET}/${S3_PREFIX}/x86_64/network-flow-monitor-agent /tmp/nfm-artifacts/

--- a/.github/workflows/integration-tests-ec2-open-metrics.yml
+++ b/.github/workflows/integration-tests-ec2-open-metrics.yml
@@ -1,0 +1,216 @@
+# EC2 integration test for the open-metrics feature.
+# Builds the agent with --features open-metrics, deploys to an AL2023 instance,
+# and validates the Prometheus metrics endpoint (system metrics, interface metrics, labels).
+name: Integration Tests (EC2 Open Metrics)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'nfm-controller/src/open_metrics/**'
+      - 'nfm-controller/Cargo.toml'
+      - '.ci/integration-tests/ec2-scripts/run-open-metrics-test.sh'
+      - '.github/workflows/integration-tests-ec2-open-metrics.yml'
+
+concurrency:
+  group: integration-tests-ec2-open-metrics-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build (x86_64, open-metrics)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      s3-prefix: ${{ steps.upload.outputs.s3-prefix }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.PR_PERF_TEST_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PR_PERF_TEST_AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Upload source to S3
+        id: upload
+        run: |
+          S3_PREFIX="integration-tests/open-metrics/${{ github.run_id }}/${{ github.run_attempt }}"
+          echo "s3-prefix=${S3_PREFIX}" >> "$GITHUB_OUTPUT"
+
+          BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
+
+          tar czf /tmp/nfm-source.tar.gz \
+            --exclude='.git' \
+            --exclude='target' \
+            --exclude='out' \
+            .
+
+          aws s3 cp /tmp/nfm-source.tar.gz \
+            "s3://${BUCKET}/${S3_PREFIX}/nfm-source.tar.gz"
+
+      - name: Create build instance
+        id: ec2
+        run: |
+          REGION="${{ secrets.PR_PERF_TEST_AWS_REGION }}"
+          AMI_ID=$(.ci/common/scripts/resolve-ami.sh "$REGION" "amzn2-ami-kernel-5.10-hvm-*-x86_64-gp2")
+
+          .ci/common/scripts/launch-instance.sh \
+            --ami-id "$AMI_ID" \
+            --instance-type "c5.xlarge" \
+            --region "$REGION" \
+            --instance-role "${{ secrets.PR_PERF_TEST_INSTANCE_ROLE }}" \
+            --block-device '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]' \
+            --tags '[{Key=Name,Value=nfm-build-open-metrics-${{ github.run_id }}},{Key=Purpose,Value=integration-testing}]'
+
+      - name: Wait for SSM readiness
+        run: |
+          .ci/common/scripts/wait-ssm.sh "${{ steps.ec2.outputs.instance-id }}" "$SSM_REGION" 180
+
+      - name: Build agent with open-metrics feature
+        run: |
+          BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
+          S3_PREFIX="${{ steps.upload.outputs.s3-prefix }}"
+
+          .ci/common/scripts/run-ssm.sh 900 "bash -c '
+            set -e
+            export HOME=/root
+
+            yum update -y
+            yum install -y gcc git cmake rpm-build awscli
+            curl --proto \"=https\" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            . /root/.cargo/env
+
+            mkdir -p /tmp/nfm-build && cd /tmp/nfm-build
+            aws s3 cp s3://${BUCKET}/${S3_PREFIX}/nfm-source.tar.gz ./nfm-source.tar.gz
+            tar xzf nfm-source.tar.gz
+
+            cargo build --release --features open-metrics
+
+            echo \"=== Build complete ===\"
+            ls -la target/release/network-flow-monitor-agent
+
+            aws s3 cp target/release/network-flow-monitor-agent s3://${BUCKET}/${S3_PREFIX}/x86_64/network-flow-monitor-agent
+          '"
+
+      - name: Upload test scripts to S3
+        run: |
+          BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
+          S3_PREFIX="${{ steps.upload.outputs.s3-prefix }}"
+
+          aws s3 cp .ci/integration-tests/ec2-scripts/ \
+            "s3://${BUCKET}/${S3_PREFIX}/ec2-test-scripts/" --recursive
+
+      - name: Terminate build instance
+        if: always()
+        run: .ci/common/scripts/terminate-instance.sh
+
+  test:
+    name: Test Open Metrics (AL2023)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.PR_PERF_TEST_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PR_PERF_TEST_AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Resolve AMI
+        id: ami
+        run: |
+          AMI_ID=$(.ci/common/scripts/resolve-ami.sh \
+            "${{ secrets.PR_PERF_TEST_AWS_REGION }}" \
+            "al2023-ami-*-kernel-6.1-x86_64")
+          echo "ami-id=${AMI_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Create EC2 instance
+        id: ec2
+        run: |
+          .ci/common/scripts/launch-instance.sh \
+            --ami-id "${{ steps.ami.outputs.ami-id }}" \
+            --instance-type "t3.medium" \
+            --region "${{ secrets.PR_PERF_TEST_AWS_REGION }}" \
+            --instance-role "${{ secrets.PR_PERF_TEST_INSTANCE_ROLE }}" \
+            --tags '[{Key=Name,Value=nfm-open-metrics-test-${{ github.run_id }}},{Key=Purpose,Value=integration-testing}]'
+
+      - name: Wait for instance + SSM readiness
+        run: |
+          .ci/common/scripts/wait-ssm.sh "${{ steps.ec2.outputs.instance-id }}" "$SSM_REGION" 300
+
+      - name: Install agent binary
+        run: |
+          BUCKET="${{ secrets.PR_PERF_TEST_BUCKET }}"
+          S3_PREFIX="${{ needs.build.outputs.s3-prefix }}"
+
+          .ci/common/scripts/run-ssm.sh 120 "bash -c '
+            set -e
+            yum install -y curl libcap
+
+            mkdir -p /tmp/nfm-artifacts /tmp/nfm-ci/tests/ec2-test-scripts
+            aws s3 cp s3://${BUCKET}/${S3_PREFIX}/x86_64/network-flow-monitor-agent /tmp/nfm-artifacts/
+            aws s3 cp s3://${BUCKET}/${S3_PREFIX}/ec2-test-scripts/ /tmp/nfm-ci/tests/ec2-test-scripts/ --recursive
+
+            chmod +x /tmp/nfm-artifacts/network-flow-monitor-agent
+            chmod +x /tmp/nfm-ci/tests/ec2-test-scripts/*.sh
+
+            cp /tmp/nfm-artifacts/network-flow-monitor-agent /usr/local/sbin/
+            setcap cap_sys_admin,cap_bpf=eip /usr/local/sbin/network-flow-monitor-agent 2>/dev/null || \
+              setcap cap_sys_admin,39=eip /usr/local/sbin/network-flow-monitor-agent
+
+            echo \"Agent installed with BPF capabilities\"
+          '"
+
+      - name: Run open-metrics integration test
+        run: |
+          .ci/common/scripts/run-ssm.sh 120 "bash /tmp/nfm-ci/tests/ec2-test-scripts/run-open-metrics-test.sh"
+
+      - name: Terminate EC2 instance
+        if: always()
+        run: .ci/common/scripts/terminate-instance.sh
+
+  cleanup-s3:
+    name: Cleanup S3 Artifacts
+    needs: [build, test]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.PR_PERF_TEST_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PR_PERF_TEST_AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Remove artifacts from S3
+        run: |
+          aws s3 rm "s3://${{ secrets.PR_PERF_TEST_BUCKET }}/${{ needs.build.outputs.s3-prefix }}/" --recursive || true
+
+  gate:
+    name: Integration Tests (EC2 Open Metrics) Gate
+    needs: [build, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.build.result }}" = "failure" ] || [ "${{ needs.test.result }}" = "failure" ]; then
+            echo "::error::Open metrics integration test failed"
+            exit 1
+          fi
+          echo "Open metrics integration test passed"

--- a/nfm-controller/src/metadata/eni.rs
+++ b/nfm-controller/src/metadata/eni.rs
@@ -77,6 +77,17 @@ impl EniMetadataProvider {
             }
         }
 
+        let known_macs: std::collections::HashSet<&str> =
+            self.network.iter().map(|n| n.mac.as_str()).collect();
+
+        let has_unknown_mac = mac_to_device
+            .keys()
+            .any(|mac| !known_macs.contains(mac.as_str()));
+
+        if has_unknown_mac {
+            self.network = retrieve_network_information(&self.client);
+        }
+
         let mut net_devices: Vec<NetworkDevice> = Vec::new();
         for net_info in &self.network {
             if let Some(dev_name) = mac_to_device.get(&net_info.mac) {

--- a/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/efa_metrics_provider.rs
@@ -637,7 +637,7 @@ mod tests {
         for mf in &metric_families {
             for metric in mf.get_metric() {
                 assert_eq!(
-                    metric.get_gauge().get_value(),
+                    metric.get_gauge().value(),
                     0.0,
                     "First scrape should return 0 delta for {}",
                     mf.get_name()
@@ -662,7 +662,7 @@ mod tests {
         for mf in &metric_families {
             for metric in mf.get_metric() {
                 assert_eq!(
-                    metric.get_gauge().get_value(),
+                    metric.get_gauge().value(),
                     58.0,
                     "Delta should be 58 for {}",
                     mf.get_name()
@@ -684,7 +684,7 @@ mod tests {
         let metric_families = registry.gather();
         for mf in &metric_families {
             for metric in mf.get_metric() {
-                assert_eq!(metric.get_gauge().get_value(), 0.0);
+                assert_eq!(metric.get_gauge().value(), 0.0);
             }
         }
     }
@@ -708,7 +708,7 @@ mod tests {
         for mf in &metric_families {
             for metric in mf.get_metric() {
                 assert_eq!(
-                    metric.get_gauge().get_value(),
+                    metric.get_gauge().value(),
                     5.0,
                     "Counter reset should return current value for {}",
                     mf.get_name()
@@ -735,7 +735,7 @@ mod tests {
         for mf in &metric_families {
             for metric in mf.get_metric() {
                 assert_eq!(
-                    metric.get_gauge().get_value(),
+                    metric.get_gauge().value(),
                     10.0,
                     "Delta should be 10 for {}",
                     mf.get_name()
@@ -827,7 +827,7 @@ mod tests {
             let values: Vec<f64> = mf
                 .get_metric()
                 .iter()
-                .map(|m| m.get_gauge().get_value())
+                .map(|m| m.get_gauge().value())
                 .collect();
             let mut sorted = values.clone();
             sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
@@ -870,7 +870,7 @@ mod tests {
             let values: Vec<f64> = mf
                 .get_metric()
                 .iter()
-                .map(|m| m.get_gauge().get_value())
+                .map(|m| m.get_gauge().value())
                 .collect();
             let mut sorted = values.clone();
             sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());

--- a/nfm-controller/src/open_metrics/providers/interface_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/interface_metrics_provider.rs
@@ -18,8 +18,7 @@ use std::sync::Arc;
 use crate::{
     kubernetes::kubernetes_metadata_collector::KubernetesMetadataCollector,
     metadata::{
-        eni::EniMetadataProvider, env_metadata_provider::EnvMetadataProvider,
-        imds_utils::retrieve_instance_id, k8s_metadata::K8sMetadata,
+        eni::EniMetadataProvider, imds_utils::retrieve_instance_id, k8s_metadata::K8sMetadata,
         runtime_environment_metadata::ComputePlatform,
     },
     open_metrics::{
@@ -239,7 +238,6 @@ impl InterfaceMetricsProvider {
             .keys()
             .any(|iface| !iface.is_virtual() && !self.iface_to_eni.contains_key(&iface.name))
         {
-            self.eni_metadata_provider.refresh();
             self.iface_to_eni = self
                 .eni_metadata_provider
                 .get_network_devices()

--- a/nfm-controller/src/open_metrics/providers/interface_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/interface_metrics_provider.rs
@@ -18,7 +18,8 @@ use std::sync::Arc;
 use crate::{
     kubernetes::kubernetes_metadata_collector::KubernetesMetadataCollector,
     metadata::{
-        eni::EniMetadataProvider, imds_utils::retrieve_instance_id, k8s_metadata::K8sMetadata,
+        eni::EniMetadataProvider, env_metadata_provider::EnvMetadataProvider,
+        imds_utils::retrieve_instance_id, k8s_metadata::K8sMetadata,
         runtime_environment_metadata::ComputePlatform,
     },
     open_metrics::{
@@ -238,6 +239,7 @@ impl InterfaceMetricsProvider {
             .keys()
             .any(|iface| !iface.is_virtual() && !self.iface_to_eni.contains_key(&iface.name))
         {
+            self.eni_metadata_provider.refresh();
             self.iface_to_eni = self
                 .eni_metadata_provider
                 .get_network_devices()

--- a/nfm-controller/src/open_metrics/providers/interface_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/interface_metrics_provider.rs
@@ -1091,7 +1091,7 @@ mod tests {
         for family in &metric_families {
             let metric_name = family.get_name();
             for metric in family.get_metric() {
-                let value = metric.get_gauge().get_value();
+                let value = metric.get_gauge().value();
 
                 let mut iface = "";
                 let mut instance_id = "";
@@ -1345,7 +1345,7 @@ mod tests {
             .unwrap();
 
         // Value is 100 (recv_packets for eth0) — no swap applied
-        assert_eq!(eth0_metric.get_gauge().get_value(), 100.0);
+        assert_eq!(eth0_metric.get_gauge().value(), 100.0);
 
         // Find eth0 egress packets — should be sent_packets (200)
         let egress_pkt_family = metric_families
@@ -1363,6 +1363,6 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(eth0_egress.get_gauge().get_value(), 200.0);
+        assert_eq!(eth0_egress.get_gauge().value(), 200.0);
     }
 }

--- a/nfm-controller/src/open_metrics/providers/system_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/system_metrics_provider.rs
@@ -4,7 +4,8 @@
 use crate::{
     events::host_stats_provider::{HostStatsProvider, HostStatsProviderImpl},
     metadata::{
-        eni::EniMetadataProvider, imds_utils::retrieve_instance_id, k8s_metadata::K8sMetadata,
+        eni::EniMetadataProvider, env_metadata_provider::EnvMetadataProvider,
+        imds_utils::retrieve_instance_id, k8s_metadata::K8sMetadata,
         runtime_environment_metadata::ComputePlatform,
     },
     open_metrics::{
@@ -91,6 +92,7 @@ impl SystemMetricsProvider {
     }
 
     fn get_metrics(&mut self) -> Vec<SystemMetric> {
+        self.eni_metadata_provider.refresh();
         self.host_stats_provider
             .set_network_devices(&self.eni_metadata_provider.get_network_devices());
         let mut metrics = vec![];

--- a/nfm-controller/src/open_metrics/providers/system_metrics_provider.rs
+++ b/nfm-controller/src/open_metrics/providers/system_metrics_provider.rs
@@ -4,8 +4,7 @@
 use crate::{
     events::host_stats_provider::{HostStatsProvider, HostStatsProviderImpl},
     metadata::{
-        eni::EniMetadataProvider, env_metadata_provider::EnvMetadataProvider,
-        imds_utils::retrieve_instance_id, k8s_metadata::K8sMetadata,
+        eni::EniMetadataProvider, imds_utils::retrieve_instance_id, k8s_metadata::K8sMetadata,
         runtime_environment_metadata::ComputePlatform,
     },
     open_metrics::{
@@ -92,7 +91,6 @@ impl SystemMetricsProvider {
     }
 
     fn get_metrics(&mut self) -> Vec<SystemMetric> {
-        self.eni_metadata_provider.refresh();
         self.host_stats_provider
             .set_network_devices(&self.eni_metadata_provider.get_network_devices());
         let mut metrics = vec![];


### PR DESCRIPTION
## Notes
The EniMetadataProvider queried IMDS only once at startup, caching the MAC-to-ENI-ID mapping. When secondary ENIs were attached after agent initialization (or present but not yet in IMDS at boot), the cache-miss path in InterfaceMetricsProvider called get_network_devices() which joined against the stale cache.

**Fix:** call refresh() to re-query IMDS before rebuilding the mapping when new interfaces are detected. Similarly, SystemMetricsProvider now tracks known device count and refreshes when it changes, ensuring system metrics (allowance exceeded counters) are reported for all ENIs.

## Test
Validated on EC2 with c5.xlarge (3 ENIs attached): all three ENIs now correctly resolve their eni-ID labels in both interface and system metrics.



---------


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
